### PR TITLE
Improve filtering and add modal-based item entry

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1222,7 +1222,7 @@ th {
   border-bottom: 2px solid var(--border);
   border-right: 1px solid var(--border);
   transition: var(--transition);
-  font-size: 0.8rem; /* Smaller font for more compact headers */
+  font-size: 0.95rem; /* Increased font size for readability */
   line-height: 1.2;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -1238,7 +1238,7 @@ td {
   border-bottom: 1px solid var(--border);
   border-right: 1px solid var(--border);
   color: var(--text-primary);
-  font-size: 0.75rem; /* Smaller font size */
+  font-size: 0.875rem; /* Increased font size */
   line-height: 1.3;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -2019,15 +2019,28 @@ td input:checked + .slider:before {
 
 .pagination-buttons {
   display: flex;
+  width: 100%;
   align-items: center;
+  justify-content: space-between;
+}
+
+.pagination-left,
+.pagination-right {
+  display: flex;
   gap: var(--spacing-sm);
+}
+
+.pagination-center {
+  display: flex;
+  gap: 4px;
+  justify-content: center;
+  flex-grow: 1;
 }
 
 .pagination-info-controls {
   display: flex;
-  gap: var(--spacing);
-  align-items: center;
   justify-content: center;
+  margin-top: var(--spacing-sm);
 }
 
 .page-numbers {
@@ -2090,13 +2103,6 @@ td input:checked + .slider:before {
   cursor: not-allowed;
 }
 
-.pagination-info {
-  min-width: 80px;
-  text-align: center;
-  font-weight: 500;
-  font-size: 0.875rem;
-  color: var(--text-primary);
-}
 
 /* =============================================================================
    SEARCH
@@ -2258,12 +2264,18 @@ input:disabled + .slider {
   opacity: 0.6;
 }
 
+.collectable-toggle {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+}
+
 .collectable-note,
 .collectable-explanation {
   font-size: 0.75rem;
   color: var(--text-muted);
-  margin-top: 0.25rem;
-  text-align: center;
+  margin-top: 0;
+  text-align: left;
   font-style: italic;
 }
 

--- a/index.html
+++ b/index.html
@@ -597,96 +597,13 @@
          Form submission is handled by events.js with validation and automatic
          premium calculation based on current spot prices
          ============================================================================= -->
+      <!--
+        Legacy add item form - commented out pending removal after
+        verifying new modal workflow.
       <section class="form-section">
-        <form id="inventoryForm">
-          <!-- First row of form fields -->
-          <div class="grid grid-2">
-            <div>
-              <label for="itemMetal">Metal</label>
-              <select id="itemMetal">
-                <option value="Silver">Silver</option>
-                <option value="Gold">Gold</option>
-                <option value="Platinum">Platinum</option>
-                <option value="Palladium">Palladium</option>
-              </select>
-            </div>
-            <div>
-              <label for="itemType">Type</label>
-              <select id="itemType">
-                <option value="Round">Round</option>
-                <option value="Bar">Bar</option>
-                <option value="Coin">Coin</option>
-                <option value="Note">Note</option>
-                <option value="Other">Other</option>
-              </select>
-            </div>
-            <div>
-              <label for="itemQty">Quantity</label>
-              <input id="itemQty" min="1" required="" step="1" type="number" />
-            </div>
-            <div>
-              <label for="itemWeight">Weight (oz)</label>
-              <input
-                id="itemWeight"
-                min="0.0001"
-                required=""
-                step="0.0001"
-                type="number"
-              />
-            </div>
-          </div>
-          <!-- Second row of form fields -->
-          <div class="grid grid-2">
-            <div>
-              <label for="itemName">Name</label>
-              <input id="itemName" required="" type="text" />
-            </div>
-            <div>
-              <label for="purchaseLocation">Purchase Location</label>
-              <input id="purchaseLocation" required="" type="text" />
-            </div>
-            <div>
-              <label for="storageLocation">Storage Location</label>
-              <input
-                id="storageLocation"
-                type="text"
-                placeholder="Vault A, Safe B, etc..."
-              />
-            </div>
-            <div>
-              <label for="itemNotes">Notes</label>
-              <input
-                id="itemNotes"
-                type="text"
-                placeholder="Additional notes or comments..."
-              />
-            </div>
-          </div>
-          <!-- Third row of form fields -->
-          <div class="grid grid-2">
-            <div>
-              <label for="itemPrice">Purchase Price ($)</label>
-              <div class="currency-input">
-                <input
-                  id="itemPrice"
-                  min="0"
-                  required=""
-                  step="0.01"
-                  type="number"
-                />
-              </div>
-            </div>
-            <div>
-              <label for="itemDate">Purchase Date</label>
-              <input id="itemDate" required="" type="date" />
-            </div>
-          </div>
-          <!-- Form submission button -->
-          <div style="margin-top: 0.5rem">
-            <button class="btn" type="submit">Add to Inventory</button>
-          </div>
-        </form>
+        ...
       </section>
+      -->
       <!-- =============================================================================
          SEARCH FUNCTIONALITY
          
@@ -707,6 +624,7 @@
             type="text"
           />
           <button class="btn" id="clearSearchBtn">Clear</button>
+          <button class="btn success" id="newItemBtn">New Item</button>
         </div>
         <div class="search-results-info" id="searchResultsInfo"></div>
       </section>
@@ -720,9 +638,9 @@
          - Delete buttons with confirmation
          - Responsive design with column resizing capability
          
-         Table rendering handled by renderTable() in inventory.js
-         Pagination controls limit display to selected items per page
-         ============================================================================= -->
+      Table rendering handled by renderTable() in inventory.js
+       Pagination controls limit display to selected items per page
+       ============================================================================= -->
       <section class="table-section">
         <table id="inventoryTable">
           <thead>
@@ -750,30 +668,33 @@
           <div class="pagination-container">
             <div class="pagination-controls">
               <div class="pagination-buttons">
-                <button
-                  class="pagination-btn"
-                  id="firstPage"
-                  title="First Page"
-                >
-                  «
-                </button>
-                <button
-                  class="pagination-btn"
-                  id="prevPage"
-                  title="Previous Page"
-                >
-                  ‹
-                </button>
-                <div class="page-numbers" id="pageNumbers"></div>
-                <button class="pagination-btn" id="nextPage" title="Next Page">
-                  ›
-                </button>
-                <button class="pagination-btn" id="lastPage" title="Last Page">
-                  »
-                </button>
+                <div class="pagination-left">
+                  <button
+                    class="pagination-btn"
+                    id="firstPage"
+                    title="First Page"
+                  >
+                    «
+                  </button>
+                  <button
+                    class="pagination-btn"
+                    id="prevPage"
+                    title="Previous Page"
+                  >
+                    ‹
+                  </button>
+                </div>
+                <div class="pagination-center" id="pageNumbers"></div>
+                <div class="pagination-right">
+                  <button class="pagination-btn" id="nextPage" title="Next Page">
+                    ›
+                  </button>
+                  <button class="pagination-btn" id="lastPage" title="Last Page">
+                    »
+                  </button>
+                </div>
               </div>
               <div class="pagination-info-controls">
-                <span class="pagination-info" id="paginationInfo">1 of 1</span>
                 <select class="pagination-select" id="itemsPerPage">
                   <option value="10">10</option>
                   <option value="15">15</option>
@@ -805,7 +726,103 @@
          
          All import/export functions include data validation and error handling
          Implementation in inventory.js with format-specific parsing
-         ============================================================================= -->
+      ============================================================================= -->
+    </div>
+    <!-- ADD ITEM MODAL -->
+    <div class="modal" id="addModal" style="display: none">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2>Add Inventory Item</h2>
+          <button aria-label="Close modal" class="modal-close" id="addCloseBtn">×</button>
+        </div>
+        <div class="modal-body">
+          <form id="inventoryForm">
+            <div class="grid grid-2">
+              <div>
+                <label for="itemMetal">Metal</label>
+                <select id="itemMetal">
+                  <option value="Silver">Silver</option>
+                  <option value="Gold">Gold</option>
+                  <option value="Platinum">Platinum</option>
+                  <option value="Palladium">Palladium</option>
+                  <option value="Alloy/Other">Alloy/Other</option>
+                </select>
+              </div>
+              <div>
+                <label for="itemType">Type</label>
+                <select id="itemType">
+                  <option value="Round">Round</option>
+                  <option value="Bar">Bar</option>
+                  <option value="Coin">Coin</option>
+                  <option value="Note">Note</option>
+                  <option value="Aurum">Aurum</option>
+                  <option value="Other">Other</option>
+                </select>
+              </div>
+              <div>
+                <label for="itemQty">Quantity</label>
+                <input id="itemQty" min="1" required step="1" type="number" />
+              </div>
+              <div>
+                <label for="itemWeight">Weight (oz)</label>
+                <input id="itemWeight" min="0.0001" required step="0.0001" type="number" />
+              </div>
+            </div>
+            <div class="grid grid-2">
+              <div>
+                <label for="itemName">Name</label>
+                <input id="itemName" required type="text" />
+              </div>
+              <div>
+                <label for="purchaseLocation">Purchase Location</label>
+                <input id="purchaseLocation" required type="text" />
+              </div>
+              <div>
+                <label for="storageLocation">Storage Location</label>
+                <input id="storageLocation" type="text" placeholder="Vault A, Safe B, etc..." />
+              </div>
+              <div>
+                <label for="itemNotes">Notes</label>
+                <input id="itemNotes" type="text" placeholder="Additional notes or comments..." />
+              </div>
+            </div>
+            <div class="grid grid-2">
+              <div>
+                <label for="itemPrice">Purchase Price ($)</label>
+                <div class="currency-input">
+                  <input id="itemPrice" min="0" required step="0.01" type="number" />
+                </div>
+              </div>
+              <div>
+                <label for="itemDate">Purchase Date</label>
+                <input id="itemDate" required type="date" />
+              </div>
+            </div>
+            <div class="grid grid-2">
+              <div>
+                <label for="itemSpotPrice">Spot Price ($/oz)</label>
+                <div class="currency-input">
+                  <input id="itemSpotPrice" min="0" step="0.01" type="number" />
+                </div>
+              </div>
+              <div class="collectable-toggle">
+                <label for="itemCollectable">Collectable Item</label>
+                <label class="switch">
+                  <input id="itemCollectable" type="checkbox" />
+                  <span class="slider"></span>
+                </label>
+                <span class="collectable-note"
+                  >Collectable items may have additional numismatic value beyond their metal content</span
+                >
+              </div>
+            </div>
+            <div style="margin-top: 1rem; text-align: right">
+              <button class="btn" id="cancelAdd" type="button">Cancel</button>
+              <button class="btn premium" type="submit">Add to Inventory</button>
+            </div>
+          </form>
+        </div>
+      </div>
     </div>
     <!-- =============================================================================
        EDIT MODAL
@@ -824,9 +841,11 @@
        ============================================================================= -->
     <div class="modal" id="editModal" style="display: none">
       <div class="modal-content">
-        <h2 style="margin-bottom: 1rem; color: var(--primary)">
-          Edit Inventory Item
-        </h2>
+        <div class="modal-header">
+          <h2>Edit Inventory Item</h2>
+          <button aria-label="Close modal" class="modal-close" id="editCloseBtn">×</button>
+        </div>
+        <div class="modal-body">
         <form id="editForm">
           <!-- First row of edit form fields -->
           <div class="grid grid-2">
@@ -837,6 +856,7 @@
                 <option value="Gold">Gold</option>
                 <option value="Platinum">Platinum</option>
                 <option value="Palladium">Palladium</option>
+                <option value="Alloy/Other">Alloy/Other</option>
               </select>
             </div>
             <div>
@@ -846,6 +866,7 @@
                 <option value="Bar">Bar</option>
                 <option value="Coin">Coin</option>
                 <option value="Note">Note</option>
+                <option value="Aurum">Aurum</option>
                 <option value="Other">Other</option>
               </select>
             </div>
@@ -910,7 +931,7 @@
               <input id="editDate" required="" type="date" />
             </div>
           </div>
-          <!-- Special field for editing historical spot prices -->
+          <!-- Spot price and collectable toggle -->
           <div class="grid grid-2">
             <div>
               <label for="editSpotPrice">Spot Price ($/oz)</label>
@@ -918,23 +939,21 @@
                 <input
                   id="editSpotPrice"
                   min="0"
-                  required=""
+                  required
                   step="0.01"
                   type="number"
                 />
               </div>
             </div>
-          </div>
-          <!-- Collectable toggle -->
-          <div style="margin-top: 0.5rem">
-            <label for="editCollectable">Collectable Item</label>
-            <label class="switch">
-              <input id="editCollectable" type="checkbox" />
-              <span class="slider"></span>
-            </label>
-            <div class="collectable-explanation">
-              Collectable items may have additional numismatic value beyond
-              their metal content
+            <div class="collectable-toggle">
+              <label for="editCollectable">Collectable Item</label>
+              <label class="switch">
+                <input id="editCollectable" type="checkbox" />
+                <span class="slider"></span>
+              </label>
+              <span class="collectable-note"
+                >Collectable items may have additional numismatic value beyond their metal content</span
+              >
             </div>
           </div>
           <!-- Form action buttons -->
@@ -943,6 +962,7 @@
             <button class="btn premium" type="submit">Save Changes</button>
           </div>
         </form>
+        </div>
       </div>
     </div>
 
@@ -955,11 +975,16 @@
        ============================================================================= -->
     <div class="modal" id="notesModal" style="display: none">
       <div class="modal-content">
-        <h2 style="margin-bottom: 1rem; color: var(--primary)">Item Notes</h2>
-        <textarea id="notesTextarea" rows="6" style="width: 100%"></textarea>
-        <div style="margin-top: 1rem; text-align: right">
-          <button class="btn" id="cancelNotes" type="button">Cancel</button>
-          <button class="btn premium" id="saveNotes" type="button">Save</button>
+        <div class="modal-header">
+          <h2>Item Notes</h2>
+          <button aria-label="Close modal" class="modal-close" id="notesCloseBtn">×</button>
+        </div>
+        <div class="modal-body">
+          <textarea id="notesTextarea" rows="6" style="width: 100%"></textarea>
+          <div style="margin-top: 1rem; text-align: right">
+            <button class="btn" id="cancelNotes" type="button">Cancel</button>
+            <button class="btn premium" id="saveNotes" type="button">Save</button>
+          </div>
         </div>
       </div>
     </div>
@@ -1701,10 +1726,12 @@
 
     <div class="modal" id="apiInfoModal" style="display: none">
       <div class="modal-content">
-        <h3 id="apiInfoTitle">Provider Information</h3>
-        <div id="apiInfoBody" class="api-info-body"></div>
-        <div class="modal-footer">
-          <button type="button" class="btn" id="apiInfoCloseBtn">Close</button>
+        <div class="modal-header">
+          <h3 id="apiInfoTitle">Provider Information</h3>
+          <button aria-label="Close modal" class="modal-close" id="apiInfoCloseBtn">×</button>
+        </div>
+        <div class="modal-body">
+          <div id="apiInfoBody" class="api-info-body"></div>
         </div>
       </div>
     </div>

--- a/js/init.js
+++ b/js/init.js
@@ -67,6 +67,8 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.storageLocation = safeGetElement("storageLocation");
     elements.itemNotes = safeGetElement("itemNotes");
     elements.itemDate = safeGetElement("itemDate", true);
+    elements.itemSpotPrice = safeGetElement("itemSpotPrice");
+    elements.itemCollectable = safeGetElement("itemCollectable");
 
     // Header buttons - CRITICAL
     debugLog("Phase 2: Initializing header buttons...");
@@ -108,6 +110,7 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.editModal = safeGetElement("editModal");
     elements.editForm = safeGetElement("editForm");
     elements.cancelEditBtn = safeGetElement("cancelEdit");
+    elements.editCloseBtn = safeGetElement("editCloseBtn");
     elements.editMetal = safeGetElement("editMetal");
     elements.editName = safeGetElement("editName");
     elements.editQty = safeGetElement("editQty");
@@ -119,6 +122,10 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.editNotes = safeGetElement("editNotes");
     elements.editDate = safeGetElement("editDate");
     elements.editSpotPrice = safeGetElement("editSpotPrice");
+
+    elements.addModal = safeGetElement("addModal");
+    elements.addCloseBtn = safeGetElement("addCloseBtn");
+    elements.cancelAddBtn = safeGetElement("cancelAdd");
 
     // Show acknowledgment modal immediately and set up modal events
     if (typeof setupAckModalEvents === "function") {
@@ -136,6 +143,7 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.notesTextarea = safeGetElement("notesTextarea");
     elements.saveNotesBtn = safeGetElement("saveNotes");
     elements.cancelNotesBtn = safeGetElement("cancelNotes");
+    elements.notesCloseBtn = safeGetElement("notesCloseBtn");
 
     // Pagination elements
     debugLog("Phase 5: Initializing pagination elements...");
@@ -145,12 +153,12 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.firstPage = safeGetElement("firstPage");
     elements.lastPage = safeGetElement("lastPage");
     elements.pageNumbers = safeGetElement("pageNumbers");
-    elements.paginationInfo = safeGetElement("paginationInfo");
 
     // Search elements
     debugLog("Phase 6: Initializing search elements...");
     elements.searchInput = safeGetElement("searchInput");
     elements.clearSearchBtn = safeGetElement("clearSearchBtn");
+    elements.newItemBtn = safeGetElement("newItemBtn");
     elements.searchResultsInfo = safeGetElement("searchResultsInfo");
 
     // Details modal elements

--- a/js/pagination.js
+++ b/js/pagination.js
@@ -40,9 +40,6 @@ const renderPagination = (filteredData = filterInventory()) => {
     pageNumbersContainer.appendChild(btn);
   }
 
-  // Update pagination info
-  elements.paginationInfo.textContent = `${currentPage} of ${totalPages}`;
-
   // Update button states
   elements.firstPage.disabled = currentPage === 1;
   elements.prevPage.disabled = currentPage === 1;

--- a/js/search.js
+++ b/js/search.js
@@ -9,13 +9,13 @@
 const filterInventory = () => {
   let result = inventory;
 
-  if (columnFilter.field) {
-    const value = columnFilter.value.toLowerCase();
-    result = result.filter(item => {
-      const fieldVal = (item[columnFilter.field] || '').toString().toLowerCase();
-      return fieldVal === value;
+  Object.entries(columnFilters).forEach(([field, value]) => {
+    const lower = value.toLowerCase();
+    result = result.filter((item) => {
+      const fieldVal = (item[field] || '').toString().toLowerCase();
+      return fieldVal === lower;
     });
-  }
+  });
 
   if (!searchQuery.trim()) return result;
 
@@ -59,10 +59,10 @@ const filterInventory = () => {
  * @param {string} value - Value to match exactly
  */
 const applyColumnFilter = (field, value) => {
-  if (columnFilter.field === field && columnFilter.value === value) {
-    columnFilter = { field: null, value: null };
+  if (columnFilters[field] === value) {
+    delete columnFilters[field];
   } else {
-    columnFilter = { field, value };
+    columnFilters[field] = value;
   }
   searchQuery = '';
   if (elements.searchInput) elements.searchInput.value = '';

--- a/js/state.js
+++ b/js/state.js
@@ -17,8 +17,8 @@ let itemsPerPage = 25; // Number of items to display per page
 /** @type {string} Current search query */
 let searchQuery = "";
 
-/** @type {{field: string|null, value: string|null}} Active column filter */
-let columnFilter = { field: null, value: null };
+/** @type {Object<string, string>} Active column filters */
+let columnFilters = {};
 
 /** @type {Object} Chart instances for proper cleanup */
 let chartInstances = {
@@ -48,6 +48,8 @@ const elements = {
   storageLocation: null,
   itemNotes: null,
   itemDate: null,
+  itemSpotPrice: null,
+  itemCollectable: null,
 
   // Spot price buttons
   saveSpotBtnSilver: null,
@@ -88,12 +90,14 @@ const elements = {
   editNotes: null,
   editDate: null,
   editSpotPrice: null,
+  editCloseBtn: null,
 
   // Notes modal elements
   notesModal: null,
   notesTextarea: null,
   saveNotesBtn: null,
   cancelNotesBtn: null,
+  notesCloseBtn: null,
 
   // Details modal elements
   detailsModal: null,
@@ -114,12 +118,17 @@ const elements = {
   firstPage: null,
   lastPage: null,
   pageNumbers: null,
-  paginationInfo: null,
 
   // Search elements
   searchInput: null,
   clearSearchBtn: null,
+  newItemBtn: null,
   searchResultsInfo: null,
+
+  // Add item modal elements
+  addModal: null,
+  addCloseBtn: null,
+  cancelAddBtn: null,
 
   // About & acknowledgment modal elements
   aboutBtn: null,


### PR DESCRIPTION
## Summary
- Allow stacking multiple column filters and reset via search clear
- Replace inline item form with modal-based “New Item” workflow and standardized modal headers
- Refine pagination layout and table styling

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/state.js js/init.js js/events.js js/pagination.js js/search.js`


------
https://chatgpt.com/codex/tasks/task_e_68973ab477d0832eb55bade40ca91a79