### PR TITLE
Improve pagination styling and reposition items-per-page control

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2002,6 +2002,18 @@ td input:checked + .slider:before {
 }
 
 /* =============================================================================
+   TABLE CONTROLS
+   ============================================================================= */
+
+.table-top-controls {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: var(--spacing-sm);
+  margin-bottom: var(--spacing-sm);
+}
+
+/* =============================================================================
    PAGINATION
    ============================================================================= */
 
@@ -2037,46 +2049,6 @@ td input:checked + .slider:before {
   flex-grow: 1;
 }
 
-.pagination-info-controls {
-  display: flex;
-  justify-content: center;
-  margin-top: var(--spacing-sm);
-}
-
-.page-numbers {
-  display: flex;
-  gap: 4px;
-  justify-content: center;
-}
-
-.page-numbers button {
-  min-width: 2.5rem;
-  height: 2.5rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  font-weight: 500;
-  transition: var(--transition);
-  cursor: pointer;
-  padding: 0;
-}
-
-.page-numbers button:hover:not(.active) {
-  background: var(--bg-secondary);
-  border-color: var(--border-hover);
-}
-
-.page-numbers button.active {
-  background: var(--primary);
-  color: white;
-  border-color: var(--primary);
-  font-weight: 600;
-}
-
 .pagination-btn {
   min-width: 2.5rem;
   height: 2.5rem;
@@ -2101,6 +2073,13 @@ td input:checked + .slider:before {
 .pagination-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.pagination-btn.active {
+  background: var(--primary);
+  color: white;
+  border-color: var(--primary);
+  font-weight: 600;
 }
 
 
@@ -2396,12 +2375,6 @@ input:disabled + .slider {
   .pagination-center {
     flex-direction: row;
     flex-wrap: wrap;
-    gap: var(--spacing-sm);
-  }
-
-  .pagination-info-controls {
-    flex-direction: column;
-    align-items: center;
     gap: var(--spacing-sm);
   }
 

--- a/index.html
+++ b/index.html
@@ -642,6 +642,16 @@
        Pagination controls limit display to selected items per page
        ============================================================================= -->
       <section class="table-section">
+        <div class="table-top-controls">
+          <label for="itemsPerPage">Items:</label>
+          <select class="pagination-select" id="itemsPerPage">
+            <option value="10">10</option>
+            <option value="15">15</option>
+            <option value="25" selected>25</option>
+            <option value="50">50</option>
+            <option value="100">100</option>
+          </select>
+        </div>
         <table id="inventoryTable">
           <thead>
             <tr>
@@ -693,15 +703,6 @@
                     »
                   </button>
                 </div>
-              </div>
-              <div class="pagination-info-controls">
-                <select class="pagination-select" id="itemsPerPage">
-                  <option value="10">10</option>
-                  <option value="15">15</option>
-                  <option selected="" value="25">25</option>
-                  <option value="50">50</option>
-                  <option value="100">100</option>
-                </select>
               </div>
             </div>
           </div>

--- a/js/pagination.js
+++ b/js/pagination.js
@@ -35,7 +35,10 @@ const renderPagination = (filteredData = filterInventory()) => {
   for (let i = startPage; i <= endPage; i++) {
     const btn = document.createElement('button');
     btn.textContent = i;
-    btn.className = currentPage === i ? 'active' : '';
+    btn.className = 'pagination-btn';
+    if (currentPage === i) {
+      btn.classList.add('active');
+    }
     btn.onclick = () => goToPage(i);
     pageNumbersContainer.appendChild(btn);
   }


### PR DESCRIPTION
## Summary
- Style numeric page buttons with pagination theme and active state
- Move Items-per-page selector to table top right with label

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68974c069594832e825cfa95c08e0a55