### PR TITLE
Fix items-per-page dropdown width

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2045,6 +2045,10 @@ td input:checked + .slider:before {
   margin-bottom: var(--spacing-sm);
 }
 
+.pagination-select {
+  width: 6rem;
+}
+
 .pagination-btn {
   min-width: 2.5rem;
   height: 2.5rem;


### PR DESCRIPTION
## Summary
- constrain items-per-page dropdown to fixed width so it no longer stretches across table

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689754931334832ea7de3883f6fe7622