### PR TITLE
Auto sync spot prices when cache is stale

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -659,6 +659,27 @@ const saveApiCache = (data, provider) => {
 };
 
 /**
+ * Automatically syncs spot prices if API keys exist and cache is stale
+ * @returns {Promise<void>} Resolves when sync completes or immediately if no sync needed
+ */
+const autoSyncSpotPrices = async () => {
+  if (
+    !apiConfig ||
+    !apiConfig.provider ||
+    !apiConfig.keys ||
+    !apiConfig.keys[apiConfig.provider]
+  ) {
+    return;
+  }
+
+  const cache = loadApiCache();
+  if (!cache || cache.provider !== apiConfig.provider) {
+    await syncSpotPricesFromApi(false, true);
+    updateSyncButtonStates();
+  }
+};
+
+/**
  * Makes API request for spot prices
  * @param {string} provider - Provider key from API_PROVIDERS
  * @param {string} apiKey - API key
@@ -1217,6 +1238,7 @@ window.showApiHistoryModal = showApiHistoryModal;
 window.hideApiHistoryModal = hideApiHistoryModal;
 window.clearApiHistory = clearApiHistory;
 window.syncAllProviders = syncAllProviders;
+window.autoSyncSpotPrices = autoSyncSpotPrices;
 
 /**
  * Shows manual price input for a specific metal

--- a/js/init.js
+++ b/js/init.js
@@ -290,6 +290,11 @@ document.addEventListener("DOMContentLoaded", () => {
     fetchSpotPrice();
     updateSyncButtonStates();
 
+    // Automatically sync prices if cache is stale and API keys are available
+    if (typeof autoSyncSpotPrices === "function") {
+      autoSyncSpotPrices();
+    }
+
     // Phase 14: Event Listeners Setup (Delayed)
     debugLog("Phase 14: Setting up event listeners...");
 


### PR DESCRIPTION
## Summary
- Add `autoSyncSpotPrices` helper to check API cache and fetch fresh spot prices when keys are stored
- Expose helper globally and invoke during initialization for seamless startup sync

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897834f2dac832eb06b7f2429f6fbdc