### PR TITLE
Fix About modal title contrast in light mode

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1484,16 +1484,16 @@ td input:checked + .slider:before {
   font-size: 1.875rem;
   font-weight: 700;
   margin: 0;
-  color: white;
   text-align: center;
-  background: linear-gradient(
-    135deg,
-    rgba(255, 255, 255, 1),
-    rgba(255, 255, 255, 0.8)
-  );
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
+  color: var(--text-primary);
+}
+
+.about-title #aboutAppName {
+  color: var(--primary);
+}
+
+.about-title #aboutVersion {
+  color: var(--text-secondary);
 }
 
 .modal-close {


### PR DESCRIPTION
## Summary
- ensure About modal title uses theme variables so it remains readable in light mode
- highlight app name and version using theme colors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689794825b58832ea6df1bb5e82a1180