### PR TITLE
Replace collectable checkbox with status button

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1317,36 +1317,6 @@ tr:hover {
 .clickable-name:focus::after {
   opacity: 0.7;
 }
-
-/* Checkbox cell styling */
-.checkbox-cell {
-  text-align: center;
-  vertical-align: middle;
-}
-
-.collectable-checkbox {
-  width: 16px;
-  height: 16px;
-  cursor: pointer;
-  margin: 0;
-  transform: scale(1.2);
-  accent-color: var(--primary);
-  border-radius: 3px;
-  transition:
-    transform 0.2s,
-    box-shadow 0.2s;
-}
-
-.collectable-checkbox:hover {
-  box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.2);
-  transform: scale(1.3);
-}
-
-.collectable-checkbox:focus {
-  outline: 2px solid var(--primary);
-  outline-offset: 1px;
-}
-
 /* Make buttons in table cells smaller */
 td .btn {
   padding: 0.25rem 0.5rem;

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -542,9 +542,7 @@ const renderTable = () => {
       <td class="shrink" style="color: ${item.isCollectable ? 'var(--text-muted)' : (item.totalPremium > 0 ? 'var(--warning)' : 'inherit')}">${item.isCollectable ? 'N/A' : formatDollar(item.totalPremium)}</td>
       <td class="shrink">${filterLink('purchaseLocation', item.purchaseLocation, getPurchaseLocationColor(item.purchaseLocation))}</td>
       <td class="shrink">${filterLink('storageLocation', item.storageLocation || 'Unknown', getStorageLocationColor(item.storageLocation || 'Unknown'))}</td>
-      <td class="checkbox-cell shrink">
-      <input type="checkbox" ${item.isCollectable ? 'checked' : ''} onchange="toggleCollectable(${originalIdx}, this)" class="collectable-checkbox" aria-label="Mark ${sanitizeHtml(item.name)} as collectable" title="Mark as collectable">
-      </td>
+      <td class="shrink"><button type="button" class="btn collectable-btn ${item.isCollectable ? 'success' : ''}" onclick="toggleCollectable(${originalIdx})" aria-label="Toggle collectable status for ${sanitizeHtml(item.name)}" title="Toggle collectable status">${item.isCollectable ? 'Yes' : 'No'}</button></td>
       <td class="shrink"><button class="btn" onclick="showNotes(${originalIdx})" aria-label="View notes" title="View notes">Notes</button></td>
       <td class="shrink"><button class="btn danger" onclick="deleteItem(${originalIdx})" aria-label="Delete item" title="Delete item">Delete</button></td>
       </tr>
@@ -852,12 +850,11 @@ const editItem = (idx) => {
  * Toggles collectable status for inventory item
  * 
  * @param {number} idx - Index of item to update
- * @param {HTMLInputElement} checkbox - Checkbox element triggering the change
- */
-const toggleCollectable = (idx, checkbox) => {
+*/
+const toggleCollectable = (idx) => {
   const item = inventory[idx];
   const wasCollectable = item.isCollectable;
-  const isCollectable = checkbox.checked;
+  const isCollectable = !wasCollectable;
 
   // If toggling from collectable to non-collectable
   if (wasCollectable && !isCollectable) {


### PR DESCRIPTION
## Summary
- swap collectable checkbox for a yes/no button matching other table controls
- toggle collectable status directly via the new button and drop unused checkbox styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897990ef544832ebd2f9d0513792eb0