### PR TITLE
Rename totals card labels

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,39 +360,37 @@
                 <span class="total-value" id="totalPurchasedSilver">$0.00</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Current Value:</span>
+                <span class="total-label">Melt Value:</span>
                 <span class="total-value" id="currentValueSilver">$0.00</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Average Price (oz):</span>
+                <span class="total-label">Avg. Price (oz):</span>
                 <span class="total-value" id="avgPriceSilver">$0.00</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Average Collectable Price (oz):</span>
+                <span class="total-label">Avg. Collectable Price (oz):</span>
                 <span class="total-value" id="avgCollectablePriceSilver"
                   >$0.00</span
                 >
               </div>
               <div class="total-item">
-                <span class="total-label"
-                  >Average Non-collectable Price (oz):</span
-                >
+                <span class="total-label">Avg Stack Price (oz):</span>
                 <span class="total-value" id="avgNonCollectablePriceSilver"
                   >$0.00</span
                 >
               </div>
               <div class="total-item">
-                <span class="total-label">Average Premium (oz):</span>
+                <span class="total-label">Avg. Premium (oz):</span>
                 <span class="total-value" id="avgPremiumSilver">$0.00</span>
               </div>
             </div>
             <div class="total-group">
               <div class="total-item">
-                <span class="total-label">Total Premium Paid:</span>
+                <span class="total-label">Lifetime Premiums Paid:</span>
                 <span class="total-value" id="totalPremiumSilver">$0.00</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Total Loss/Profit:</span>
+                <span class="total-label">Lifetime Loss/Profit:</span>
                 <span class="total-value" id="lossProfitSilver">$0.00</span>
               </div>
             </div>
@@ -419,39 +417,37 @@
                 <span class="total-value" id="totalPurchasedGold">$0.00</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Current Value:</span>
+                <span class="total-label">Melt Value:</span>
                 <span class="total-value" id="currentValueGold">$0.00</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Average Price (oz):</span>
+                <span class="total-label">Avg. Price (oz):</span>
                 <span class="total-value" id="avgPriceGold">$0.00</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Average Collectable Price (oz):</span>
+                <span class="total-label">Avg. Collectable Price (oz):</span>
                 <span class="total-value" id="avgCollectablePriceGold"
                   >$0.00</span
                 >
               </div>
               <div class="total-item">
-                <span class="total-label"
-                  >Average Non-collectable Price (oz):</span
-                >
+                <span class="total-label">Avg Stack Price (oz):</span>
                 <span class="total-value" id="avgNonCollectablePriceGold"
                   >$0.00</span
                 >
               </div>
               <div class="total-item">
-                <span class="total-label">Average Premium (oz):</span>
+                <span class="total-label">Avg. Premium (oz):</span>
                 <span class="total-value" id="avgPremiumGold">$0.00</span>
               </div>
             </div>
             <div class="total-group">
               <div class="total-item">
-                <span class="total-label">Total Premium Paid:</span>
+                <span class="total-label">Lifetime Premiums Paid:</span>
                 <span class="total-value" id="totalPremiumGold">$0.00</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Total Loss/Profit:</span>
+                <span class="total-label">Lifetime Loss/Profit:</span>
                 <span class="total-value" id="lossProfitGold">$0.00</span>
               </div>
             </div>
@@ -478,39 +474,37 @@
                 >
               </div>
               <div class="total-item">
-                <span class="total-label">Current Value:</span>
+                <span class="total-label">Melt Value:</span>
                 <span class="total-value" id="currentValuePlatinum">$0.00</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Average Price (oz):</span>
+                <span class="total-label">Avg. Price (oz):</span>
                 <span class="total-value" id="avgPricePlatinum">$0.00</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Average Collectable Price (oz):</span>
+                <span class="total-label">Avg. Collectable Price (oz):</span>
                 <span class="total-value" id="avgCollectablePricePlatinum"
                   >$0.00</span
                 >
               </div>
               <div class="total-item">
-                <span class="total-label"
-                  >Average Non-collectable Price (oz):</span
-                >
+                <span class="total-label">Avg Stack Price (oz):</span>
                 <span class="total-value" id="avgNonCollectablePricePlatinum"
                   >$0.00</span
                 >
               </div>
               <div class="total-item">
-                <span class="total-label">Average Premium (oz):</span>
+                <span class="total-label">Avg. Premium (oz):</span>
                 <span class="total-value" id="avgPremiumPlatinum">$0.00</span>
               </div>
             </div>
             <div class="total-group">
               <div class="total-item">
-                <span class="total-label">Total Premium Paid:</span>
+                <span class="total-label">Lifetime Premiums Paid:</span>
                 <span class="total-value" id="totalPremiumPlatinum">$0.00</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Total Loss/Profit:</span>
+                <span class="total-label">Lifetime Loss/Profit:</span>
                 <span class="total-value" id="lossProfitPlatinum">$0.00</span>
               </div>
             </div>
@@ -540,43 +534,41 @@
                 >
               </div>
               <div class="total-item">
-                <span class="total-label">Current Value:</span>
+                <span class="total-label">Melt Value:</span>
                 <span class="total-value" id="currentValuePalladium"
                   >$0.00</span
                 >
               </div>
               <div class="total-item">
-                <span class="total-label">Average Price (oz):</span>
+                <span class="total-label">Avg. Price (oz):</span>
                 <span class="total-value" id="avgPricePalladium">$0.00</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Average Collectable Price (oz):</span>
+                <span class="total-label">Avg. Collectable Price (oz):</span>
                 <span class="total-value" id="avgCollectablePricePalladium"
                   >$0.00</span
                 >
               </div>
               <div class="total-item">
-                <span class="total-label"
-                  >Average Non-collectable Price (oz):</span
-                >
+                <span class="total-label">Avg Stack Price (oz):</span>
                 <span class="total-value" id="avgNonCollectablePricePalladium"
                   >$0.00</span
                 >
               </div>
               <div class="total-item">
-                <span class="total-label">Average Premium (oz):</span>
+                <span class="total-label">Avg. Premium (oz):</span>
                 <span class="total-value" id="avgPremiumPalladium">$0.00</span>
               </div>
             </div>
             <div class="total-group">
               <div class="total-item">
-                <span class="total-label">Total Premium Paid:</span>
+                <span class="total-label">Lifetime Premiums Paid:</span>
                 <span class="total-value" id="totalPremiumPalladium"
                   >$0.00</span
                 >
               </div>
               <div class="total-item">
-                <span class="total-label">Total Loss/Profit:</span>
+                <span class="total-label">Lifetime Loss/Profit:</span>
                 <span class="total-value" id="lossProfitPalladium">$0.00</span>
               </div>
             </div>

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -628,9 +628,9 @@ const updateSummary = () => {
         const itemWeight = Number(item.qty) * parseFloat(item.weight);
         totalWeight += itemWeight;
 
-        // Current Value calculation
+        // Melt Value calculation
         if (item.isCollectable) {
-          // For collectible items: Current Value = Current spot price × weight
+          // For collectible items: Melt Value = Current spot price × weight
           const currentSpot = spotPrices[item.metal.toLowerCase()];
           currentSpotValue += currentSpot * itemWeight;
 
@@ -638,7 +638,7 @@ const updateSummary = () => {
           collectableWeight += itemWeight;
           collectableValue += Number(item.qty) * parseFloat(item.price);
         } else {
-          // For regular items: Current Value = Weight × Current Spot Price
+          // For regular items: Melt Value = Weight × Current Spot Price
           const currentSpot = spotPrices[item.metal.toLowerCase()];
           currentSpotValue += currentSpot * itemWeight;
 
@@ -661,7 +661,7 @@ const updateSummary = () => {
 
         // Loss/Profit calculation
         if (!item.isCollectable) {
-          // For regular items: Loss/Profit = Current Value - Purchase Price
+          // For regular items: Loss/Profit = Melt Value - Purchase Price
           const currentSpot = spotPrices[item.metal.toLowerCase()];
           const currentValue = currentSpot * itemWeight;
           const purchaseValue = item.price * item.qty;
@@ -1494,28 +1494,28 @@ const exportPdf = () => {
   doc.text(`Total Items: ${elements.totals.silver.items.textContent}`, 25, finalY + 22);
   doc.text(`Total Weight: ${elements.totals.silver.weight.textContent} oz`, 25, finalY + 28);
   doc.text(`Purchase Price: ${elements.totals.silver.purchased.textContent}`, 25, finalY + 34);
-  doc.text(`Current Value: ${elements.totals.silver.value.textContent}`, 25, finalY + 40);
+  doc.text(`Melt Value: ${elements.totals.silver.value.textContent}`, 25, finalY + 40);
 
   // Gold Totals
   doc.text("Gold:", 100, finalY + 16);
   doc.text(`Total Items: ${elements.totals.gold.items.textContent}`, 111, finalY + 22);
   doc.text(`Total Weight: ${elements.totals.gold.weight.textContent} oz`, 111, finalY + 28);
   doc.text(`Purchase Price: ${elements.totals.gold.purchased.textContent}`, 111, finalY + 34);
-  doc.text(`Current Value: ${elements.totals.gold.value.textContent}`, 111, finalY + 40);
+  doc.text(`Melt Value: ${elements.totals.gold.value.textContent}`, 111, finalY + 40);
 
   // Platinum Totals
   doc.text("Platinum:", 14, finalY + 46);
   doc.text(`Total Items: ${elements.totals.platinum.items.textContent}`, 25, finalY + 52);
   doc.text(`Total Weight: ${elements.totals.platinum.weight.textContent} oz`, 25, finalY + 58);
   doc.text(`Purchase Price: ${elements.totals.platinum.purchased.textContent}`, 25, finalY + 64);
-  doc.text(`Current Value: ${elements.totals.platinum.value.textContent}`, 25, finalY + 70);
+  doc.text(`Melt Value: ${elements.totals.platinum.value.textContent}`, 25, finalY + 70);
 
   // Palladium Totals
   doc.text("Palladium:", 100, finalY + 46);
   doc.text(`Total Items: ${elements.totals.palladium.items.textContent}`, 111, finalY + 52);
   doc.text(`Total Weight: ${elements.totals.palladium.weight.textContent} oz`, 111, finalY + 58);
   doc.text(`Purchase Price: ${elements.totals.palladium.purchased.textContent}`, 111, finalY + 64);
-  doc.text(`Current Value: ${elements.totals.palladium.value.textContent}`, 111, finalY + 70);
+  doc.text(`Melt Value: ${elements.totals.palladium.value.textContent}`, 111, finalY + 70);
 
   // All Totals (only if elements exist)
   if (elements.totals.all.items.textContent !== undefined) {
@@ -1524,7 +1524,7 @@ const exportPdf = () => {
     doc.text(`Total Items: ${elements.totals.all.items.textContent}`, 25, finalY + 82);
     doc.text(`Total Weight: ${elements.totals.all.weight.textContent} oz`, 25, finalY + 88);
     doc.text(`Purchase Price: ${elements.totals.all.purchased.textContent}`, 25, finalY + 94);
-    doc.text(`Current Value: ${elements.totals.all.value.textContent}`, 25, finalY + 100);
+    doc.text(`Melt Value: ${elements.totals.all.value.textContent}`, 25, finalY + 100);
   }
 
   // Save PDF


### PR DESCRIPTION
## Summary
- Replace totals card labels with new terminology such as "Melt Value", "Avg. Price (oz)", and "Lifetime Premiums Paid"
- Update inventory comments and PDF export text to reflect Melt Value terminology

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68979f3b5aec832e9665294d5742d459