### PR TITLE
refactor: adjust totals card labels and font sizes

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1061,7 +1061,7 @@ input[type="submit"] {
 }
 
 .total-title {
-  font-size: 1.125rem;
+  font-size: 1.0625rem;
   font-weight: 700;
   margin-bottom: var(--spacing);
   color: var(--primary);
@@ -1093,12 +1093,13 @@ input[type="submit"] {
 .total-label {
   font-weight: 500;
   color: var(--text-secondary);
-  font-size: 0.875rem;
+  font-size: 0.8125rem;
 }
 
 .total-value {
   font-weight: 600;
   color: var(--text-primary);
+  font-size: 0.9375rem;
 }
 
 .details-btn {
@@ -1152,7 +1153,7 @@ input[type="submit"] {
 }
 
 .total-title {
-  font-size: 1.125rem;
+  font-size: 1.0625rem;
   font-weight: 700;
   margin-bottom: var(--spacing);
   color: var(--text-primary) !important;

--- a/index.html
+++ b/index.html
@@ -350,8 +350,8 @@
                 <span class="total-value" id="totalItemsSilver">0</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Total Weight:</span>
-                <span class="total-value" id="totalWeightSilver">0.00</span> oz
+                <span class="total-label">Total Weight (oz):</span>
+                <span class="total-value" id="totalWeightSilver">0.00</span>
               </div>
             </div>
             <div class="total-group">
@@ -368,13 +368,13 @@
                 <span class="total-value" id="avgPriceSilver">$0.00</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Avg. Collectable Price (oz):</span>
+                <span class="total-label">Avg. Collectable (oz):</span>
                 <span class="total-value" id="avgCollectablePriceSilver"
                   >$0.00</span
                 >
               </div>
               <div class="total-item">
-                <span class="total-label">Avg Stack Price (oz):</span>
+                <span class="total-label">Avg Non-Collectable (oz):</span>
                 <span class="total-value" id="avgNonCollectablePriceSilver"
                   >$0.00</span
                 >
@@ -407,8 +407,8 @@
                 <span class="total-value" id="totalItemsGold">0</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Total Weight:</span>
-                <span class="total-value" id="totalWeightGold">0.00</span> oz
+                <span class="total-label">Total Weight (oz):</span>
+                <span class="total-value" id="totalWeightGold">0.00</span>
               </div>
             </div>
             <div class="total-group">
@@ -425,13 +425,13 @@
                 <span class="total-value" id="avgPriceGold">$0.00</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Avg. Collectable Price (oz):</span>
+                <span class="total-label">Avg. Collectable (oz):</span>
                 <span class="total-value" id="avgCollectablePriceGold"
                   >$0.00</span
                 >
               </div>
               <div class="total-item">
-                <span class="total-label">Avg Stack Price (oz):</span>
+                <span class="total-label">Avg Non-Collectable (oz):</span>
                 <span class="total-value" id="avgNonCollectablePriceGold"
                   >$0.00</span
                 >
@@ -462,7 +462,7 @@
                 <span class="total-value" id="totalItemsPlatinum">0</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Total Weight:</span>
+                <span class="total-label">Total Weight (oz):</span>
                 <span class="total-value" id="totalWeightPlatinum">0.00</span>
               </div>
             </div>
@@ -482,13 +482,13 @@
                 <span class="total-value" id="avgPricePlatinum">$0.00</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Avg. Collectable Price (oz):</span>
+                <span class="total-label">Avg. Collectable (oz):</span>
                 <span class="total-value" id="avgCollectablePricePlatinum"
                   >$0.00</span
                 >
               </div>
               <div class="total-item">
-                <span class="total-label">Avg Stack Price (oz):</span>
+                <span class="total-label">Avg Non-Collectable (oz):</span>
                 <span class="total-value" id="avgNonCollectablePricePlatinum"
                   >$0.00</span
                 >
@@ -521,9 +521,8 @@
                 <span class="total-value" id="totalItemsPalladium">0</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Total Weight:</span>
+                <span class="total-label">Total Weight (oz):</span>
                 <span class="total-value" id="totalWeightPalladium">0.00</span>
-                oz
               </div>
             </div>
             <div class="total-group">
@@ -544,13 +543,13 @@
                 <span class="total-value" id="avgPricePalladium">$0.00</span>
               </div>
               <div class="total-item">
-                <span class="total-label">Avg. Collectable Price (oz):</span>
+                <span class="total-label">Avg. Collectable (oz):</span>
                 <span class="total-value" id="avgCollectablePricePalladium"
                   >$0.00</span
                 >
               </div>
               <div class="total-item">
-                <span class="total-label">Avg Stack Price (oz):</span>
+                <span class="total-label">Avg Non-Collectable (oz):</span>
                 <span class="total-value" id="avgNonCollectablePricePalladium"
                   >$0.00</span
                 >


### PR DESCRIPTION
## Summary
- Refine totals card labels to clarify collectable vs non-collectable averages and include weight units in the label.
- Reduce totals card typography by 1px for a more compact display.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897a4af1130832ea21432bbbdfc454a