### PR TITLE
docs: synchronize documentation with v3.2.06

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# StackTrackr v3.2.05rc
+# StackTrackr v3.2.06rc
 
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
 
 ## Recent Updates
+- **v3.2.06rc - UI Refinements & Auto Sync**: Adds modal-based item entry with stacked filters, pagination polish, collectable status button, and automatic spot price refresh when cached data expires
 - **v3.2.05rc - Splash Opt-Out & Branding**: Disclaimer modal now hides after acknowledgment, header branding adapts to the hosting domain with an updated subtitle, and API providers store keys separately
 - **v3.2.04rc - Import Negative Price Handling**: Negative prices default to $0 during imports
 - **v3.2.03rc - Cache Flush Confirmation**: Added warning before clearing API cache and history
@@ -16,6 +17,14 @@ StackTrackr is a comprehensive client-side web application for tracking precious
 - **v3.1.9 - UI Consistency**: Clear Cache button styling improvements across themes
 - **v3.1.8 - Backup System**: Full ZIP backup functionality with restoration guides
 - **v3.1.6 - Theme Toggle**: Fixed theme management with system preference detection
+
+## 🆕 What's New in v3.2.06rc
+- Automatically refreshes spot prices at startup when an API key is configured and cached data is stale
+- Item entry now occurs in a dedicated modal with support for stacked filtering
+- Items-per-page selector repositioned with unified pagination button theming and fixed dropdown width
+- Collectable checkbox replaced with status button and action buttons aligned in inventory table
+- Totals cards renamed with refined labels and font sizes
+- About modal title contrast improved in light mode
 
 ## 🆕 What's New in v3.2.05rc
 - Disclaimer splash hides permanently after you click "I Understand"
@@ -226,7 +235,7 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: 3.2.05rc
+**Current Version**: 3.2.06rc
 **Last Updated**: August 9, 2025
 **Status**: Feature complete release candidate
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ### Version 3.2.06rc – Auto Spot Price Sync (2025-08-09)
 - Automatically refreshes spot prices at startup when API keys exist and the cache is expired
+- Item entry moved to a dedicated modal with stacked filter support
+- Pagination controls polished with repositioned items-per-page selector and fixed dropdown width
+- Collectable checkbox replaced with status button and aligned action buttons
+- Totals cards renamed with refined labels and font sizing
+- Improved About modal title contrast in light mode
 
 ### Version 3.2.05rc – Splash Opt-Out (2025-08-09)
 - Disclaimer splash now hides permanently after the acknowledgment button is clicked, removing the previous checkbox

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,10 +1,10 @@
-# Multi-Agent Development Workflow - StackTrackr v3.2.05rc
+# Multi-Agent Development Workflow - StackTrackr v3.2.06rc
 
 ## 🎯 Project Overview
 
-You are contributing to the **StackTrackr v3.2.05rc**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to the **StackTrackr v3.2.06rc**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.2.05rc (feature-complete release candidate)
+**Current Status**: v3.2.06rc (feature-complete release candidate)
 **Your Role**: Complete individual 2-hour subtasks as part of a coordinated multi-agent development effort
 
 ---
@@ -287,6 +287,6 @@ Before starting ANY subtask, read these files:
 
 ---
 
-**Remember: Each subtask is designed to be completed independently while contributing to the larger v3.2.05rc vision. Focus on quality over speed, and don't hesitate to coordinate with other agents when working on shared components.**
+**Remember: Each subtask is designed to be completed independently while contributing to the larger v3.2.06rc vision. Focus on quality over speed, and don't hesitate to coordinate with other agents when working on shared components.**
 
 **Your contribution helps build a professional-grade inventory management system that serves users worldwide. Every subtask matters!** 🚀

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,8 +1,8 @@
 # Project Status - StackTrackr
 
-## 🎯 Current State: **FEATURE COMPLETE v3.2.05rc** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **FEATURE COMPLETE v3.2.06rc** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.2.05rc** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.2.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.2.06rc** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.2.x series focuses on polish, maintenance, and optimization.
 
 ## 🏗️ Architecture Overview
 
@@ -18,8 +18,9 @@ The tool features a **modular JavaScript architecture** with separate files for 
 - `theme.js` - Dark/light theme management
 - `utils.js` - Helper functions and formatters
 
-## ✨ Latest Changes (3.1.x Series)
+## ✨ Latest Changes (3.2.x Series)
 
+- **v3.2.06rc - UI Refinements & Auto Sync**: Modal-based item entry with stacked filters, pagination polish with repositioned items-per-page selector, collectable status button, totals card label updates, improved About modal contrast, and automatic spot price refresh at startup
 - **v3.2.05rc - Splash Opt-Out & Branding**: Disclaimer modal can be hidden permanently, header adapts to hosting domain with updated subtitle, and each API provider stores its own key
 - **v3.2.03rc - Cache Flush Confirmation**: Added warning before clearing API cache and history
 - **v3.2.02rc - Feature Complete Release Candidate**: Application rebranded to StackTrackr and prepared for final release
@@ -118,8 +119,8 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.2.05rc (managed in `js/constants.js`)
-2. **Last Change**: Added confirmation before flushing API cache and history
+1. **Current Version**: 3.2.06rc (managed in `js/constants.js`)
+2. **Last Change**: Introduced modal-based item entry, pagination refinements, totals card updates, and auto spot price refresh
 3. **Last Documentation Update**: August 9, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns
 5. **Documentation**: Comprehensive JSDoc comments throughout codebase

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -7,17 +7,16 @@ The StackTrackr now uses a dynamic version management system that automatically 
 ## How It Works
 
 ### Single Source of Truth
-- Version is defined once in `/app/js/constants.js` as `APP_VERSION = '3.2.05rc'`
+- Version is defined once in `js/constants.js` as `APP_VERSION = '3.2.06rc'`
 - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation
-- **Root Landing Page** (`/index.html`): JavaScript automatically updates the page title and heading
-- **Main Application** (`/app/index.html`): JavaScript automatically updates the page title and heading  
+- **index.html**: JavaScript automatically updates the page title and heading
 - **Browser Tab Title**: Dynamically updated with current version
 - **Application Header**: Shows current version in the main app interface
 
 ### Utility Functions
-Two helper functions are available in `/app/js/utils.js`:
+Two helper functions are available in `js/utils.js`:
 - `getVersionString(prefix)`: Returns formatted version (e.g., "v3.0.1")
 - `getAppTitle(baseTitle)`: Returns full app title with version
 
@@ -27,30 +26,24 @@ To release a new version:
 
 1. **Update ONLY the constants file:**
    ```javascript
-   // In /app/js/constants.js
-   const APP_VERSION = '3.2.05rc';  // Change this line only
+   // In js/constants.js
+   const APP_VERSION = '3.2.06rc';  // Change this line only
    ```
 
 2. **All these will automatically update:**
-   - Root page title: "StackTrackr v3.1.0"
-   - Root page heading: "StackTrackr v3.1.0"
-   - App page title: "StackTrackr v3.1.0"
-   - App header: "StackTrackr v3.1.0"
+   - Page title: "StackTrackr v3.2.06rc"
+   - Page heading: "StackTrackr v3.2.06rc"
+   - Browser tab title: "StackTrackr v3.2.06rc"
+   - App header: "StackTrackr v3.2.06rc"
 
 3. **Update changelog:** Add entry to `/docs/CHANGELOG.md` for documentation
 
 ## Technical Implementation
 
-### Root Page (app/index.html)
+### index.html
 ```javascript
-// Loads app/js/constants.js and utils.js
-// Updates title and heading via DOM manipulation
-document.title = `StackTrackr ${getVersionString()}`;
-```
-
-### Main App (app/app/index.html)
-```javascript
-// In init.js - runs on DOM load
+// Loads js/constants.js and utils.js
+// Updates title, header, and other references via DOM manipulation
 document.title = getAppTitle();
 const appHeader = document.querySelector('.app-header h1');
 appHeader.textContent = getAppTitle();
@@ -77,15 +70,15 @@ Use semantic versioning: `MAJOR.MINOR.PATCH`
 ## Example Usage in Code
 ```javascript
 // Get just the version number
-const version = APP_VERSION; // "3.2.05rc"
+const version = APP_VERSION; // "3.2.06rc"
 
 // Get formatted version string
-const versionString = getVersionString(); // "v3.2.05rc"
-const customVersion = getVersionString('version '); // "version 3.2.05rc"
+const versionString = getVersionString(); // "v3.2.06rc"
+const customVersion = getVersionString('version '); // "version 3.2.06rc"
 
 // Get full app title
-const title = getAppTitle(); // "StackTrackr v3.2.05rc"
-const customTitle = getAppTitle('My Custom Tool'); // "My Custom Tool v3.2.05rc"
+const title = getAppTitle(); // "StackTrackr v3.2.06rc"
+const customTitle = getAppTitle('My Custom Tool'); // "My Custom Tool v3.2.06rc"
 ```
 
 This system ensures version consistency and makes maintenance much easier!

--- a/docs/notes/documentation-consolidation.md
+++ b/docs/notes/documentation-consolidation.md
@@ -15,7 +15,7 @@ The original `docs/LLM.md` served as a general AI assistant guide but contained:
 ## Replacement
 `docs/MULTI_AGENT_WORKFLOW.md` provides:
 - ✅ **Complete project context** - Everything from LLM.md plus more
-- ✅ **Current v3.2.05rc focus** - Up-to-date technical information
+- ✅ **Current v3.2.06rc focus** - Up-to-date technical information
 - ✅ **Actionable workflow guidance** - Specific step-by-step processes
 - ✅ **Quality standards** - Testing and validation protocols
 - ✅ **Coordination system** - Multi-agent conflict prevention

--- a/structure.md
+++ b/structure.md
@@ -1,6 +1,6 @@
 # StackTrackr - Project Structure
 
-## Current Structure (Version 3.2.05rc)
+## Current Structure (Version 3.2.06rc)
 
 ```text
 ├── css/


### PR DESCRIPTION
## Summary
- update docs for v3.2.06 with auto spot price sync and UI refinements
- refresh versioning guide and workflow references
- bump structure and notes to current release

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897a88cbfd8832e86ec6bc6398120aa