### PR TITLE
feat: highlight notes presence in table

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
 
 ## Recent Updates
-- **v3.2.06rc - UI Refinements & Auto Sync**: Adds modal-based item entry with stacked filters, pagination polish, collectable status button, notes button highlighting when notes exist, and automatic spot price refresh when cached data expires
+- **v3.2.06rc - UI Refinements & Auto Sync**: Adds modal-based item entry with stacked filters, pagination polish, collectable status button, notes button showing green "Yes" when notes exist, and automatic spot price refresh when cached data expires
 - **v3.2.05rc - Splash Opt-Out & Branding**: Disclaimer modal now hides after acknowledgment, header branding adapts to the hosting domain with an updated subtitle, and API providers store keys separately
 - **v3.2.04rc - Import Negative Price Handling**: Negative prices default to $0 during imports
 - **v3.2.03rc - Cache Flush Confirmation**: Added warning before clearing API cache and history
@@ -25,7 +25,7 @@ StackTrackr is a comprehensive client-side web application for tracking precious
 - Collectable checkbox replaced with status button and action buttons aligned in inventory table
 - Totals cards renamed with refined labels and font sizes
 - About modal title contrast improved in light mode
-- Notes button turns orange when an item contains notes
+- Notes button displays "Yes" in green when an item contains notes
 
 ## 🆕 What's New in v3.2.05rc
 - Disclaimer splash hides permanently after you click "I Understand"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
 
 ## Recent Updates
-- **v3.2.06rc - UI Refinements & Auto Sync**: Adds modal-based item entry with stacked filters, pagination polish, collectable status button, and automatic spot price refresh when cached data expires
+- **v3.2.06rc - UI Refinements & Auto Sync**: Adds modal-based item entry with stacked filters, pagination polish, collectable status button, notes button highlighting when notes exist, and automatic spot price refresh when cached data expires
 - **v3.2.05rc - Splash Opt-Out & Branding**: Disclaimer modal now hides after acknowledgment, header branding adapts to the hosting domain with an updated subtitle, and API providers store keys separately
 - **v3.2.04rc - Import Negative Price Handling**: Negative prices default to $0 during imports
 - **v3.2.03rc - Cache Flush Confirmation**: Added warning before clearing API cache and history
@@ -25,6 +25,7 @@ StackTrackr is a comprehensive client-side web application for tracking precious
 - Collectable checkbox replaced with status button and action buttons aligned in inventory table
 - Totals cards renamed with refined labels and font sizes
 - About modal title contrast improved in light mode
+- Notes button turns orange when an item contains notes
 
 ## 🆕 What's New in v3.2.05rc
 - Disclaimer splash hides permanently after you click "I Understand"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Collectable checkbox replaced with status button and aligned action buttons
 - Totals cards renamed with refined labels and font sizing
 - Improved About modal title contrast in light mode
+- Notes button highlights items with saved notes
 
 ### Version 3.2.05rc – Splash Opt-Out (2025-08-09)
 - Disclaimer splash now hides permanently after the acknowledgment button is clicked, removing the previous checkbox

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@
 - Collectable checkbox replaced with status button and aligned action buttons
 - Totals cards renamed with refined labels and font sizing
 - Improved About modal title contrast in light mode
-- Notes button highlights items with saved notes
+- Notes button displays a green "Yes" when items have saved notes
 
 ### Version 3.2.05rc – Splash Opt-Out (2025-08-09)
 - Disclaimer splash now hides permanently after the acknowledgment button is clicked, removing the previous checkbox

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -543,7 +543,7 @@ const renderTable = () => {
       <td class="shrink">${filterLink('purchaseLocation', item.purchaseLocation, getPurchaseLocationColor(item.purchaseLocation))}</td>
       <td class="shrink">${filterLink('storageLocation', item.storageLocation || 'Unknown', getStorageLocationColor(item.storageLocation || 'Unknown'))}</td>
       <td class="shrink"><button type="button" class="btn action-btn collectable-btn ${item.isCollectable ? 'success' : ''}" onclick="toggleCollectable(${originalIdx})" aria-label="Toggle collectable status for ${sanitizeHtml(item.name)}" title="Toggle collectable status">${item.isCollectable ? 'Yes' : 'No'}</button></td>
-      <td class="shrink"><button class="btn action-btn ${item.notes && item.notes.trim() ? 'warning' : ''}" onclick="showNotes(${originalIdx})" aria-label="View notes" title="View notes">Notes</button></td>
+      <td class="shrink"><button type="button" class="btn action-btn notes-btn ${item.notes && item.notes.trim() ? 'success' : ''}" onclick="showNotes(${originalIdx})" aria-label="View notes" title="View notes">${item.notes && item.notes.trim() ? 'Yes' : 'No'}</button></td>
       <td class="shrink"><button class="btn action-btn danger" onclick="deleteItem(${originalIdx})" aria-label="Delete item" title="Delete item">Delete</button></td>
       </tr>
       `);

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -543,7 +543,7 @@ const renderTable = () => {
       <td class="shrink">${filterLink('purchaseLocation', item.purchaseLocation, getPurchaseLocationColor(item.purchaseLocation))}</td>
       <td class="shrink">${filterLink('storageLocation', item.storageLocation || 'Unknown', getStorageLocationColor(item.storageLocation || 'Unknown'))}</td>
       <td class="shrink"><button type="button" class="btn action-btn collectable-btn ${item.isCollectable ? 'success' : ''}" onclick="toggleCollectable(${originalIdx})" aria-label="Toggle collectable status for ${sanitizeHtml(item.name)}" title="Toggle collectable status">${item.isCollectable ? 'Yes' : 'No'}</button></td>
-      <td class="shrink"><button class="btn action-btn" onclick="showNotes(${originalIdx})" aria-label="View notes" title="View notes">Notes</button></td>
+      <td class="shrink"><button class="btn action-btn ${item.notes && item.notes.trim() ? 'warning' : ''}" onclick="showNotes(${originalIdx})" aria-label="View notes" title="View notes">Notes</button></td>
       <td class="shrink"><button class="btn action-btn danger" onclick="deleteItem(${originalIdx})" aria-label="Delete item" title="Delete item">Delete</button></td>
       </tr>
       `);


### PR DESCRIPTION
## Summary
- color Notes button orange when an item contains notes
- document notes button highlight in changelog and readme

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897ab803ba4832ea4fb05ccc787d20d