### PR TITLE
feat: show spot source timestamp and reposition totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# StackTrackr v3.2.06rc
+# StackTrackr v3.2.07rc
 
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
 
 ## Recent Updates
+- **v3.2.07rc - Spot Timestamp Source Display**: Spot price cards now show the API provider or Manual entry along with the exact timestamp of the last update
 - **v3.2.06rc - UI Refinements & Auto Sync**: Adds modal-based item entry with stacked filters, pagination polish, collectable status button, notes button showing green "Yes" when notes exist, and automatic spot price refresh when cached data expires
 - **v3.2.05rc - Splash Opt-Out & Branding**: Disclaimer modal now hides after acknowledgment, header branding adapts to the hosting domain with an updated subtitle, and API providers store keys separately
 - **v3.2.04rc - Import Negative Price Handling**: Negative prices default to $0 during imports
@@ -17,6 +18,9 @@ StackTrackr is a comprehensive client-side web application for tracking precious
 - **v3.1.9 - UI Consistency**: Clear Cache button styling improvements across themes
 - **v3.1.8 - Backup System**: Full ZIP backup functionality with restoration guides
 - **v3.1.6 - Theme Toggle**: Fixed theme management with system preference detection
+
+## 🆕 What's New in v3.2.07rc
+- Spot price cards display API provider or Manual entry along with exact timestamp of last update
 
 ## 🆕 What's New in v3.2.06rc
 - Automatically refreshes spot prices at startup when an API key is configured and cached data is stale
@@ -236,7 +240,7 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: 3.2.06rc
+**Current Version**: 3.2.07rc
 **Last Updated**: August 9, 2025
 **Status**: Feature complete release candidate
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -2066,7 +2066,7 @@ td input:checked + .slider:before {
    ============================================================================= */
 
 .search-section {
-  margin-bottom: var(--spacing);
+  margin-bottom: 0;
 }
 
 .search-container {
@@ -2093,8 +2093,11 @@ td input:checked + .slider:before {
 .search-results-info {
   font-size: 0.875rem;
   color: var(--text-muted);
-  margin-top: var(--spacing-sm);
   text-align: right;
+}
+
+.search-results-info:not(:empty) {
+  margin-top: var(--spacing-sm);
 }
 
 /* =============================================================================

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ## 📋 Version History
 
+### Version 3.2.07rc – Spot Timestamp Source Display (2025-08-09)
+- Spot price cards now show API provider or Manual entry along with exact timestamp of the last update
+- Footer dynamically displays the active StackTrackr domain and links to issue reporting
+
 ### Version 3.2.06rc – Auto Spot Price Sync (2025-08-09)
 - Automatically refreshes spot prices at startup when API keys exist and the cache is expired
 - Item entry moved to a dedicated modal with stacked filter support

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,10 +1,10 @@
-# Multi-Agent Development Workflow - StackTrackr v3.2.06rc
+# Multi-Agent Development Workflow - StackTrackr v3.2.07rc
 
 ## 🎯 Project Overview
 
-You are contributing to the **StackTrackr v3.2.06rc**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to the **StackTrackr v3.2.07rc**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.2.06rc (feature-complete release candidate)
+**Current Status**: v3.2.07rc (feature-complete release candidate)
 **Your Role**: Complete individual 2-hour subtasks as part of a coordinated multi-agent development effort
 
 ---
@@ -287,6 +287,6 @@ Before starting ANY subtask, read these files:
 
 ---
 
-**Remember: Each subtask is designed to be completed independently while contributing to the larger v3.2.06rc vision. Focus on quality over speed, and don't hesitate to coordinate with other agents when working on shared components.**
+**Remember: Each subtask is designed to be completed independently while contributing to the larger v3.2.07rc vision. Focus on quality over speed, and don't hesitate to coordinate with other agents when working on shared components.**
 
 **Your contribution helps build a professional-grade inventory management system that serves users worldwide. Every subtask matters!** 🚀

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,8 +1,8 @@
 # Project Status - StackTrackr
 
-## 🎯 Current State: **FEATURE COMPLETE v3.2.06rc** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **FEATURE COMPLETE v3.2.07rc** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.2.06rc** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.2.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.2.07rc** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.2.x series focuses on polish, maintenance, and optimization.
 
 ## 🏗️ Architecture Overview
 
@@ -20,6 +20,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes (3.2.x Series)
 
+- **v3.2.07rc - Spot Timestamp Source Display**: Spot price cards show the API provider or Manual entry and the exact time of the last update
 - **v3.2.06rc - UI Refinements & Auto Sync**: Modal-based item entry with stacked filters, pagination polish with repositioned items-per-page selector, collectable status button, totals card label updates, improved About modal contrast, and automatic spot price refresh at startup
 - **v3.2.05rc - Splash Opt-Out & Branding**: Disclaimer modal can be hidden permanently, header adapts to hosting domain with updated subtitle, and each API provider stores its own key
 - **v3.2.03rc - Cache Flush Confirmation**: Added warning before clearing API cache and history
@@ -119,7 +120,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.2.06rc (managed in `js/constants.js`)
+1. **Current Version**: 3.2.07rc (managed in `js/constants.js`)
 2. **Last Change**: Introduced modal-based item entry, pagination refinements, totals card updates, and auto spot price refresh
 3. **Last Documentation Update**: August 9, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -7,7 +7,7 @@ The StackTrackr now uses a dynamic version management system that automatically 
 ## How It Works
 
 ### Single Source of Truth
-- Version is defined once in `js/constants.js` as `APP_VERSION = '3.2.06rc'`
+- Version is defined once in `js/constants.js` as `APP_VERSION = '3.2.07rc'`
 - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation
@@ -27,14 +27,14 @@ To release a new version:
 1. **Update ONLY the constants file:**
    ```javascript
    // In js/constants.js
-   const APP_VERSION = '3.2.06rc';  // Change this line only
+   const APP_VERSION = '3.2.07rc';  // Change this line only
    ```
 
 2. **All these will automatically update:**
-   - Page title: "StackTrackr v3.2.06rc"
-   - Page heading: "StackTrackr v3.2.06rc"
-   - Browser tab title: "StackTrackr v3.2.06rc"
-   - App header: "StackTrackr v3.2.06rc"
+   - Page title: "StackTrackr v3.2.07rc"
+   - Page heading: "StackTrackr v3.2.07rc"
+   - Browser tab title: "StackTrackr v3.2.07rc"
+   - App header: "StackTrackr v3.2.07rc"
 
 3. **Update changelog:** Add entry to `/docs/CHANGELOG.md` for documentation
 
@@ -70,15 +70,15 @@ Use semantic versioning: `MAJOR.MINOR.PATCH`
 ## Example Usage in Code
 ```javascript
 // Get just the version number
-const version = APP_VERSION; // "3.2.06rc"
+const version = APP_VERSION; // "3.2.07rc"
 
 // Get formatted version string
-const versionString = getVersionString(); // "v3.2.06rc"
-const customVersion = getVersionString('version '); // "version 3.2.06rc"
+const versionString = getVersionString(); // "v3.2.07rc"
+const customVersion = getVersionString('version '); // "version 3.2.07rc"
 
 // Get full app title
-const title = getAppTitle(); // "StackTrackr v3.2.06rc"
-const customTitle = getAppTitle('My Custom Tool'); // "My Custom Tool v3.2.06rc"
+const title = getAppTitle(); // "StackTrackr v3.2.07rc"
+const customTitle = getAppTitle('My Custom Tool'); // "My Custom Tool v3.2.07rc"
 ```
 
 This system ensures version consistency and makes maintenance much easier!

--- a/docs/notes/documentation-consolidation.md
+++ b/docs/notes/documentation-consolidation.md
@@ -15,7 +15,7 @@ The original `docs/LLM.md` served as a general AI assistant guide but contained:
 ## Replacement
 `docs/MULTI_AGENT_WORKFLOW.md` provides:
 - ✅ **Complete project context** - Everything from LLM.md plus more
-- ✅ **Current v3.2.06rc focus** - Up-to-date technical information
+- ✅ **Current v3.2.07rc focus** - Up-to-date technical information
 - ✅ **Actionable workflow guidance** - Specific step-by-step processes
 - ✅ **Quality standards** - Testing and validation protocols
 - ✅ **Coordination system** - Multi-agent conflict prevention

--- a/index.html
+++ b/index.html
@@ -325,17 +325,138 @@
             </div>
           </div>
         </div>
+      </section><!-- =============================================================================
+         INVENTORY FORM SECTION
+         
+         Primary data entry form for adding new inventory items. Includes fields for:
+         - Metal type selection (Silver, Gold, Platinum, Palladium)
+         - Item details (name, type, quantity, weight)
+         - Purchase information (price, location, storage location, date)
+         
+         Form submission is handled by events.js with validation and automatic
+         premium calculation based on current spot prices
+         ============================================================================= -->
+      <!--
+        Legacy add item form - commented out pending removal after
+        verifying new modal workflow.
+      <section class="form-section">
+        ...
+      </section>
+      -->
+      <!-- =============================================================================
+         SEARCH FUNCTIONALITY
+         
+         Live search interface that filters inventory table in real-time.
+         Searches across all relevant fields including:
+         - Metal type, name, type, purchase/storage locations, date
+         - Quantity, weight, price values
+         - Collectable status (yes/no)
+         
+         Search is case-insensitive and supports partial matches
+         Implementation in search.js with filterInventory() function
+         ============================================================================= -->
+      <section class="search-section">
+        <div class="search-container">
+          <input
+            id="searchInput"
+            placeholder="Search inventory by metal, name, type, purchase location, storage location, notes, date..."
+            type="text"
+          />
+          <button class="btn" id="clearSearchBtn">Clear</button>
+          <button class="btn success" id="newItemBtn">New Item</button>
+        </div>
+        <div class="search-results-info" id="searchResultsInfo"></div>
+      </section>
+      <!-- =============================================================================
+         INVENTORY TABLE SECTION
+         
+         Main data display table showing all inventory items with:
+         - Sortable columns (click headers to sort ascending/descending)
+         - Clickable item names for editing (opens edit modal)
+         - Collectable status checkboxes for quick toggle
+         - Delete buttons with confirmation
+         - Responsive design with column resizing capability
+         
+      Table rendering handled by renderTable() in inventory.js
+       Pagination controls limit display to selected items per page
+       ============================================================================= -->
+      <section class="table-section">
+        <div class="items-per-page">
+          <span>Items:</span>
+          <select class="pagination-select" id="itemsPerPage">
+            <option value="10">10</option>
+            <option value="15">15</option>
+            <option selected value="25">25</option>
+            <option value="50">50</option>
+            <option value="100">100</option>
+          </select>
+        </div>
+        <table id="inventoryTable">
+          <thead>
+            <tr>
+              <th class="shrink">Date</th>
+              <th class="shrink">Type</th>
+              <th class="shrink">Metal</th>
+              <th class="shrink">Qty</th>
+              <th class="expand">Name</th>
+              <th class="shrink">Weight (oz)</th>
+              <th class="shrink">Purchase Price ($)</th>
+              <th class="shrink">Spot at Purchase ($)</th>
+              <th class="shrink">Premium ($)</th>
+              <th class="shrink">Purchase Location</th>
+              <th class="shrink">Storage Location</th>
+              <th class="shrink">Collectable</th>
+              <th class="shrink">Notes</th>
+              <th class="shrink">Delete</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+        <!-- Pagination Controls -->
+        <section class="pagination-section">
+          <div class="pagination-container">
+            <div class="pagination-controls">
+              <div class="pagination-buttons">
+                <div class="pagination-left">
+                  <button
+                    class="pagination-btn"
+                    id="firstPage"
+                    title="First Page"
+                  >
+                    «
+                  </button>
+                  <button
+                    class="pagination-btn"
+                    id="prevPage"
+                    title="Previous Page"
+                  >
+                    ‹
+                  </button>
+                </div>
+                <div class="pagination-center" id="pageNumbers"></div>
+                <div class="pagination-right">
+                  <button class="pagination-btn" id="nextPage" title="Next Page">
+                    ›
+                  </button>
+                  <button class="pagination-btn" id="lastPage" title="Last Page">
+                    »
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
       </section>
       <!-- =============================================================================
          TOTALS SECTION
-         
+
          Comprehensive financial summary cards for each metal type showing:
          - Total items and weight in inventory
          - Purchase price vs current value calculations
          - Average prices (overall, collectable, non-collectable)
          - Premium analysis and profit/loss calculations
          - "View Details" buttons that open analytics modals with pie charts
-         
+
          All calculations are performed by updateSummary() in inventory.js
          Values are updated automatically when inventory changes
          ============================================================================= -->
@@ -576,128 +697,6 @@
             </button>
           </div>
         </div>
-      </section>
-      <!-- =============================================================================
-         INVENTORY FORM SECTION
-         
-         Primary data entry form for adding new inventory items. Includes fields for:
-         - Metal type selection (Silver, Gold, Platinum, Palladium)
-         - Item details (name, type, quantity, weight)
-         - Purchase information (price, location, storage location, date)
-         
-         Form submission is handled by events.js with validation and automatic
-         premium calculation based on current spot prices
-         ============================================================================= -->
-      <!--
-        Legacy add item form - commented out pending removal after
-        verifying new modal workflow.
-      <section class="form-section">
-        ...
-      </section>
-      -->
-      <!-- =============================================================================
-         SEARCH FUNCTIONALITY
-         
-         Live search interface that filters inventory table in real-time.
-         Searches across all relevant fields including:
-         - Metal type, name, type, purchase/storage locations, date
-         - Quantity, weight, price values
-         - Collectable status (yes/no)
-         
-         Search is case-insensitive and supports partial matches
-         Implementation in search.js with filterInventory() function
-         ============================================================================= -->
-      <section class="search-section">
-        <div class="search-container">
-          <input
-            id="searchInput"
-            placeholder="Search inventory by metal, name, type, purchase location, storage location, notes, date..."
-            type="text"
-          />
-          <button class="btn" id="clearSearchBtn">Clear</button>
-          <button class="btn success" id="newItemBtn">New Item</button>
-        </div>
-        <div class="search-results-info" id="searchResultsInfo"></div>
-      </section>
-      <!-- =============================================================================
-         INVENTORY TABLE SECTION
-         
-         Main data display table showing all inventory items with:
-         - Sortable columns (click headers to sort ascending/descending)
-         - Clickable item names for editing (opens edit modal)
-         - Collectable status checkboxes for quick toggle
-         - Delete buttons with confirmation
-         - Responsive design with column resizing capability
-         
-      Table rendering handled by renderTable() in inventory.js
-       Pagination controls limit display to selected items per page
-       ============================================================================= -->
-      <section class="table-section">
-        <div class="items-per-page">
-          <span>Items:</span>
-          <select class="pagination-select" id="itemsPerPage">
-            <option value="10">10</option>
-            <option value="15">15</option>
-            <option selected value="25">25</option>
-            <option value="50">50</option>
-            <option value="100">100</option>
-          </select>
-        </div>
-        <table id="inventoryTable">
-          <thead>
-            <tr>
-              <th class="shrink">Date</th>
-              <th class="shrink">Type</th>
-              <th class="shrink">Metal</th>
-              <th class="shrink">Qty</th>
-              <th class="expand">Name</th>
-              <th class="shrink">Weight (oz)</th>
-              <th class="shrink">Purchase Price ($)</th>
-              <th class="shrink">Spot at Purchase ($)</th>
-              <th class="shrink">Premium ($)</th>
-              <th class="shrink">Purchase Location</th>
-              <th class="shrink">Storage Location</th>
-              <th class="shrink">Collectable</th>
-              <th class="shrink">Notes</th>
-              <th class="shrink">Delete</th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
-        <!-- Pagination Controls -->
-        <section class="pagination-section">
-          <div class="pagination-container">
-            <div class="pagination-controls">
-              <div class="pagination-buttons">
-                <div class="pagination-left">
-                  <button
-                    class="pagination-btn"
-                    id="firstPage"
-                    title="First Page"
-                  >
-                    «
-                  </button>
-                  <button
-                    class="pagination-btn"
-                    id="prevPage"
-                    title="Previous Page"
-                  >
-                    ‹
-                  </button>
-                </div>
-                <div class="pagination-center" id="pageNumbers"></div>
-                <div class="pagination-right">
-                  <button class="pagination-btn" id="nextPage" title="Next Page">
-                    ›
-                  </button>
-                  <button class="pagination-btn" id="lastPage" title="Last Page">
-                    »
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
       </section>
       <!-- =============================================================================
          IMPORT/EXPORT SECTION
@@ -1039,13 +1038,21 @@
       </div>
     </div>
     <footer class="app-footer">
-      © 2025 stacktrackr.com. Open source project licensed
+      © 2025 <span id="footerDomain">stacktrackr.com</span>. Open source project licensed
       <a
         href="https://www.gnu.org/licenses/gpl-3.0.en.html"
         target="_blank"
         rel="noopener"
         >GPL-3.0</a
       >.
+      <br />
+      Report issues or bugs here:
+      <a
+        href="https://github.com/lbruton/StackTrackr/issues"
+        target="_blank"
+        rel="noopener"
+        >https://github.com/lbruton/StackTrackr/issues</a
+      >
     </footer>
     <!-- =============================================================================
        ABOUT & DISCLAIMER MODAL

--- a/js/constants.js
+++ b/js/constants.js
@@ -93,7 +93,7 @@ const API_PROVIDERS = {
 // =============================================================================
 
 /** @constant {string} APP_VERSION - Application version */
-const APP_VERSION = "3.2.06rc";
+const APP_VERSION = "3.2.07rc";
 
 /** @constant {string} BRANDING_TITLE - Optional custom application title */
 const BRANDING_TITLE = "StackTrackr";

--- a/js/init.js
+++ b/js/init.js
@@ -264,6 +264,10 @@ document.addEventListener("DOMContentLoaded", () => {
     if (aboutVersion) {
       aboutVersion.textContent = `v${APP_VERSION}`;
     }
+    const footerDomainEl = document.getElementById("footerDomain");
+    if (footerDomainEl) {
+      footerDomainEl.textContent = getFooterDomain();
+    }
     if (typeof loadChangelog === "function") {
       loadChangelog();
     }

--- a/js/utils.js
+++ b/js/utils.js
@@ -39,6 +39,19 @@ const getAppTitle = (baseTitle = "StackTrackr") => {
 };
 
 /**
+ * Determines active domain for footer copyright
+ *
+ * @returns {string} Domain name to display
+ */
+const getFooterDomain = () => {
+  const host = window.location.hostname.toLowerCase();
+  if (host.includes("stackrtrackr.com")) return "stackrtrackr.com";
+  if (host.includes("stacktrackr.com")) return "stacktrackr.com";
+  if (host.includes("stackertrackr.com")) return "stackertrackr.com";
+  return "stacktrackr.com";
+};
+
+/**
  * Performance monitoring utility
  *
  * @param {Function} fn - Function to monitor
@@ -76,24 +89,8 @@ const getLastUpdateTime = (metalName) => {
 
   const latestEntry = metalEntries[metalEntries.length - 1];
   const timestamp = new Date(latestEntry.timestamp);
-  const now = new Date();
-  const diffMs = now - timestamp;
-  const diffMins = Math.floor(diffMs / (1000 * 60));
-  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
 
-  let timeText;
-  if (diffMins < 1) {
-    timeText = "Just now";
-  } else if (diffMins < 60) {
-    timeText = `${diffMins} min${diffMins === 1 ? "" : "s"} ago`;
-  } else if (diffHours < 24) {
-    timeText = `${diffHours} hr${diffHours === 1 ? "" : "s"} ago`;
-  } else if (diffDays < 30) {
-    timeText = `${diffDays} day${diffDays === 1 ? "" : "s"} ago`;
-  } else {
-    timeText = timestamp.toLocaleDateString();
-  }
+  const timeText = timestamp.toLocaleString();
 
   let sourceText;
   if (latestEntry.source === "api") {

--- a/structure.md
+++ b/structure.md
@@ -1,6 +1,6 @@
 # StackTrackr - Project Structure
 
-## Current Structure (Version 3.2.06rc)
+## Current Structure (Version 3.2.07rc)
 
 ```text
 ├── css/


### PR DESCRIPTION
## Summary
- display API provider or manual entry with exact timestamp beneath each spot price
- move totals cards below the inventory table and tighten search spacing
- dynamically show site domain in footer and link to issue tracker
- bump version to v3.2.07rc and document change

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897b5959038832e9b3d5e9b0c926972