### PR TITLE
feat: add inventory change log and reorder columns

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1037,6 +1037,43 @@ input[type="submit"] {
   flex: 1;
 }
 
+/* Standardized modal layout for change log and details views */
+#changeLogModal .modal-content,
+#detailsModal .modal-content {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+}
+
+#changeLogModal .modal-content {
+  max-width: 800px;
+}
+
+#changeLogModal .modal-header,
+#detailsModal .modal-header {
+  background: linear-gradient(135deg, var(--primary), var(--primary-hover));
+  color: white;
+  padding: var(--spacing-xl);
+  position: relative;
+  border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+  box-shadow: var(--shadow);
+}
+
+#changeLogModal .modal-header h2,
+#detailsModal .modal-header h2 {
+  margin: 0;
+  color: white;
+  text-align: center;
+}
+
+#changeLogModal .modal-body,
+#detailsModal .modal-body {
+  padding: var(--spacing-xl);
+  overflow-y: auto;
+  flex: 1;
+}
+
 /* =============================================================================
    TOTALS CARDS
    ============================================================================= */
@@ -1824,19 +1861,6 @@ td input:checked + .slider:before {
   }
 }
 
-.details-modal-content {
-  background: var(--bg-card);
-  border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
-  padding: var(--spacing-xl);
-  max-width: 1200px;
-  width: 100%;
-  max-height: 90vh;
-  overflow-y: auto;
-  box-shadow: var(--shadow-lg);
-  animation: modalSlideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
 @keyframes modalSlideIn {
   from {
     opacity: 0;
@@ -1846,15 +1870,6 @@ td input:checked + .slider:before {
     opacity: 1;
     transform: scale(1) translateY(0);
   }
-}
-
-.details-modal-title {
-  font-size: 1.5rem;
-  color: var(--primary);
-  margin-bottom: var(--spacing-lg);
-  text-align: center;
-  border-bottom: 2px solid var(--primary);
-  padding-bottom: var(--spacing-sm);
 }
 
 .details-content {
@@ -1966,17 +1981,6 @@ td input:checked + .slider:before {
 
 .chart-canvas {
   max-height: 300px !important;
-}
-
-.close-details-btn {
-  background: var(--primary);
-  color: white;
-  width: 100%;
-  margin-top: var(--spacing-lg);
-}
-
-.close-details-btn:hover {
-  background: var(--primary-hover);
 }
 
 /* =============================================================================
@@ -2314,7 +2318,7 @@ input:disabled + .slider {
     grid-template-columns: repeat(3, 1fr);
   }
 
-  .details-modal-content {
+  #detailsModal .modal-content {
     max-width: 900px;
   }
 
@@ -2329,7 +2333,7 @@ input:disabled + .slider {
     grid-template-columns: repeat(2, 1fr);
   }
 
-  .details-modal-content {
+  #detailsModal .modal-content {
     max-width: 700px;
   }
 }
@@ -2405,7 +2409,7 @@ input:disabled + .slider {
     gap: var(--spacing);
   }
 
-  .details-modal-content {
+  #detailsModal .modal-content {
     max-width: 95%;
     padding: var(--spacing);
   }
@@ -2432,8 +2436,7 @@ input:disabled + .slider {
     font-size: 1.5rem;
   }
 
-  .modal-content,
-  .details-modal-content {
+  .modal-content {
     margin: var(--spacing-sm);
     padding: var(--spacing);
   }

--- a/css/styles.css
+++ b/css/styles.css
@@ -2020,7 +2020,20 @@ td input:checked + .slider:before {
   justify-content: flex-end;
   align-items: center;
   gap: var(--spacing-sm);
+}
+
+.table-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   margin-bottom: var(--spacing-sm);
+}
+
+.change-log-link {
+  font-size: 0.9rem;
+  cursor: pointer;
+  color: var(--primary);
+  text-decoration: underline;
 }
 
 .pagination-select {
@@ -2361,6 +2374,12 @@ input:disabled + .slider {
 
     .items-per-page {
       justify-content: center;
+    }
+
+    .table-controls {
+      flex-direction: column;
+      align-items: stretch;
+      gap: var(--spacing-sm);
     }
 
   .search-container {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Version 3.2.07rc – Spot Timestamp Source Display (2025-08-09)
 - Spot price cards now show API provider or Manual entry along with exact timestamp of the last update
 - Footer dynamically displays the active StackTrackr domain and links to issue reporting
+- Inventory change log tracks last 25 edits and displays the 10 most recent in a modal
+- Quantity column repositioned after item name for improved readability
 
 ### Version 3.2.06rc – Auto Spot Price Sync (2025-08-09)
 - Automatically refreshes spot prices at startup when API keys exist and the cache is expired

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Spot price cards now show API provider or Manual entry along with exact timestamp of the last update
 - Footer dynamically displays the active StackTrackr domain and links to issue reporting
 - Inventory change log tracks last 25 edits and displays the 10 most recent in a modal
+- Change Log and metal totals details modals now share the site's standard header style
 - Quantity column repositioned after item name for improved readability
 
 ### Version 3.2.06rc – Auto Spot Price Sync (2025-08-09)

--- a/index.html
+++ b/index.html
@@ -381,15 +381,18 @@
        Pagination controls limit display to selected items per page
        ============================================================================= -->
       <section class="table-section">
-        <div class="items-per-page">
-          <span>Items:</span>
-          <select class="pagination-select" id="itemsPerPage">
-            <option value="10">10</option>
-            <option value="15">15</option>
-            <option selected value="25">25</option>
-            <option value="50">50</option>
-            <option value="100">100</option>
-          </select>
+        <div class="table-controls">
+          <a href="#" id="changeLogLink" class="change-log-link">Change Log</a>
+          <div class="items-per-page">
+            <span>Items:</span>
+            <select class="pagination-select" id="itemsPerPage">
+              <option value="10">10</option>
+              <option value="15">15</option>
+              <option selected value="25">25</option>
+              <option value="50">50</option>
+              <option value="100">100</option>
+            </select>
+          </div>
         </div>
         <table id="inventoryTable">
           <thead>
@@ -397,8 +400,8 @@
               <th class="shrink">Date</th>
               <th class="shrink">Type</th>
               <th class="shrink">Metal</th>
-              <th class="shrink">Qty</th>
               <th class="expand">Name</th>
+              <th class="shrink">Qty</th>
               <th class="shrink">Weight (oz)</th>
               <th class="shrink">Purchase Price ($)</th>
               <th class="shrink">Spot at Purchase ($)</th>
@@ -976,6 +979,35 @@
             <button class="btn" id="cancelNotes" type="button">Cancel</button>
             <button class="btn premium" id="saveNotes" type="button">Save</button>
           </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- =============================================================================
+       CHANGE LOG MODAL
+
+       Displays the 10 most recent inventory cell changes tracked by the system.
+       Data is populated dynamically from localStorage and rendered as a table.
+       ============================================================================= -->
+    <div class="modal" id="changeLogModal" style="display: none">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2>Change Log</h2>
+          <button aria-label="Close modal" class="modal-close" id="changeLogCloseBtn">×</button>
+        </div>
+        <div class="modal-body">
+          <table id="changeLogTable">
+            <thead>
+              <tr>
+                <th class="shrink">Date</th>
+                <th class="shrink">Item</th>
+                <th class="shrink">Field</th>
+                <th class="shrink">Old Value</th>
+                <th class="shrink">New Value</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
         </div>
       </div>
     </div>
@@ -1792,6 +1824,7 @@
     <script defer src="./js/constants.js"></script>
     <script defer src="./js/state.js"></script>
     <script defer src="./js/utils.js"></script>
+    <script defer src="./js/changeLog.js"></script>
     <script defer src="./js/charts.js"></script>
     <script defer src="./js/theme.js"></script>
     <script defer src="./js/search.js"></script>

--- a/index.html
+++ b/index.html
@@ -1032,41 +1032,45 @@
        Data preparation and chart rendering handled by charts.js
        ============================================================================= -->
     <div class="modal" id="detailsModal" style="display: none">
-      <div class="details-modal-content">
-        <h2 class="details-modal-title" id="detailsModalTitle"></h2>
-        <!-- Pie Charts Section -->
-        <div class="charts-section">
-          <div class="chart-container">
-            <div class="chart-title">Breakdown by Type</div>
-            <div class="chart-canvas-container">
-              <canvas class="chart-canvas" id="typeChart"></canvas>
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2 id="detailsModalTitle"></h2>
+          <button aria-label="Close modal" class="modal-close" id="detailsCloseBtn">×</button>
+        </div>
+        <div class="modal-body">
+          <!-- Pie Charts Section -->
+          <div class="charts-section">
+            <div class="chart-container">
+              <div class="chart-title">Breakdown by Type</div>
+              <div class="chart-canvas-container">
+                <canvas class="chart-canvas" id="typeChart"></canvas>
+              </div>
+            </div>
+            <div class="chart-container">
+              <div class="chart-title">Breakdown by Purchase Location</div>
+              <div class="chart-canvas-container">
+                <canvas class="chart-canvas" id="locationChart"></canvas>
+              </div>
             </div>
           </div>
-          <div class="chart-container">
-            <div class="chart-title">Breakdown by Purchase Location</div>
-            <div class="chart-canvas-container">
-              <canvas class="chart-canvas" id="locationChart"></canvas>
+          <!-- Data Tables Section -->
+          <div class="details-content">
+            <!-- Type breakdown column -->
+            <div class="details-section">
+              <div class="details-section-title">Type Details</div>
+              <div class="details-breakdown" id="typeBreakdown">
+                <!-- Content will be populated by JavaScript -->
+              </div>
+            </div>
+            <!-- Location breakdown column -->
+            <div class="details-section">
+              <div class="details-section-title">Location Details</div>
+              <div class="details-breakdown" id="locationBreakdown">
+                <!-- Content will be populated by JavaScript -->
+              </div>
             </div>
           </div>
         </div>
-        <!-- Data Tables Section -->
-        <div class="details-content">
-          <!-- Type breakdown column -->
-          <div class="details-section">
-            <div class="details-section-title">Type Details</div>
-            <div class="details-breakdown" id="typeBreakdown">
-              <!-- Content will be populated by JavaScript -->
-            </div>
-          </div>
-          <!-- Location breakdown column -->
-          <div class="details-section">
-            <div class="details-section-title">Location Details</div>
-            <div class="details-breakdown" id="locationBreakdown">
-              <!-- Content will be populated by JavaScript -->
-            </div>
-          </div>
-        </div>
-        <button class="close-details-btn" id="closeDetailsBtn">Close</button>
       </div>
     </div>
     <footer class="app-footer">

--- a/js/changeLog.js
+++ b/js/changeLog.js
@@ -1,0 +1,78 @@
+/**
+ * Change log tracking and rendering
+ * Tracks the last 25 cell changes in the inventory table
+ */
+
+/**
+ * Records a change to the change log and persists it
+ * @param {string} itemName - Name of the inventory item
+ * @param {string} field - Field that was changed
+ * @param {any} oldValue - Previous value
+ * @param {any} newValue - New value
+ */
+const logChange = (itemName, field, oldValue, newValue) => {
+  changeLog.push({
+    timestamp: Date.now(),
+    itemName,
+    field,
+    oldValue,
+    newValue,
+  });
+  if (changeLog.length > 25) {
+    changeLog = changeLog.slice(-25);
+  }
+  localStorage.setItem('changeLog', JSON.stringify(changeLog));
+};
+
+/**
+ * Compares two item objects and logs any differences
+ * @param {Object} oldItem - Original item values
+ * @param {Object} newItem - Updated item values
+ */
+const logItemChanges = (oldItem, newItem) => {
+  const fields = [
+    'date',
+    'type',
+    'metal',
+    'name',
+    'qty',
+    'weight',
+    'price',
+    'spotPriceAtPurchase',
+    'totalPremium',
+    'purchaseLocation',
+    'storageLocation',
+    'isCollectable',
+    'notes',
+  ];
+
+  fields.forEach((field) => {
+    if (oldItem[field] !== newItem[field]) {
+      logChange(newItem.name, field, oldItem[field], newItem[field]);
+    }
+  });
+};
+
+/**
+ * Renders the change log table with the 10 most recent entries
+ */
+const renderChangeLog = () => {
+  const tableBody = document.querySelector('#changeLogTable tbody');
+  if (!tableBody) return;
+
+  const recent = changeLog.slice(-10).reverse();
+  const rows = recent.map((entry) => `
+    <tr>
+      <td class="shrink">${new Date(entry.timestamp).toLocaleString()}</td>
+      <td class="shrink">${sanitizeHtml(entry.itemName)}</td>
+      <td class="shrink">${sanitizeHtml(entry.field)}</td>
+      <td class="shrink">${sanitizeHtml(String(entry.oldValue))}</td>
+      <td class="shrink">${sanitizeHtml(String(entry.newValue))}</td>
+    </tr>
+  `);
+  tableBody.innerHTML = rows.join('');
+};
+
+window.logChange = logChange;
+window.logItemChanges = logItemChanges;
+window.renderChangeLog = renderChangeLog;

--- a/js/events.js
+++ b/js/events.js
@@ -447,6 +447,8 @@ const setupEventListeners = () => {
             totalPremium = premiumPerOz * qty * weight;
           }
 
+          const oldItem = { ...inventory[editingIndex] };
+
           // Update the item
           inventory[editingIndex] = {
             metal,
@@ -467,6 +469,7 @@ const setupEventListeners = () => {
 
           saveInventory();
           renderTable();
+          logItemChanges(oldItem, inventory[editingIndex]);
 
           // Close modal
           elements.editModal.style.display = "none";
@@ -534,9 +537,11 @@ const setupEventListeners = () => {
             elements.notesTextarea || document.getElementById("notesTextarea");
           const text = textareaElement ? textareaElement.value.trim() : "";
 
+          const oldItem = { ...inventory[notesIndex] };
           inventory[notesIndex].notes = text;
           saveInventory();
           renderTable();
+          logItemChanges(oldItem, inventory[notesIndex]);
 
           const modalElement =
             elements.notesModal || document.getElementById("notesModal");
@@ -578,6 +583,32 @@ const setupEventListeners = () => {
           notesIndex = null;
         },
         "Notes modal close button",
+      );
+    }
+
+    if (elements.changeLogLink) {
+      safeAttachListener(
+        elements.changeLogLink,
+        "click",
+        (e) => {
+          e.preventDefault();
+          renderChangeLog();
+          if (elements.changeLogModal)
+            elements.changeLogModal.style.display = "flex";
+        },
+        "Change log link",
+      );
+    }
+
+    if (elements.changeLogCloseBtn) {
+      safeAttachListener(
+        elements.changeLogCloseBtn,
+        "click",
+        () => {
+          if (elements.changeLogModal)
+            elements.changeLogModal.style.display = "none";
+        },
+        "Change log close button",
       );
     }
 
@@ -1391,6 +1422,7 @@ const setupApiEvents = () => {
           const addModal = document.getElementById("addModal");
           const notesModal = document.getElementById("notesModal");
           const detailsModal = document.getElementById("detailsModal");
+          const changeLogModal = document.getElementById("changeLogModal");
 
           if (
             settingsModal &&
@@ -1424,6 +1456,8 @@ const setupApiEvents = () => {
           } else if (notesModal && notesModal.style.display === "flex") {
             notesModal.style.display = "none";
             notesIndex = null;
+          } else if (changeLogModal && changeLogModal.style.display === "flex") {
+            changeLogModal.style.display = "none";
           } else if (
             detailsModal &&
             detailsModal.style.display === "flex" &&

--- a/js/events.js
+++ b/js/events.js
@@ -254,9 +254,9 @@ const setupEventListeners = () => {
       });
     }
 
-    if (elements.closeDetailsBtn) {
+    if (elements.detailsCloseBtn) {
       safeAttachListener(
-        elements.closeDetailsBtn,
+        elements.detailsCloseBtn,
         "click",
         () => {
           if (typeof closeDetailsModal === "function") {

--- a/js/init.js
+++ b/js/init.js
@@ -172,7 +172,7 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.detailsModalTitle = safeGetElement("detailsModalTitle");
     elements.typeBreakdown = safeGetElement("typeBreakdown");
     elements.locationBreakdown = safeGetElement("locationBreakdown");
-    elements.closeDetailsBtn = safeGetElement("closeDetailsBtn");
+    elements.detailsCloseBtn = safeGetElement("detailsCloseBtn");
     elements.detailsButtons = document.querySelectorAll(".details-btn");
 
     // Chart elements

--- a/js/init.js
+++ b/js/init.js
@@ -154,6 +154,11 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.lastPage = safeGetElement("lastPage");
     elements.pageNumbers = safeGetElement("pageNumbers");
 
+    elements.changeLogLink = safeGetElement("changeLogLink");
+    elements.changeLogModal = safeGetElement("changeLogModal");
+    elements.changeLogCloseBtn = safeGetElement("changeLogCloseBtn");
+    elements.changeLogTable = safeGetElement("changeLogTable");
+
     // Search elements
     debugLog("Phase 6: Initializing search elements...");
     elements.searchInput = safeGetElement("searchInput");

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -534,8 +534,8 @@ const renderTable = () => {
       <td class="shrink">${formatDisplayDate(item.date)}</td>
       <td class="shrink">${filterLink('type', item.type, getTypeColor(item.type))}</td>
       <td class="shrink">${filterLink('metal', item.metal || 'Silver', METAL_COLORS[item.metal] || 'var(--primary)')}</td>
-      <td class="shrink">${item.qty}</td>
       <td class="clickable-name expand" onclick="editItem(${originalIdx})" title="Click to edit" tabindex="0" role="button" aria-label="Edit ${sanitizeHtml(item.name)}" onkeydown="if(event.key==='Enter'||event.key===' ')editItem(${originalIdx})">${sanitizeHtml(item.name)}</td>
+      <td class="shrink">${item.qty}</td>
       <td class="shrink">${parseFloat(item.weight).toFixed(2)}</td>
       <td class="shrink">${formatDollar(item.price)}</td>
       <td class="shrink">${item.isCollectable ? 'N/A' : (item.spotPriceAtPurchase > 0 ? formatDollar(item.spotPriceAtPurchase) : 'N/A')}</td>
@@ -775,10 +775,12 @@ const updateSummary = () => {
  * @param {number} idx - Index of item to delete
  */
 const deleteItem = (idx) => {
+  const item = inventory[idx];
   if (confirm("Delete this item?")) {
     inventory.splice(idx, 1);
     saveInventory();
     renderTable();
+    if (item) logChange(item.name, 'Deleted', '', '');
   }
 };
 
@@ -853,6 +855,7 @@ const editItem = (idx) => {
 */
 const toggleCollectable = (idx) => {
   const item = inventory[idx];
+  const oldItem = { ...item };
   const wasCollectable = item.isCollectable;
   const isCollectable = !wasCollectable;
 
@@ -888,6 +891,7 @@ const toggleCollectable = (idx) => {
 
   saveInventory();
   renderTable();
+  logItemChanges(oldItem, item);
 };
 
 // =============================================================================

--- a/js/sorting.js
+++ b/js/sorting.js
@@ -18,8 +18,8 @@ const sortInventory = (data = inventory) => {
       case 0: valA = a.date; valB = b.date; break; // Date
       case 1: valA = a.type; valB = b.type; break; // Type
       case 2: valA = a.metal; valB = b.metal; break; // Metal
-      case 3: valA = a.qty; valB = b.qty; break; // Qty
-      case 4: valA = a.name; valB = b.name; break; // Name
+      case 3: valA = a.name; valB = b.name; break; // Name
+      case 4: valA = a.qty; valB = b.qty; break; // Qty
       case 5: valA = a.weight; valB = b.weight; break; // Weight
       case 6: valA = a.price; valB = b.price; break; // Purchase Price
       case 7: valA = a.spotPriceAtPurchase; valB = b.spotPriceAtPurchase; break; // Spot at Purchase

--- a/js/state.js
+++ b/js/state.js
@@ -119,6 +119,12 @@ const elements = {
   lastPage: null,
   pageNumbers: null,
 
+  // Change log elements
+  changeLogLink: null,
+  changeLogModal: null,
+  changeLogCloseBtn: null,
+  changeLogTable: null,
+
   // Search elements
   searchInput: null,
   clearSearchBtn: null,
@@ -216,6 +222,9 @@ const elements = {
     },
   },
 };
+
+/** @type {Array} Change log entries */
+let changeLog = JSON.parse(localStorage.getItem('changeLog') || '[]');
 
 /** @type {Array} Main inventory data structure */
 let inventory = [];

--- a/js/state.js
+++ b/js/state.js
@@ -104,7 +104,7 @@ const elements = {
   detailsModalTitle: null,
   typeBreakdown: null,
   locationBreakdown: null,
-  closeDetailsBtn: null,
+  detailsCloseBtn: null,
   detailsButtons: null,
 
   // Chart canvas elements


### PR DESCRIPTION
## Summary
- track last 25 inventory edits and display 10 most recent in a change log modal
- add Change Log link with new table controls
- move Qty column after Name and adjust sorting accordingly

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6897bddc8f30832e8e81c53d9a9d3b33