### PR TITLE
Refactor changelog UI and spot price interactions

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -122,8 +122,9 @@ html {
 }
 
 body {
-  max-width: 2000px;
-  margin: var(--spacing-lg) auto;
+  max-width: none;
+  min-width: 1200px;
+  margin: var(--spacing-lg) 10%;
   padding: var(--spacing);
   transition: var(--transition);
 }
@@ -216,6 +217,16 @@ section {
 
 .app-footer a {
   color: var(--primary);
+}
+
+.storage-line {
+  margin-top: var(--spacing-sm);
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.storage-line a {
+  margin-left: var(--spacing-sm);
 }
 
 section:hover {
@@ -430,6 +441,7 @@ input[type="submit"] {
   margin-bottom: var(--spacing);
   border: 1px solid var(--border);
   box-shadow: var(--shadow-sm);
+  cursor: pointer;
 }
 
 .spot-card-label {
@@ -457,7 +469,7 @@ input[type="submit"] {
 
 /* Spot Price Action Buttons */
 .spot-actions {
-  display: flex;
+  display: none;
   gap: var(--spacing-sm);
   margin-bottom: var(--spacing);
   justify-content: center;
@@ -1047,7 +1059,7 @@ input[type="submit"] {
 }
 
 #changeLogModal .modal-content {
-  max-width: 800px;
+  max-width: 1200px;
 }
 
 #changeLogModal .modal-header,
@@ -2024,24 +2036,31 @@ td input:checked + .slider:before {
   justify-content: flex-end;
   align-items: center;
   gap: var(--spacing-sm);
+  margin-left: auto;
 }
 
 .table-controls {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   margin-bottom: var(--spacing-sm);
+  gap: var(--spacing-lg);
 }
 
-.change-log-link {
-  font-size: 0.9rem;
-  cursor: pointer;
-  color: var(--primary);
-  text-decoration: underline;
+.items-label {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.table-disclaimer {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  font-style: italic;
 }
 
 .pagination-select {
   width: 6rem;
+  height: 2.75rem;
 }
 
 .pagination-btn {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,9 @@
 - Inventory change log tracks last 25 edits and displays the 10 most recent in a modal
 - Change Log and metal totals details modals now share the site's standard header style
 - Quantity column repositioned after item name for improved readability
+- Change Log modal widened and buttonized; items-per-page controls restyled with disclaimer and fixed layout
+- Spot price action buttons reveal on card click and timestamps now reflect only API updates
+- Footer shows local storage usage with downloadable report link
 
 ### Version 3.2.06rc – Auto Spot Price Sync (2025-08-09)
 - Automatically refreshes spot prices at startup when API keys exist and the cache is expired

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,8 @@
 - Footer shows local storage usage with downloadable report link
 - Spot price manual input closes when card is collapsed to avoid stuck dropdowns
 - Storage usage counter refreshes after imports and API syncs
+- Inventory table now defaults to showing 10 rows per page
+- Storage report export omits API keys for security
 
 ### Version 3.2.06rc – Auto Spot Price Sync (2025-08-09)
 - Automatically refreshes spot prices at startup when API keys exist and the cache is expired

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,8 @@
 - Change Log modal widened and buttonized; items-per-page controls restyled with disclaimer and fixed layout
 - Spot price action buttons reveal on card click and timestamps now reflect only API updates
 - Footer shows local storage usage with downloadable report link
+- Spot price manual input closes when card is collapsed to avoid stuck dropdowns
+- Storage usage counter refreshes after imports and API syncs
 
 ### Version 3.2.06rc – Auto Spot Price Sync (2025-08-09)
 - Automatically refreshes spot prices at startup when API keys exist and the cache is expired

--- a/index.html
+++ b/index.html
@@ -382,9 +382,12 @@
        ============================================================================= -->
       <section class="table-section">
         <div class="table-controls">
-          <a href="#" id="changeLogLink" class="change-log-link">Change Log</a>
+          <button id="changeLogBtn" class="btn">Change Log</button>
+          <span class="table-disclaimer"
+            >All data is stored locally. Back up often.</span
+          >
           <div class="items-per-page">
-            <span>Items:</span>
+            <span class="items-label">Items:</span>
             <select class="pagination-select" id="itemsPerPage">
               <option value="10">10</option>
               <option value="15">15</option>
@@ -1082,14 +1085,18 @@
         >GPL-3.0</a
       >.
       <br />
-      Report issues or bugs here:
-      <a
-        href="https://github.com/lbruton/StackTrackr/issues"
-        target="_blank"
-        rel="noopener"
-        >https://github.com/lbruton/StackTrackr/issues</a
-      >
-    </footer>
+  Report issues or bugs here:
+  <a
+    href="https://github.com/lbruton/StackTrackr/issues"
+    target="_blank"
+    rel="noopener"
+    >https://github.com/lbruton/StackTrackr/issues</a
+  >
+  <div class="storage-line">
+    Storage: <span id="storageUsage"></span>
+    <a href="#" id="storageReportLink">Download storage report</a>
+  </div>
+</footer>
     <!-- =============================================================================
        ABOUT & DISCLAIMER MODAL
        Comprehensive application information and disclaimer modal similar to the

--- a/index.html
+++ b/index.html
@@ -389,9 +389,9 @@
           <div class="items-per-page">
             <span class="items-label">Items:</span>
             <select class="pagination-select" id="itemsPerPage">
-              <option value="10">10</option>
+              <option selected value="10">10</option>
               <option value="15">15</option>
-              <option selected value="25">25</option>
+              <option value="25">25</option>
               <option value="50">50</option>
               <option value="100">100</option>
             </select>

--- a/js/api.js
+++ b/js/api.js
@@ -899,6 +899,9 @@ const syncSpotPricesFromApi = async (
 
       // Update summary calculations
       updateSummary();
+      if (typeof updateStorageStats === "function") {
+        updateStorageStats();
+      }
 
       setProviderStatus(apiConfig.provider, "connected");
 

--- a/js/events.js
+++ b/js/events.js
@@ -586,19 +586,33 @@ const setupEventListeners = () => {
       );
     }
 
-    if (elements.changeLogLink) {
-      safeAttachListener(
-        elements.changeLogLink,
-        "click",
-        (e) => {
-          e.preventDefault();
-          renderChangeLog();
-          if (elements.changeLogModal)
-            elements.changeLogModal.style.display = "flex";
-        },
-        "Change log link",
-      );
-    }
+      if (elements.changeLogBtn) {
+        safeAttachListener(
+          elements.changeLogBtn,
+          "click",
+          (e) => {
+            e.preventDefault();
+            renderChangeLog();
+            if (elements.changeLogModal)
+              elements.changeLogModal.style.display = "flex";
+          },
+          "Change log button",
+        );
+      }
+
+      if (elements.storageReportLink) {
+        safeAttachListener(
+          elements.storageReportLink,
+          "click",
+          (e) => {
+            e.preventDefault();
+            if (typeof downloadStorageReport === "function") {
+              downloadStorageReport();
+            }
+          },
+          "Storage report link",
+        );
+      }
 
     if (elements.changeLogCloseBtn) {
       safeAttachListener(
@@ -619,9 +633,30 @@ const setupEventListeners = () => {
       const metalName = metalConfig.name;
 
       // Main spot price action buttons
-      const addBtn = document.getElementById(`addBtn${metalName}`);
-      const resetBtn = document.getElementById(`resetBtn${metalName}`);
-      const syncBtn = document.getElementById(`syncBtn${metalName}`);
+        const addBtn = document.getElementById(`addBtn${metalName}`);
+        const resetBtn = document.getElementById(`resetBtn${metalName}`);
+        const syncBtn = document.getElementById(`syncBtn${metalName}`);
+        const spotCard = document.querySelector(
+          `.spot-input.${metalKey} .spot-card`,
+        );
+        const actions = document.querySelector(
+          `.spot-input.${metalKey} .spot-actions`,
+        );
+
+        if (spotCard && actions) {
+          safeAttachListener(
+            spotCard,
+            "click",
+            () => {
+              const visible = actions.style.display === "flex";
+              document
+                .querySelectorAll(".spot-actions")
+                .forEach((el) => (el.style.display = "none"));
+              actions.style.display = visible ? "none" : "flex";
+            },
+            `${metalName} spot card`,
+          );
+        }
 
       // Manual input buttons
       const saveBtn = elements.saveSpotBtn[metalKey];

--- a/js/events.js
+++ b/js/events.js
@@ -652,6 +652,9 @@ const setupEventListeners = () => {
               document
                 .querySelectorAll(".spot-actions")
                 .forEach((el) => (el.style.display = "none"));
+              document
+                .querySelectorAll(".manual-input")
+                .forEach((el) => (el.style.display = "none"));
               actions.style.display = visible ? "none" : "flex";
             },
             `${metalName} spot card`,

--- a/js/init.js
+++ b/js/init.js
@@ -154,10 +154,12 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.lastPage = safeGetElement("lastPage");
     elements.pageNumbers = safeGetElement("pageNumbers");
 
-    elements.changeLogLink = safeGetElement("changeLogLink");
-    elements.changeLogModal = safeGetElement("changeLogModal");
-    elements.changeLogCloseBtn = safeGetElement("changeLogCloseBtn");
-    elements.changeLogTable = safeGetElement("changeLogTable");
+      elements.changeLogBtn = safeGetElement("changeLogBtn");
+      elements.changeLogModal = safeGetElement("changeLogModal");
+      elements.changeLogCloseBtn = safeGetElement("changeLogCloseBtn");
+      elements.changeLogTable = safeGetElement("changeLogTable");
+      elements.storageUsage = safeGetElement("storageUsage");
+      elements.storageReportLink = safeGetElement("storageReportLink");
 
     // Search elements
     debugLog("Phase 6: Initializing search elements...");
@@ -295,9 +297,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Phase 13: Initial Rendering
     debugLog("Phase 13: Rendering initial display...");
-    renderTable();
-    fetchSpotPrice();
-    updateSyncButtonStates();
+      renderTable();
+      fetchSpotPrice();
+      updateSyncButtonStates();
+      if (typeof updateStorageStats === "function") {
+        updateStorageStats();
+      }
 
     // Automatically sync prices if cache is stale and API keys are available
     if (typeof autoSyncSpotPrices === "function") {

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1059,6 +1059,9 @@ const importCsv = (file) => {
         inventory = imported;
         saveInventory();
         renderTable();
+        if (typeof updateStorageStats === "function") {
+          updateStorageStats();
+        }
       }
 
         this.value = "";
@@ -1212,6 +1215,9 @@ const importJson = (file) => {
         inventory = imported;
         saveInventory();
         renderTable();
+        if (typeof updateStorageStats === "function") {
+          updateStorageStats();
+        }
       }
     } catch (error) {
       endImportProgress();
@@ -1377,6 +1383,9 @@ const importExcel = (file) => {
         inventory = imported;
         saveInventory();
         renderTable();
+        if (typeof updateStorageStats === "function") {
+          updateStorageStats();
+        }
       }
     } catch (error) {
       endImportProgress();

--- a/js/spot.js
+++ b/js/spot.js
@@ -53,12 +53,6 @@ const fetchSpotPrice = () => {
           spotPrices[metalConfig.key],
         );
       }
-      const hasHistory = spotHistory.some(
-        (e) => e.metal === metalConfig.name,
-      );
-      if (!hasHistory) {
-        recordSpot(spotPrices[metalConfig.key], "stored", metalConfig.name);
-      }
     } else {
       // Use default price if no stored price
       const defaultPrice = metalConfig.defaultPrice;

--- a/js/state.js
+++ b/js/state.js
@@ -120,10 +120,12 @@ const elements = {
   pageNumbers: null,
 
   // Change log elements
-  changeLogLink: null,
+  changeLogBtn: null,
   changeLogModal: null,
   changeLogCloseBtn: null,
   changeLogTable: null,
+  storageUsage: null,
+  storageReportLink: null,
 
   // Search elements
   searchInput: null,

--- a/js/state.js
+++ b/js/state.js
@@ -12,7 +12,7 @@ let notesIndex = null;
 
 /** @type {Object} Pagination state */
 let currentPage = 1; // Current page number (1-based)
-let itemsPerPage = 25; // Number of items to display per page
+let itemsPerPage = 10; // Number of items to display per page
 
 /** @type {string} Current search query */
 let searchQuery = "";

--- a/js/utils.js
+++ b/js/utils.js
@@ -84,7 +84,9 @@ const getLastUpdateTime = (metalName) => {
   if (!spotHistory || spotHistory.length === 0) return null;
 
   // Find the most recent entry for this metal
-  const metalEntries = spotHistory.filter((entry) => entry.metal === metalName);
+  const metalEntries = spotHistory.filter(
+    (entry) => entry.metal === metalName && entry.source === "api",
+  );
   if (metalEntries.length === 0) return null;
 
   const latestEntry = metalEntries[metalEntries.length - 1];
@@ -438,9 +440,9 @@ const getUserFriendlyMessage = (errorMessage) => {
  * @param {string} content - Content of the file
  * @param {string} mimeType - MIME type of the file (default: text/plain)
  */
-const downloadFile = (filename, content, mimeType = "text/plain") => {
-  try {
-    const blob = new Blob([content], { type: mimeType });
+  const downloadFile = (filename, content, mimeType = "text/plain") => {
+    try {
+      const blob = new Blob([content], { type: mimeType });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
 
@@ -458,6 +460,46 @@ const downloadFile = (filename, content, mimeType = "text/plain") => {
     console.error("Error downloading file:", error);
     handleError(error, "file download");
   }
+  };
+
+  // =============================================================================
+
+/**
+ * Updates footer with localStorage usage statistics
+ */
+const updateStorageStats = async () => {
+  try {
+    if (navigator?.storage?.estimate) {
+      const { usage, quota } = await navigator.storage.estimate();
+      const used = usage / 1024;
+      const total = quota / 1024;
+      const el = document.getElementById("storageUsage");
+      if (el) {
+        el.textContent = `${used.toFixed(1)} KB / ${total.toFixed(1)} KB`;
+      }
+    }
+  } catch (err) {
+    const el = document.getElementById("storageUsage");
+    if (el) el.textContent = "Storage info unavailable";
+    console.warn("Could not estimate storage", err);
+  }
 };
 
-// =============================================================================
+/**
+ * Downloads a report of all localStorage data
+ */
+const downloadStorageReport = () => {
+  const report = {};
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i);
+    report[key] = localStorage.getItem(key);
+  }
+  downloadFile(
+    "storage-report.json",
+    JSON.stringify(report, null, 2),
+    "application/json",
+  );
+};
+
+window.updateStorageStats = updateStorageStats;
+window.downloadStorageReport = downloadStorageReport;

--- a/js/utils.js
+++ b/js/utils.js
@@ -490,10 +490,29 @@ const updateStorageStats = async () => {
  */
 const downloadStorageReport = () => {
   const report = {};
+
   for (let i = 0; i < localStorage.length; i++) {
     const key = localStorage.key(i);
+
+    // Skip or sanitize sensitive data such as API keys
+    if (key === API_KEY_STORAGE_KEY) {
+      try {
+        const config = JSON.parse(localStorage.getItem(key) || "{}");
+        if (config?.keys) {
+          // Remove any stored API keys before exporting
+          report[key] = { ...config, keys: {} };
+        } else {
+          report[key] = config;
+        }
+      } catch (err) {
+        console.warn("Could not sanitize API config for report", err);
+      }
+      continue;
+    }
+
     report[key] = localStorage.getItem(key);
   }
+
   downloadFile(
     "storage-report.json",
     JSON.stringify(report, null, 2),


### PR DESCRIPTION
## Summary
- restyled changelog controls with blue button, disclaimers, and modern items-per-page layout
- hide spot price action buttons until card is clicked and show only API pull timestamps
- add footer storage usage stats with downloadable localStorage report

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897d80624e0832eac7e686f2937e956