### PR TITLE
Nest inventory search with table and tighten pagination

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1927,7 +1927,7 @@ td input:checked + .slider:before {
   flex-direction: column;
   align-items: center;
   gap: var(--spacing-sm);
-  padding: var(--spacing-sm) 0;
+  padding: 2px 0;
 }
 
 .pagination-buttons {

--- a/index.html
+++ b/index.html
@@ -355,7 +355,8 @@
          Search is case-insensitive and supports partial matches
          Implementation in search.js with filterInventory() function
          ============================================================================= -->
-      <section class="search-section">
+      <section class="inventory-section">
+        <section class="search-section">
         <div class="search-container">
           <input
             id="searchInput"
@@ -366,8 +367,8 @@
           <button class="btn success" id="newItemBtn">New Item</button>
         </div>
         <div class="search-results-info" id="searchResultsInfo"></div>
-      </section>
-      <!-- =============================================================================
+        </section>
+        <!-- =============================================================================
          INVENTORY TABLE SECTION
          
          Main data display table showing all inventory items with:
@@ -452,6 +453,7 @@
             </div>
           </div>
         </section>
+      </section>
       </section>
       <!-- =============================================================================
          TOTALS SECTION


### PR DESCRIPTION
## Summary
- Nest inventory search and table in single inventory section
- Trim extra padding around pagination controls for a tighter layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897e784e244832eb6a4e66d869d07b3