### PR TITLE
feat: show detailed spot timestamp

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -130,7 +130,7 @@ If continuing development in a new chat session:
 8. **Key Files**: Focus on `inventory.js`, `events.js`, and `state.js` for major modifications
 9. **Testing**: Use `sample.csv` for import testing (includes notes examples)
 10. **Version Updates**: Only update `APP_VERSION` in `constants.js` - propagates automatically
-11. **Timestamp Display**: Implemented via `getLastUpdateTime()` utility function
+11. **Timestamp Display**: Two-line source + last sync via `getLastUpdateTime()` utility function
 
 ## 📁 Project Structure
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -20,7 +20,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes (3.2.x Series)
 
-- **v3.2.07rc - Spot Timestamp Source Display**: Spot price cards show the API provider or Manual entry and the exact time of the last update
+- **v3.2.07rc - Spot Timestamp Source Display**: Spot price cards show the API provider or Manual entry and the exact time of the last update. API provider modal checks stored keys and cache age to display "Connected" or "Connected (cached)" statuses and its sync buttons read "Save and Test".
 - **v3.2.06rc - UI Refinements & Auto Sync**: Modal-based item entry with stacked filters, pagination polish with repositioned items-per-page selector, collectable status button, totals card label updates, improved About modal contrast, and automatic spot price refresh at startup
 - **v3.2.05rc - Splash Opt-Out & Branding**: Disclaimer modal can be hidden permanently, header adapts to hosting domain with updated subtitle, and each API provider stores its own key
 - **v3.2.03rc - Cache Flush Confirmation**: Added warning before clearing API cache and history

--- a/docs/notes/timestamp-display-implementation.md
+++ b/docs/notes/timestamp-display-implementation.md
@@ -14,12 +14,13 @@ Added timestamp display to spot price cards showing when each metal price was la
 
 ### Key Function
 ```javascript
-getLastUpdateTime(metalName) // Returns formatted string like "2 hrs ago (API)"
+getLastUpdateTime(metalName) // Returns HTML: "Source<br>Last sync YYYY-MM-DD HH:MM:SS - Xd Xh ago"
 ```
 
 ### Features
-- Relative time display (mins/hrs/days ago vs absolute dates)
-- Source indicators (API, Manual, Cached, Default, Stored)
+- Two-line display separating source and sync time
+- Absolute timestamp with relative age (days + hours)
+- Source indicators (API, Cached, Manual, Default, Stored)
 - Auto-updates when prices change
 - Uses existing spotHistory data structure
 

--- a/index.html
+++ b/index.html
@@ -1488,7 +1488,7 @@
                         class="btn api-sync-btn success"
                         data-provider="METALS_DEV"
                       >
-                        Test & Sync
+                        Save and Test
                       </button>
                     </div>
                   </div>
@@ -1550,7 +1550,7 @@
                         class="btn api-sync-btn success"
                         data-provider="METALS_API"
                       >
-                        Test & Sync
+                        Save and Test
                       </button>
                     </div>
                   </div>
@@ -1618,7 +1618,7 @@
                         class="btn api-sync-btn success"
                         data-provider="METAL_PRICE_API"
                       >
-                        Test & Sync
+                        Save and Test
                       </button>
                     </div>
                   </div>
@@ -1699,7 +1699,7 @@
                         class="btn api-sync-btn success"
                         data-provider="CUSTOM"
                       >
-                        Test & Sync
+                        Save and Test
                       </button>
                     </div>
                   </div>

--- a/js/api.js
+++ b/js/api.js
@@ -19,10 +19,13 @@ const renderApiStatusSummary = () => {
       const statusText =
         status === "connected"
           ? "Connected"
-          : status === "error"
-            ? "Error"
-            : "Disconnected";
-      return `<span class="status-item ${status}">${name}: ${statusText}</span>`;
+          : status === "cached"
+            ? "Connected (cached)"
+            : status === "error"
+              ? "Error"
+              : "Disconnected";
+      const statusClass = status === "cached" ? "connected" : status;
+      return `<span class="status-item ${statusClass}">${name}: ${statusText}</span>`;
     })
     .join("");
   container.innerHTML = html;
@@ -200,8 +203,8 @@ const getCacheDurationMs = () => {
 /**
  * Sets connection status for a provider in the settings UI
  * @param {string} provider
- * @param {"connected"|"disconnected"|"error"} status
- */
+ * @param {"connected"|"disconnected"|"error"|"cached"} status
+*/
 const setProviderStatus = (provider, status) => {
   providerStatuses[provider] = status;
   renderApiStatusSummary();
@@ -213,16 +216,21 @@ const setProviderStatus = (provider, status) => {
     "status-connected",
     "status-disconnected",
     "status-error",
+    "status-cached",
   );
-  block.classList.add(`status-${status}`);
+  block.classList.add(
+    status === "cached" ? "status-connected" : `status-${status}`,
+  );
   const text = block.querySelector(".status-text");
   if (text) {
     text.textContent =
       status === "connected"
         ? "Connected"
-        : status === "error"
-          ? "Error"
-          : "Disconnected";
+        : status === "cached"
+          ? "Connected (cached)"
+          : status === "error"
+            ? "Error"
+            : "Disconnected";
   }
 };
 
@@ -277,6 +285,38 @@ const updateProviderHistoryTables = () => {
         saveApiConfig(cfg);
       });
     });
+  });
+};
+
+/**
+ * Refreshes provider statuses based on stored keys and cache age
+ */
+const refreshProviderStatuses = () => {
+  const config = loadApiConfig();
+  let cache = null;
+  try {
+    const stored = localStorage.getItem(API_CACHE_KEY);
+    cache = stored ? JSON.parse(stored) : null;
+  } catch (err) {
+    console.error("Error reading API cache for status check:", err);
+  }
+  const now = Date.now();
+  const duration = getCacheDurationMs();
+  Object.keys(API_PROVIDERS).forEach((prov) => {
+    if (config.keys[prov]) {
+      if (cache && cache.provider === prov && cache.timestamp) {
+        const age = now - cache.timestamp;
+        if (age <= duration) {
+          setProviderStatus(prov, "connected");
+        } else {
+          setProviderStatus(prov, "cached");
+        }
+      } else {
+        setProviderStatus(prov, "connected");
+      }
+    } else {
+      setProviderStatus(prov, "disconnected");
+    }
   });
 };
 
@@ -475,6 +515,7 @@ const hideApiHistoryModal = () => {
 const showApiProvidersModal = () => {
   const modal = document.getElementById("apiProvidersModal");
   if (modal) {
+    refreshProviderStatuses();
     updateProviderHistoryTables();
     modal.style.display = "flex";
   }

--- a/js/api.js
+++ b/js/api.js
@@ -593,7 +593,7 @@ const refreshFromCache = () => {
 
       const ts = document.getElementById(`spotTimestamp${metalConfig.name}`);
       if (ts) {
-        ts.textContent = getLastUpdateTime(metalConfig.name) || "No data";
+        ts.innerHTML = getLastUpdateTime(metalConfig.name);
       }
 
       updatedCount++;
@@ -886,7 +886,7 @@ const syncSpotPricesFromApi = async (
 
         const ts = document.getElementById(`spotTimestamp${metalConfig.name}`);
         if (ts) {
-          ts.textContent = getLastUpdateTime(metalConfig.name) || "No data";
+          ts.innerHTML = getLastUpdateTime(metalConfig.name);
         }
 
         updatedCount++;
@@ -1044,7 +1044,7 @@ const handleProviderSync = async (provider) => {
         );
         const ts = document.getElementById(`spotTimestamp${metalConfig.name}`);
         if (ts) {
-          ts.textContent = getLastUpdateTime(metalConfig.name) || "No data";
+          ts.innerHTML = getLastUpdateTime(metalConfig.name);
         }
         updatedCount++;
       }

--- a/js/spot.js
+++ b/js/spot.js
@@ -73,8 +73,7 @@ const fetchSpotPrice = () => {
       `spotTimestamp${metalConfig.name}`,
     );
     if (timestampElement) {
-      const lastUpdate = getLastUpdateTime(metalConfig.name);
-      timestampElement.textContent = lastUpdate || "No data";
+      timestampElement.innerHTML = getLastUpdateTime(metalConfig.name);
     }
   });
 
@@ -117,8 +116,7 @@ const updateManualSpot = (metalKey) => {
     `spotTimestamp${metalConfig.name}`,
   );
   if (timestampElement) {
-    timestampElement.textContent =
-      getLastUpdateTime(metalConfig.name) || "No data";
+    timestampElement.innerHTML = getLastUpdateTime(metalConfig.name);
   }
 
   updateSummary();
@@ -177,8 +175,7 @@ const resetSpot = (metalKey) => {
     `spotTimestamp${metalConfig.name}`,
   );
   if (timestampElement) {
-    timestampElement.textContent =
-      getLastUpdateTime(metalConfig.name) || "No data";
+    timestampElement.innerHTML = getLastUpdateTime(metalConfig.name);
   }
 
   // Update summary

--- a/js/utils.js
+++ b/js/utils.js
@@ -75,41 +75,54 @@ const monitorPerformance = (fn, name, ...args) => {
 };
 
 /**
- * Gets the most recent timestamp for a specific metal from spot history
+ * Builds two-line HTML showing source and last sync info for a metal
  *
  * @param {string} metalName - Metal name ('Silver', 'Gold', 'Platinum', 'Palladium')
- * @returns {string|null} Formatted timestamp or null if no data
+ * @returns {string} HTML string with source line and time line
  */
 const getLastUpdateTime = (metalName) => {
-  if (!spotHistory || spotHistory.length === 0) return null;
+  if (!spotHistory || spotHistory.length === 0) return "Default<br>Default";
 
   // Find the most recent entry for this metal
-  const metalEntries = spotHistory.filter(
-    (entry) => entry.metal === metalName && entry.source === "api",
-  );
-  if (metalEntries.length === 0) return null;
+  const metalEntries = spotHistory.filter((entry) => entry.metal === metalName);
+  if (metalEntries.length === 0) return "Default<br>Default";
 
   const latestEntry = metalEntries[metalEntries.length - 1];
   const timestamp = new Date(latestEntry.timestamp);
 
-  const timeText = timestamp.toLocaleString();
+  const dateText = `${timestamp.getFullYear()}-${pad2(
+    timestamp.getMonth() + 1,
+  )}-${pad2(timestamp.getDate())}`;
+  const timeText = `${pad2(timestamp.getHours())}:${pad2(
+    timestamp.getMinutes(),
+  )}:${pad2(timestamp.getSeconds())}`;
+  const diffMs = Date.now() - timestamp.getTime();
+  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  const diffHours = Math.floor((diffMs / (1000 * 60 * 60)) % 24);
 
-  let sourceText;
+  let sourceLine;
+  let timeLine;
+
   if (latestEntry.source === "api") {
-    sourceText = latestEntry.provider || "API";
+    sourceLine = latestEntry.provider || "API";
+    timeLine = `Last sync ${dateText} ${timeText} - ${diffDays}d ${diffHours}h ago`;
   } else if (latestEntry.source === "cached") {
-    sourceText = latestEntry.provider
+    sourceLine = latestEntry.provider
       ? `${latestEntry.provider} (cached)`
       : "Cached";
+    timeLine = `Last sync ${dateText} ${timeText} - ${diffDays}d ${diffHours}h ago`;
   } else if (latestEntry.source === "manual") {
-    sourceText = "Manual";
+    sourceLine = "Manual";
+    timeLine = "Manual";
   } else if (latestEntry.source === "default") {
-    sourceText = "Default";
+    sourceLine = "Default";
+    timeLine = "Default";
   } else {
-    sourceText = "Stored";
+    sourceLine = "Stored";
+    timeLine = `Last sync ${dateText} ${timeText} - ${diffDays}d ${diffHours}h ago`;
   }
 
-  return `${sourceText} - ${timeText}`;
+  return `${sourceLine}<br>${timeLine}`;
 };
 
 // =============================================================================


### PR DESCRIPTION
## Summary
- show spot price source on its own line and move last sync details below
- update related docs and modules for the new timestamp display

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_6897eb934264832eb8da17189cb2964c