### PR TITLE
feat: add undo/redo support to change log table

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1056,6 +1056,7 @@ input[type="submit"] {
   flex-direction: column;
   padding: 0;
   overflow: hidden;
+  width: 90%;
 }
 
 #changeLogModal .modal-content {
@@ -1084,6 +1085,10 @@ input[type="submit"] {
   padding: var(--spacing-xl);
   overflow-y: auto;
   flex: 1;
+}
+
+#detailsModal {
+  font-size: clamp(0.8rem, 1vw + 0.5rem, 1rem);
 }
 
 /* =============================================================================
@@ -1216,6 +1221,10 @@ table {
   table-layout: auto; /* Allow columns to size based on content */
 }
 
+#inventoryTable tbody {
+  min-height: calc(10 * 2.2rem);
+}
+
 th {
   background: var(--bg-tertiary);
   color: var(--text-primary);
@@ -1328,11 +1337,12 @@ td .btn {
   font-size: 0.7rem;
   min-height: 1.8rem;
   line-height: 1;
+  margin: 1px;
 }
 
 td .action-btn {
   width: 4.5rem;
-  margin: 0 auto;
+  margin: 1px auto;
   display: flex;
   justify-content: center;
 }

--- a/index.html
+++ b/index.html
@@ -1004,6 +1004,7 @@
                 <th class="shrink">Field</th>
                 <th class="shrink">Old Value</th>
                 <th class="shrink">New Value</th>
+                <th class="shrink">Action</th>
               </tr>
             </thead>
             <tbody></tbody>

--- a/js/changeLog.js
+++ b/js/changeLog.js
@@ -9,14 +9,17 @@
  * @param {string} field - Field that was changed
  * @param {any} oldValue - Previous value
  * @param {any} newValue - New value
- */
-const logChange = (itemName, field, oldValue, newValue) => {
+ * @param {number} idx - Index of item in inventory array
+*/
+const logChange = (itemName, field, oldValue, newValue, idx) => {
   changeLog.push({
     timestamp: Date.now(),
     itemName,
     field,
     oldValue,
     newValue,
+    idx,
+    undone: false,
   });
   if (changeLog.length > 25) {
     changeLog = changeLog.slice(-25);
@@ -48,7 +51,8 @@ const logItemChanges = (oldItem, newItem) => {
 
   fields.forEach((field) => {
     if (oldItem[field] !== newItem[field]) {
-      logChange(newItem.name, field, oldItem[field], newItem[field]);
+      const idx = inventory.indexOf(newItem);
+      logChange(newItem.name, field, oldItem[field], newItem[field], idx);
     }
   });
 };
@@ -61,18 +65,58 @@ const renderChangeLog = () => {
   if (!tableBody) return;
 
   const recent = changeLog.slice(-10).reverse();
-  const rows = recent.map((entry) => `
+  const rows = recent.map((entry, i) => {
+    const globalIndex = changeLog.length - 1 - i;
+    const actionLabel = entry.undone ? 'Redo' : 'Undo';
+    return `
     <tr>
       <td class="shrink">${new Date(entry.timestamp).toLocaleString()}</td>
       <td class="shrink">${sanitizeHtml(entry.itemName)}</td>
       <td class="shrink">${sanitizeHtml(entry.field)}</td>
       <td class="shrink">${sanitizeHtml(String(entry.oldValue))}</td>
       <td class="shrink">${sanitizeHtml(String(entry.newValue))}</td>
-    </tr>
-  `);
-  tableBody.innerHTML = rows.join('');
+      <td class="shrink"><button class="btn action-btn" style="margin:1px;" onclick="toggleChange(${globalIndex})">${actionLabel}</button></td>
+    </tr>`;
+  });
+
+  const placeholders = Array.from({ length: 10 - recent.length }, () => '<tr><td class="shrink" colspan="6">&nbsp;</td></tr>');
+  tableBody.innerHTML = rows.concat(placeholders).join('');
+};
+
+/**
+ * Toggles a logged change between undone and redone states
+ * @param {number} logIdx - Index of change entry in changeLog array
+ */
+const toggleChange = (logIdx) => {
+  const entry = changeLog[logIdx];
+  if (!entry) return;
+  if (entry.field === 'Deleted') {
+    if (entry.undone) {
+      inventory.splice(entry.idx, 1);
+      entry.undone = false;
+    } else {
+      const restored = JSON.parse(entry.oldValue || '{}');
+      inventory.splice(entry.idx, 0, restored);
+      entry.undone = true;
+    }
+  } else {
+    const item = inventory[entry.idx];
+    if (!item) return;
+    if (entry.undone) {
+      item[entry.field] = entry.newValue;
+      entry.undone = false;
+    } else {
+      item[entry.field] = entry.oldValue;
+      entry.undone = true;
+    }
+  }
+  saveInventory();
+  renderTable();
+  renderChangeLog();
+  localStorage.setItem('changeLog', JSON.stringify(changeLog));
 };
 
 window.logChange = logChange;
 window.logItemChanges = logItemChanges;
 window.renderChangeLog = renderChangeLog;
+window.toggleChange = toggleChange;

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -496,11 +496,11 @@ const storageLocationColors = {};
 
 const getColor = (map, key) => {
   if (!map[key]) {
-    map[key] = (Object.keys(map).length * 137) % 360; // store hue for consistency
+    map[key] = (Object.keys(map).length * 137) % 360; // distribute hues using golden angle
   }
   const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-  const lightness = isDark ? 70 : 40;
-  return `hsl(${map[key]}, 60%, ${lightness}%)`;
+  const lightness = isDark ? 65 : 35;
+  return `hsl(${map[key]}, 70%, ${lightness}%)`;
 };
 
 const filterLink = (field, value, color) => {
@@ -780,7 +780,7 @@ const deleteItem = (idx) => {
     inventory.splice(idx, 1);
     saveInventory();
     renderTable();
-    if (item) logChange(item.name, 'Deleted', '', '');
+    if (item) logChange(item.name, 'Deleted', JSON.stringify(item), '', idx);
   }
 };
 


### PR DESCRIPTION
## Summary
- add Action column with undo/redo control to change log and keep table height at 10 rows
- ensure inventory table keeps fixed height and button padding, and generate higher-contrast purchase location colors
- scale details modal layout and typography to fit up to 1200px wide and 90% of viewport height

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897efc6cf44832ebd666c17c74b50de