### PR TITLE
Split settings into dedicated modals

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -935,8 +935,10 @@ input[type="submit"] {
   margin-top: 0.75rem;
 }
 
-/* Settings modal layout */
-#settingsModal .modal-content {
+/* Settings-style modal layout */
+#appearanceModal .modal-content,
+#apiModal .modal-content,
+#filesModal .modal-content {
   max-width: 750px;
   max-height: 90vh;
   display: flex;
@@ -945,7 +947,9 @@ input[type="submit"] {
   overflow: hidden;
 }
 
-#settingsModal .modal-header {
+#appearanceModal .modal-header,
+#apiModal .modal-header,
+#filesModal .modal-header {
   background: linear-gradient(135deg, var(--primary), var(--primary-hover));
   color: white;
   padding: var(--spacing-xl);
@@ -954,13 +958,17 @@ input[type="submit"] {
   box-shadow: var(--shadow);
 }
 
-#settingsModal .modal-header h2 {
+#appearanceModal .modal-header h2,
+#apiModal .modal-header h2,
+#filesModal .modal-header h2 {
   margin: 0;
   color: white;
   text-align: center;
 }
 
-#settingsModal .modal-body {
+#appearanceModal .modal-body,
+#apiModal .modal-body,
+#filesModal .modal-body {
   padding: var(--spacing-xl);
   overflow-y: auto;
   flex: 1;
@@ -968,21 +976,29 @@ input[type="submit"] {
   scrollbar-color: var(--primary) var(--bg-secondary);
 }
 
-#settingsModal .modal-body::-webkit-scrollbar {
+#appearanceModal .modal-body::-webkit-scrollbar,
+#apiModal .modal-body::-webkit-scrollbar,
+#filesModal .modal-body::-webkit-scrollbar {
   width: 8px;
 }
 
-#settingsModal .modal-body::-webkit-scrollbar-track {
+#appearanceModal .modal-body::-webkit-scrollbar-track,
+#apiModal .modal-body::-webkit-scrollbar-track,
+#filesModal .modal-body::-webkit-scrollbar-track {
   background: var(--bg-secondary);
   border-radius: var(--radius);
 }
 
-#settingsModal .modal-body::-webkit-scrollbar-thumb {
+#appearanceModal .modal-body::-webkit-scrollbar-thumb,
+#apiModal .modal-body::-webkit-scrollbar-thumb,
+#filesModal .modal-body::-webkit-scrollbar-thumb {
   background-color: var(--primary);
   border-radius: var(--radius);
 }
 
-#settingsModal .modal-body::-webkit-scrollbar-thumb:hover {
+#appearanceModal .modal-body::-webkit-scrollbar-thumb:hover,
+#apiModal .modal-body::-webkit-scrollbar-thumb:hover,
+#filesModal .modal-body::-webkit-scrollbar-thumb:hover {
   background-color: var(--primary-hover);
 }
 

--- a/index.html
+++ b/index.html
@@ -71,16 +71,22 @@
         <p class="app-subtitle">The open source precious metals tracking tool.</p>
       </div>
       <div style="margin-left: auto; display: flex; gap: 0.5rem">
-        <button
-          class="btn"
-          id="settingsBtn"
-          title="Settings"
-          aria-label="Settings"
-        >
-          Settings ⚙️
-        </button>
         <button class="btn" id="aboutBtn" title="About" aria-label="About">
           About 📖
+        </button>
+        <button class="btn" id="apiBtn" title="API" aria-label="API">
+          API 🔌
+        </button>
+        <button
+          class="btn"
+          id="appearanceBtn"
+          title="Appearance"
+          aria-label="Appearance"
+        >
+          Appearance 🎨
+        </button>
+        <button class="btn" id="filesBtn" title="Files" aria-label="Files">
+          Files 📁
         </button>
       </div>
     </div>
@@ -1287,20 +1293,16 @@
       </div>
     </div>
     <!-- =============================================================================
-       API CONFIGURATION MODAL
-       
-       Modal for configuring API providers and keys for live spot price data.
-       Includes provider selection, API key input, and status display.
-       Data is stored in localStorage with 24-hour caching system.
        ============================================================================= -->
-    <div class="modal" id="settingsModal" style="display: none">
+
+    <div class="modal" id="appearanceModal" style="display: none">
       <div class="modal-content">
         <div class="modal-header">
-          <h2>Settings</h2>
+          <h2>Appearance</h2>
           <button
             aria-label="Close modal"
             class="modal-close"
-            id="settingsCloseBtn"
+            id="appearanceCloseBtn"
           >
             ×
           </button>
@@ -1318,7 +1320,19 @@
               <div class="theme-display" id="themeDisplay"></div>
             </div>
           </div>
+        </div>
+      </div>
+    </div>
 
+    <div class="modal" id="apiModal" style="display: none">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2>API</h2>
+          <button aria-label="Close modal" class="modal-close" id="apiCloseBtn">
+            ×
+          </button>
+        </div>
+        <div class="modal-body">
           <div class="settings-section">
             <h3 style="margin-bottom: 1rem">API Configuration</h3>
             <p class="settings-subtext">Manage API cache, history, and providers.</p>
@@ -1351,7 +1365,19 @@
               </button>
             </div>
           </div>
+        </div>
+      </div>
+    </div>
 
+    <div class="modal" id="filesModal" style="display: none">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2>Files</h2>
+          <button aria-label="Close modal" class="modal-close" id="filesCloseBtn">
+            ×
+          </button>
+        </div>
+        <div class="modal-body">
           <div class="settings-section">
             <h3>Files</h3>
             <p class="settings-subtext">Import or export your data files.</p>

--- a/js/api.js
+++ b/js/api.js
@@ -1172,8 +1172,8 @@ const updateSyncButtonStates = (syncing = false) => {
 /**
  * Shows settings modal and populates API fields
  */
-const showSettingsModal = () => {
-  const modal = document.getElementById("settingsModal");
+const showApiModal = () => {
+  const modal = document.getElementById("apiModal");
   if (!modal) return;
   let currentConfig = loadApiConfig() || {
     provider: "",
@@ -1184,18 +1184,6 @@ const showSettingsModal = () => {
   if (!currentConfig.provider) {
     currentConfig.provider = Object.keys(API_PROVIDERS)[0];
     saveApiConfig(currentConfig);
-  }
-
-  const savedTheme = localStorage.getItem(THEME_KEY);
-  const themeValue = savedTheme ? savedTheme : "system";
-  const themeDisplay = document.getElementById("themeDisplay");
-  if (themeDisplay) {
-    themeDisplay.textContent =
-      themeValue === "dark"
-        ? "Dark Mode"
-        : themeValue === "light"
-          ? "Light Mode"
-          : "System";
   }
 
   Object.keys(API_PROVIDERS).forEach((prov) => {
@@ -1224,10 +1212,48 @@ const showSettingsModal = () => {
 };
 
 /**
- * Hides settings modal
+ * Hides API modal
  */
-const hideSettingsModal = () => {
-  const modal = document.getElementById("settingsModal");
+const hideApiModal = () => {
+  const modal = document.getElementById("apiModal");
+  if (modal) {
+    modal.style.display = "none";
+  }
+};
+
+const showFilesModal = () => {
+  const modal = document.getElementById("filesModal");
+  if (modal) {
+    modal.style.display = "flex";
+  }
+};
+
+const hideFilesModal = () => {
+  const modal = document.getElementById("filesModal");
+  if (modal) {
+    modal.style.display = "none";
+  }
+};
+
+const showAppearanceModal = () => {
+  const modal = document.getElementById("appearanceModal");
+  if (!modal) return;
+  const savedTheme = localStorage.getItem(THEME_KEY);
+  const themeValue = savedTheme ? savedTheme : "system";
+  const themeDisplay = document.getElementById("themeDisplay");
+  if (themeDisplay) {
+    themeDisplay.textContent =
+      themeValue === "dark"
+        ? "Dark Mode"
+        : themeValue === "light"
+          ? "Light Mode"
+          : "System";
+  }
+  modal.style.display = "flex";
+};
+
+const hideAppearanceModal = () => {
+  const modal = document.getElementById("appearanceModal");
   if (modal) {
     modal.style.display = "none";
   }
@@ -1279,8 +1305,12 @@ const hideProviderInfo = () => {
 };
 
 // Make modal controls available globally
-window.showSettingsModal = showSettingsModal;
-window.hideSettingsModal = hideSettingsModal;
+window.showApiModal = showApiModal;
+window.hideApiModal = hideApiModal;
+window.showFilesModal = showFilesModal;
+window.hideFilesModal = hideFilesModal;
+window.showAppearanceModal = showAppearanceModal;
+window.hideAppearanceModal = hideAppearanceModal;
 window.showProviderInfo = showProviderInfo;
 window.hideProviderInfo = hideProviderInfo;
 

--- a/js/events.js
+++ b/js/events.js
@@ -159,24 +159,22 @@ const setupEventListeners = () => {
     // CRITICAL HEADER BUTTONS
     debugLog("Setting up header buttons...");
 
-    // Settings Button
-    if (elements.settingsBtn) {
+    // Files Button
+    if (elements.filesBtn) {
       safeAttachListener(
-        elements.settingsBtn,
+        elements.filesBtn,
         "click",
         (e) => {
           e.preventDefault();
-          debugLog("Settings button clicked");
-          if (typeof showSettingsModal === "function") {
-            showSettingsModal();
-          } else {
-            alert("Settings interface");
+          debugLog("Files button clicked");
+          if (typeof showFilesModal === "function") {
+            showFilesModal();
           }
         },
-        "Settings Button",
+        "Files Button",
       );
     } else {
-      console.error("Settings button element not found!");
+      console.error("Files button element not found!");
     }
 
     // About Button
@@ -191,6 +189,36 @@ const setupEventListeners = () => {
           }
         },
         "About Button",
+      );
+    }
+
+    // API Button
+    if (elements.apiBtn) {
+      safeAttachListener(
+        elements.apiBtn,
+        "click",
+        (e) => {
+          e.preventDefault();
+          if (typeof showApiModal === "function") {
+            showApiModal();
+          }
+        },
+        "API Button",
+      );
+    }
+
+    // Appearance Button
+    if (elements.appearanceBtn) {
+      safeAttachListener(
+        elements.appearanceBtn,
+        "click",
+        (e) => {
+          e.preventDefault();
+          if (typeof showAppearanceModal === "function") {
+            showAppearanceModal();
+          }
+        },
+        "Appearance Button",
       );
     }
 
@@ -925,6 +953,61 @@ const setupEventListeners = () => {
       );
     }
 
+    // Files modal close handlers
+    const filesModal = document.getElementById("filesModal");
+    const filesCloseBtn = document.getElementById("filesCloseBtn");
+    if (filesModal) {
+      safeAttachListener(
+        filesModal,
+        "click",
+        (e) => {
+          if (e.target === filesModal && typeof hideFilesModal === "function") {
+            hideFilesModal();
+          }
+        },
+        "Files modal background",
+      );
+    }
+    if (filesCloseBtn) {
+      safeAttachListener(
+        filesCloseBtn,
+        "click",
+        () => {
+          if (typeof hideFilesModal === "function") hideFilesModal();
+        },
+        "Files close button",
+      );
+    }
+
+    // Appearance modal close handlers
+    const appearanceModal = document.getElementById("appearanceModal");
+    const appearanceCloseBtn = document.getElementById("appearanceCloseBtn");
+    if (appearanceModal) {
+      safeAttachListener(
+        appearanceModal,
+        "click",
+        (e) => {
+          if (
+            e.target === appearanceModal &&
+            typeof hideAppearanceModal === "function"
+          ) {
+            hideAppearanceModal();
+          }
+        },
+        "Appearance modal background",
+      );
+    }
+    if (appearanceCloseBtn) {
+      safeAttachListener(
+        appearanceCloseBtn,
+        "click",
+        () => {
+          if (typeof hideAppearanceModal === "function") hideAppearanceModal();
+        },
+        "Appearance close button",
+      );
+    }
+
     // API MODAL EVENT LISTENERS
     debugLog("Setting up API modal listeners...");
     setupApiEvents();
@@ -1114,37 +1197,34 @@ const setupApiEvents = () => {
 
   try {
     let quotaProvider = null;
-    const settingsModal = document.getElementById("settingsModal");
-    const settingsCloseBtn = document.getElementById("settingsCloseBtn");
+    const apiModal = document.getElementById("apiModal");
+    const apiCloseBtn = document.getElementById("apiCloseBtn");
     const infoModal = document.getElementById("apiInfoModal");
     const infoCloseBtn = document.getElementById("apiInfoCloseBtn");
 
-    if (settingsModal) {
+    if (apiModal) {
       safeAttachListener(
-        settingsModal,
+        apiModal,
         "click",
         (e) => {
-          if (
-            e.target === settingsModal &&
-            typeof hideSettingsModal === "function"
-          ) {
-            hideSettingsModal();
+          if (e.target === apiModal && typeof hideApiModal === "function") {
+            hideApiModal();
           }
         },
-        "Settings modal background",
+        "API modal background",
       );
     }
 
-    if (settingsCloseBtn) {
+    if (apiCloseBtn) {
       safeAttachListener(
-        settingsCloseBtn,
+        apiCloseBtn,
         "click",
         () => {
-          if (typeof hideSettingsModal === "function") {
-            hideSettingsModal();
+          if (typeof hideApiModal === "function") {
+            hideApiModal();
           }
         },
-        "Settings close button",
+        "API close button",
       );
     }
 
@@ -1421,7 +1501,9 @@ const setupApiEvents = () => {
       "keydown",
       (e) => {
         if (e.key === "Escape") {
-          const settingsModal = document.getElementById("settingsModal");
+          const filesModal = document.getElementById("filesModal");
+          const apiModal = document.getElementById("apiModal");
+          const appearanceModal = document.getElementById("appearanceModal");
           const infoModal = document.getElementById("apiInfoModal");
           const historyModal = document.getElementById("apiHistoryModal");
           const providersModal = document.getElementById("apiProvidersModal");
@@ -1432,11 +1514,23 @@ const setupApiEvents = () => {
           const changeLogModal = document.getElementById("changeLogModal");
 
           if (
-            settingsModal &&
-            settingsModal.style.display === "flex" &&
-            typeof hideSettingsModal === "function"
+            filesModal &&
+            filesModal.style.display === "flex" &&
+            typeof hideFilesModal === "function"
           ) {
-            hideSettingsModal();
+            hideFilesModal();
+          } else if (
+            apiModal &&
+            apiModal.style.display === "flex" &&
+            typeof hideApiModal === "function"
+          ) {
+            hideApiModal();
+          } else if (
+            appearanceModal &&
+            appearanceModal.style.display === "flex" &&
+            typeof hideAppearanceModal === "function"
+          ) {
+            hideAppearanceModal();
           } else if (
             infoModal &&
             infoModal.style.display === "flex" &&

--- a/js/init.js
+++ b/js/init.js
@@ -72,13 +72,15 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Header buttons - CRITICAL
     debugLog("Phase 2: Initializing header buttons...");
-    elements.settingsBtn = safeGetElement("settingsBtn", true);
+    elements.appearanceBtn = safeGetElement("appearanceBtn");
+    elements.apiBtn = safeGetElement("apiBtn");
+    elements.filesBtn = safeGetElement("filesBtn", true);
     elements.aboutBtn = safeGetElement("aboutBtn");
 
     // Check if critical buttons exist
     debugLog(
-      "Settings Button found:",
-      !!document.getElementById("settingsBtn"),
+      "Files Button found:",
+      !!document.getElementById("filesBtn"),
     );
 
     // Import/Export elements
@@ -98,7 +100,9 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Modal elements
     debugLog("Phase 4: Initializing modal elements...");
-    elements.settingsModal = safeGetElement("settingsModal");
+    elements.appearanceModal = safeGetElement("appearanceModal");
+    elements.apiModal = safeGetElement("apiModal");
+    elements.filesModal = safeGetElement("filesModal");
     elements.apiInfoModal = safeGetElement("apiInfoModal");
     elements.apiHistoryModal = safeGetElement("apiHistoryModal");
     elements.apiProvidersModal = safeGetElement("apiProvidersModal");
@@ -335,7 +339,7 @@ document.addEventListener("DOMContentLoaded", () => {
     debugLog("✓ API configured:", !!apiConfig);
     debugLog("✓ Inventory items:", inventory.length);
     debugLog("✓ Critical elements check:");
-    debugLog("  - Settings button:", !!elements.settingsBtn);
+    debugLog("  - Files button:", !!elements.filesBtn);
     debugLog("  - Inventory form:", !!elements.inventoryForm);
     debugLog("  - Inventory table:", !!elements.inventoryTable);
   } catch (error) {
@@ -358,14 +362,32 @@ document.addEventListener("DOMContentLoaded", () => {
 function setupBasicEventListeners() {
   debugLog("Setting up basic event listeners as fallback...");
 
-  // Settings button
-  const settingsBtn = document.getElementById("settingsBtn");
-  if (settingsBtn) {
-    settingsBtn.onclick = function () {
-      if (typeof showSettingsModal === "function") {
-        showSettingsModal();
-      } else {
-        alert("Settings interface");
+  // Files button
+  const filesBtn = document.getElementById("filesBtn");
+  if (filesBtn) {
+    filesBtn.onclick = function () {
+      if (typeof showFilesModal === "function") {
+        showFilesModal();
+      }
+    };
+  }
+
+  // Appearance button
+  const appearanceBtn = document.getElementById("appearanceBtn");
+  if (appearanceBtn) {
+    appearanceBtn.onclick = function () {
+      if (typeof showAppearanceModal === "function") {
+        showAppearanceModal();
+      }
+    };
+  }
+
+  // API button
+  const apiBtn = document.getElementById("apiBtn");
+  if (apiBtn) {
+    apiBtn.onclick = function () {
+      if (typeof showApiModal === "function") {
+        showApiModal();
       }
     };
   }

--- a/js/state.js
+++ b/js/state.js
@@ -144,9 +144,13 @@ const elements = {
   ackModal: null,
   ackAcceptBtn: null,
 
-  // Settings & API elements
-  settingsBtn: null,
-  settingsModal: null,
+  // Appearance, API & Files elements
+  appearanceBtn: null,
+  apiBtn: null,
+  filesBtn: null,
+  appearanceModal: null,
+  apiModal: null,
+  filesModal: null,
   apiInfoModal: null,
   apiHistoryModal: null,
   apiProvidersModal: null,


### PR DESCRIPTION
## Summary
- add Appearance and API buttons with dedicated modals
- repurpose original Settings modal into Files
- wire up new modal listeners and styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898071b4c54832e9d328ed349dec163