### PR TITLE
fix: stabilize totals modals and scrolling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1067,6 +1067,7 @@ input[type="submit"] {
 }
 
 /* Standardized modal layout for change log and details views */
+/* shared modal content structure */
 #changeLogModal .modal-content,
 #detailsModal .modal-content {
   display: flex;
@@ -1097,11 +1098,18 @@ input[type="submit"] {
   text-align: center;
 }
 
-#changeLogModal .modal-body,
-#detailsModal .modal-body {
+#changeLogModal .modal-body {
   padding: var(--spacing-xl);
   overflow: auto;
   flex: 1;
+}
+
+#detailsModal .modal-body {
+  padding: var(--spacing-xl);
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
 }
 
 #changeLogTable {
@@ -1876,6 +1884,8 @@ td input:checked + .slider:before {
   grid-template-columns: 1fr 1fr;
   gap: var(--spacing-xl);
   margin-bottom: var(--spacing-lg);
+  flex: 1;
+  overflow: hidden;
 }
 
 .details-panel {
@@ -1886,6 +1896,13 @@ td input:checked + .slider:before {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-lg);
+  overflow: hidden;
+}
+
+.details-breakdown {
+  flex: 1;
+  overflow: auto;
+  padding-right: var(--spacing-sm);
 }
 
 .details-panel-title {
@@ -1940,6 +1957,7 @@ td input:checked + .slider:before {
   height: 300px;
   width: 100%;
   margin: 0 auto;
+  flex: 0 0 300px;
 }
 
 .chart-canvas {

--- a/js/detailsModal.js
+++ b/js/detailsModal.js
@@ -148,6 +148,7 @@ const showDetailsModal = (metal) => {
 
   // Show modal
   elements.detailsModal.style.display = 'flex';
+  document.body.style.overflow = 'hidden';
 
   // Add chart resize handling
   const resizeObserver = new ResizeObserver(() => {
@@ -166,6 +167,7 @@ const showDetailsModal = (metal) => {
  */
 const closeDetailsModal = () => {
   elements.detailsModal.style.display = 'none';
+  document.body.style.overflow = '';
   destroyCharts();
 };
 

--- a/js/events.js
+++ b/js/events.js
@@ -621,8 +621,10 @@ const setupEventListeners = () => {
           (e) => {
             e.preventDefault();
             renderChangeLog();
-            if (elements.changeLogModal)
+            if (elements.changeLogModal) {
               elements.changeLogModal.style.display = "flex";
+              document.body.style.overflow = "hidden";
+            }
           },
           "Change log button",
         );
@@ -647,8 +649,10 @@ const setupEventListeners = () => {
         elements.changeLogCloseBtn,
         "click",
         () => {
-          if (elements.changeLogModal)
+          if (elements.changeLogModal) {
             elements.changeLogModal.style.display = "none";
+            document.body.style.overflow = "";
+          }
         },
         "Change log close button",
       );
@@ -1554,16 +1558,17 @@ const setupApiEvents = () => {
             editingIndex = null;
           } else if (addModal && addModal.style.display === "flex") {
             addModal.style.display = "none";
-          } else if (notesModal && notesModal.style.display === "flex") {
-            notesModal.style.display = "none";
-            notesIndex = null;
-          } else if (changeLogModal && changeLogModal.style.display === "flex") {
-            changeLogModal.style.display = "none";
-          } else if (
-            detailsModal &&
-            detailsModal.style.display === "flex" &&
-            typeof closeDetailsModal === "function"
-          ) {
+        } else if (notesModal && notesModal.style.display === "flex") {
+          notesModal.style.display = "none";
+          notesIndex = null;
+        } else if (changeLogModal && changeLogModal.style.display === "flex") {
+          changeLogModal.style.display = "none";
+          document.body.style.overflow = "";
+        } else if (
+          detailsModal &&
+          detailsModal.style.display === "flex" &&
+          typeof closeDetailsModal === "function"
+        ) {
             closeDetailsModal();
           }
         }


### PR DESCRIPTION
## Summary
- prevent page scrolling when totals or change log modals are open
- redesign totals details modal layout with flex grid and internal scroll areas
- improve chart containers and breakdown panels for consistent aesthetics

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689812f967f0832e9bfaad211fd1394e