### PR TITLE
fix: stabilize totals modals and scrolling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1067,6 +1067,7 @@ input[type="submit"] {
 }
 
 /* Standardized modal layout for change log and details views */
+/* shared modal content structure */
 #changeLogModal .modal-content,
 #detailsModal .modal-content {
   display: flex;
@@ -1097,16 +1098,45 @@ input[type="submit"] {
   text-align: center;
 }
 
-#changeLogModal .modal-body,
-#detailsModal .modal-body {
+#changeLogModal .modal-body {
   padding: var(--spacing-xl);
   overflow: auto;
   flex: 1;
 }
 
+#detailsModal .modal-body {
+  padding: var(--spacing-xl);
+  flex: 1;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
 #changeLogTable {
-  width: max-content;
-  min-width: 100%;
+  width: 100%;
+  table-layout: fixed;
+  border-collapse: collapse;
+}
+
+#changeLogTable th,
+#changeLogTable td {
+  padding: var(--spacing-sm);
+  text-align: left;
+}
+
+#changeLogTable td {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+#changeLogTable th:last-child,
+#changeLogTable td:last-child {
+  width: 8rem;
+}
+
+#changeLogTable td.action-cell {
+  white-space: nowrap;
 }
 
 #detailsModal {
@@ -1876,6 +1906,8 @@ td input:checked + .slider:before {
   grid-template-columns: 1fr 1fr;
   gap: var(--spacing-xl);
   margin-bottom: var(--spacing-lg);
+  flex: 1;
+  overflow: hidden;
 }
 
 .details-panel {
@@ -1886,6 +1918,13 @@ td input:checked + .slider:before {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-lg);
+  overflow: hidden;
+}
+
+.details-breakdown {
+  flex: 1;
+  overflow: auto;
+  padding-right: var(--spacing-sm);
 }
 
 .details-panel-title {
@@ -1940,6 +1979,7 @@ td input:checked + .slider:before {
   height: 300px;
   width: 100%;
   margin: 0 auto;
+  flex: 0 0 300px;
 }
 
 .chart-canvas {

--- a/index.html
+++ b/index.html
@@ -1005,12 +1005,12 @@
           <table id="changeLogTable">
             <thead>
               <tr>
-                <th class="shrink">Date</th>
-                <th class="shrink">Item</th>
-                <th class="shrink">Field</th>
-                <th class="shrink">Old Value</th>
-                <th class="shrink">New Value</th>
-                <th class="shrink">Action</th>
+                <th>Date</th>
+                <th>Item</th>
+                <th>Field</th>
+                <th>Old Value</th>
+                <th>New Value</th>
+                <th>Action</th>
               </tr>
             </thead>
             <tbody></tbody>

--- a/js/changeLog.js
+++ b/js/changeLog.js
@@ -70,16 +70,16 @@ const renderChangeLog = () => {
     const actionLabel = entry.undone ? 'Redo' : 'Undo';
     return `
     <tr>
-      <td class="shrink">${new Date(entry.timestamp).toLocaleString()}</td>
-      <td class="shrink">${sanitizeHtml(entry.itemName)}</td>
-      <td class="shrink">${sanitizeHtml(entry.field)}</td>
-      <td class="shrink">${sanitizeHtml(String(entry.oldValue))}</td>
-      <td class="shrink">${sanitizeHtml(String(entry.newValue))}</td>
-      <td class="shrink"><button class="btn action-btn" style="margin:1px;" onclick="toggleChange(${globalIndex})">${actionLabel}</button></td>
+      <td title="${new Date(entry.timestamp).toLocaleString()}">${new Date(entry.timestamp).toLocaleString()}</td>
+      <td title="${sanitizeHtml(entry.itemName)}">${sanitizeHtml(entry.itemName)}</td>
+      <td title="${sanitizeHtml(entry.field)}">${sanitizeHtml(entry.field)}</td>
+      <td title="${sanitizeHtml(String(entry.oldValue))}">${sanitizeHtml(String(entry.oldValue))}</td>
+      <td title="${sanitizeHtml(String(entry.newValue))}">${sanitizeHtml(String(entry.newValue))}</td>
+      <td class="action-cell"><button class="btn action-btn" style="margin:1px;" onclick="editFromChangeLog(${entry.idx})">Edit</button><button class="btn action-btn" style="margin:1px;" onclick="toggleChange(${globalIndex})">${actionLabel}</button></td>
     </tr>`;
   });
 
-  const placeholders = Array.from({ length: 10 - recent.length }, () => '<tr><td class="shrink" colspan="6">&nbsp;</td></tr>');
+  const placeholders = Array.from({ length: 10 - recent.length }, () => '<tr><td colspan="6">&nbsp;</td></tr>');
   tableBody.innerHTML = rows.concat(placeholders).join('');
 };
 
@@ -120,3 +120,11 @@ window.logChange = logChange;
 window.logItemChanges = logItemChanges;
 window.renderChangeLog = renderChangeLog;
 window.toggleChange = toggleChange;
+window.editFromChangeLog = (idx) => {
+  const modal = document.getElementById('changeLogModal');
+  if (modal) {
+    modal.style.display = 'none';
+  }
+  document.body.style.overflow = '';
+  editItem(idx);
+};

--- a/js/detailsModal.js
+++ b/js/detailsModal.js
@@ -148,6 +148,7 @@ const showDetailsModal = (metal) => {
 
   // Show modal
   elements.detailsModal.style.display = 'flex';
+  document.body.style.overflow = 'hidden';
 
   // Add chart resize handling
   const resizeObserver = new ResizeObserver(() => {
@@ -166,6 +167,7 @@ const showDetailsModal = (metal) => {
  */
 const closeDetailsModal = () => {
   elements.detailsModal.style.display = 'none';
+  document.body.style.overflow = '';
   destroyCharts();
 };
 

--- a/js/events.js
+++ b/js/events.js
@@ -621,8 +621,10 @@ const setupEventListeners = () => {
           (e) => {
             e.preventDefault();
             renderChangeLog();
-            if (elements.changeLogModal)
+            if (elements.changeLogModal) {
               elements.changeLogModal.style.display = "flex";
+              document.body.style.overflow = "hidden";
+            }
           },
           "Change log button",
         );
@@ -647,8 +649,10 @@ const setupEventListeners = () => {
         elements.changeLogCloseBtn,
         "click",
         () => {
-          if (elements.changeLogModal)
+          if (elements.changeLogModal) {
             elements.changeLogModal.style.display = "none";
+            document.body.style.overflow = "";
+          }
         },
         "Change log close button",
       );
@@ -1554,16 +1558,17 @@ const setupApiEvents = () => {
             editingIndex = null;
           } else if (addModal && addModal.style.display === "flex") {
             addModal.style.display = "none";
-          } else if (notesModal && notesModal.style.display === "flex") {
-            notesModal.style.display = "none";
-            notesIndex = null;
-          } else if (changeLogModal && changeLogModal.style.display === "flex") {
-            changeLogModal.style.display = "none";
-          } else if (
-            detailsModal &&
-            detailsModal.style.display === "flex" &&
-            typeof closeDetailsModal === "function"
-          ) {
+        } else if (notesModal && notesModal.style.display === "flex") {
+          notesModal.style.display = "none";
+          notesIndex = null;
+        } else if (changeLogModal && changeLogModal.style.display === "flex") {
+          changeLogModal.style.display = "none";
+          document.body.style.overflow = "";
+        } else if (
+          detailsModal &&
+          detailsModal.style.display === "flex" &&
+          typeof closeDetailsModal === "function"
+        ) {
             closeDetailsModal();
           }
         }


### PR DESCRIPTION
## Summary
- prevent page scrolling when totals or change log modals are open
- redesign totals details modal layout with flex grid and internal scroll areas
- allow change log table to truncate overflowing columns and include inline edit actions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689812f967f0832e9bfaad211fd1394e