### PR TITLE
Display manual spot price entry time

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Version 3.2.07rc – Spot Timestamp Source Display (2025-08-09)
 - Spot price cards now show API provider or Manual entry along with exact timestamp of the last update
+- Manual spot price entries now display the entry time as "Time entered" with date and timestamp
 - Footer dynamically displays the active StackTrackr domain and links to issue reporting
 - Inventory change log records every edit and the modal displays the complete history with scrolling
 - Change Log and metal totals details modals now share the site's standard header style

--- a/js/utils.js
+++ b/js/utils.js
@@ -110,7 +110,7 @@ const getLastUpdateTime = (metalName) => {
     timeLine = `Last sync ${dateText} ${timeText}`;
   } else if (latestEntry.source === "manual") {
     sourceLine = "Manual";
-    timeLine = "Manual";
+    timeLine = `Time entered ${dateText} ${timeText}`;
   } else if (latestEntry.source === "default") {
     sourceLine = "";
     timeLine = "";


### PR DESCRIPTION
## Summary
- Show "Time entered" with timestamp for manual spot price updates
- Document manual spot entry timestamp in changelog

## Testing
- `node --check js/utils.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898260be2d4832e9c8e59fe790ad369