### PR TITLE
Display manual spot entry timestamp and widen desktop layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -123,7 +123,7 @@ html {
 
 body {
   max-width: none;
-  min-width: 1200px;
+  min-width: 1800px;
   margin: var(--spacing-lg) 10%;
   padding: var(--spacing);
   transition: var(--transition);

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -130,7 +130,7 @@ If continuing development in a new chat session:
 8. **Key Files**: Focus on `inventory.js`, `events.js`, and `state.js` for major modifications
 9. **Testing**: Use `sample.csv` for import testing (includes notes examples)
 10. **Version Updates**: Only update `APP_VERSION` in `constants.js` - propagates automatically
-11. **Timestamp Display**: Two-line source + last sync via `getLastUpdateTime()` utility function
+11. **Timestamp Display**: Two-line source with last sync or time entered via `getLastUpdateTime()` utility function
 
 ## 📁 Project Structure
 

--- a/docs/notes/timestamp-display-implementation.md
+++ b/docs/notes/timestamp-display-implementation.md
@@ -14,13 +14,13 @@ Added timestamp display to spot price cards showing when each metal price was la
 
 ### Key Function
 ```javascript
-getLastUpdateTime(metalName) // Returns HTML: "Source<br>Last sync YYYY-MM-DD HH:MM:SS - Xd Xh ago"
+getLastUpdateTime(metalName) // Returns HTML: "Source<br>Last sync YYYY-MM-DD HH:MM:SS" or "Time Entered YYYY-MM-DD HH:MM:SS" for manual entries
 ```
 
 ### Features
-- Two-line display separating source and sync time
-- Absolute timestamp with relative age (days + hours)
-- Source indicators (API, Cached, Manual, Default, Stored)
+- Two-line display separating source and time information
+- Absolute timestamp
+- Source indicators (API, Cached, Manual, Default, Stored) with manual entries showing time entered
 - Auto-updates when prices change
 - Uses existing spotHistory data structure
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -110,7 +110,7 @@ const getLastUpdateTime = (metalName) => {
     timeLine = `Last sync ${dateText} ${timeText}`;
   } else if (latestEntry.source === "manual") {
     sourceLine = "Manual";
-    timeLine = "Manual";
+    timeLine = `Time Entered ${dateText} ${timeText}`;
   } else if (latestEntry.source === "default") {
     sourceLine = "";
     timeLine = "";


### PR DESCRIPTION
## Summary
- show "Time Entered" timestamp when spot prices are set manually
- increase minimum page width to 1800px for desktop layout
- document timestamp behavior for manual entries

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68982697e554832ebc64c86ab7e07391