### PR TITLE
Add function reference table and storage usage indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Each inventory item includes:
 │   ├── ROADMAP.md                      # Planned features and subtasks
 │   ├── STATUS.md                       # Project status and features overview
 │   ├── STRUCTURE.md                    # Documentation of folder and file organization
+│   ├── functionstable.md               # Function reference table
 │   └── VERSIONING.md                   # Version management notes
 ├── js/
 │   ├── api.js
@@ -205,6 +206,7 @@ Each inventory item includes:
 - **[docs/CHANGELOG.md](docs/CHANGELOG.md)** - Version history and features.
 - **[docs/STATUS.md](docs/STATUS.md)** - Current project status.
 - **[docs/STRUCTURE.md](docs/STRUCTURE.md)** - Project organization.
+- **[docs/functionstable.md](docs/functionstable.md)** - Function reference table.
 - **[docs/VERSIONING.md](docs/VERSIONING.md)** - Version management.
 
 ## Code Quality

--- a/css/styles.css
+++ b/css/styles.css
@@ -229,6 +229,11 @@ section {
   margin-left: var(--spacing-sm);
 }
 
+.storage-line progress {
+  margin-left: var(--spacing-sm);
+  vertical-align: middle;
+}
+
 section:hover {
   box-shadow: var(--shadow-lg);
 }

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -36,6 +36,7 @@ Before starting ANY subtask, read these files:
 - `docs/archive/notes/v3.2.0-planning-notes.md` - Technical implementation details
 - `docs/STATUS.md` - Current project status
 - `docs/STRUCTURE.md` - Project architecture and file organization
+- `docs/functionstable.md` - Reference table of all JavaScript functions
 
 ### **Step 2: Choose Your Subtask**
 1. **Review available subtasks** in `docs/ROADMAP.md`
@@ -271,6 +272,7 @@ Before starting ANY subtask, read these files:
 ### **Essential Files:**
 - `docs/ROADMAP.md` - Your subtask list
 - `docs/archive/notes/v3.2.0-planning-notes.md` - Implementation details
+- `docs/functionstable.md` - Lookup table for all functions
 - `index.html` - Main application
 - `js/constants.js` - Configuration and version
 - `css/styles.css` - All styling

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,0 +1,148 @@
+# Function Reference
+
+| File | Function | Description |
+|------|----------|-------------|
+| about.js | showAboutModal | Shows the About modal and populates it with current data |
+| about.js | hideAboutModal | Hides the About modal |
+| about.js | showAckModal | Shows the acknowledgment modal on load |
+| about.js | hideAckModal | Hides the acknowledgment modal |
+| about.js | acceptAck | Accepts the acknowledgment and hides the modal |
+| about.js | populateAboutModal | Populates the about modal with current version and changelog information |
+| about.js | populateAckModal | Populates the acknowledgment modal with version information |
+| about.js | loadChangelog | Loads changelog information from docs/CHANGELOG.md and populates the About modal |
+| about.js | extractChangelogItems | Extracts changelog items from content, filtering for meaningful changes |
+| about.js | showFullChangelog | Shows full changelog in a new window or navigates to documentation |
+| about.js | setupAboutModalEvents | Sets up event listeners for about modal elements |
+| about.js | setupAckModalEvents | Sets up event listeners for acknowledgment modal elements |
+| api.js | renderApiStatusSummary |  |
+| api.js | loadApiConfig | Loads API configuration from localStorage |
+| api.js | saveApiConfig | Saves API configuration to localStorage |
+| api.js | clearApiConfig | Clears API configuration |
+| api.js | clearApiCache | Clears only the API cache, keeping the configuration |
+| api.js | getCacheDurationMs | Gets cache duration in milliseconds |
+| api.js | setProviderStatus | Sets connection status for a provider in the settings UI |
+| api.js | updateProviderHistoryTables | Updates provider history tables with latest API values |
+| api.js | refreshProviderStatuses | Refreshes provider statuses based on stored keys and cache age |
+| api.js | updateDefaultProviderButtons | Updates default provider button states |
+| api.js | renderApiHistoryTable | Renders API history table with filtering, sorting and pagination |
+| api.js | renderApiHistoryCharts | Renders API history chart |
+| api.js | showApiHistoryModal | Shows API history modal with table and chart |
+| api.js | hideApiHistoryModal | Hides API history modal |
+| api.js | showApiProvidersModal | Shows API providers modal |
+| api.js | hideApiProvidersModal | Hides API providers modal |
+| api.js | clearApiHistory | Clears stored API price history |
+| api.js | setDefaultProvider | Updates default provider selection in config |
+| api.js | clearApiKey | Clears stored API key for a provider |
+| api.js | setCacheDuration | Updates cache duration setting |
+| api.js | refreshFromCache | Refreshes display using cached data without making API calls |
+| api.js | loadApiCache | Loads cached API data from localStorage |
+| api.js | saveApiCache | Saves API data to cache |
+| api.js | autoSyncSpotPrices | Automatically syncs spot prices if API keys exist and cache is stale |
+| api.js | fetchSpotPricesFromApi | Makes API request for spot prices |
+| api.js | testApiConnection | Tests API connection |
+| api.js | handleProviderSync | Handles testing and syncing for a specific provider |
+| api.js | syncAllProviders | Syncs all configured providers and records results |
+| api.js | updateSyncButtonStates | Updates sync button states based on API availability |
+| api.js | showApiModal | Shows settings modal and populates API fields |
+| api.js | hideApiModal | Hides API modal |
+| api.js | showFilesModal |  |
+| api.js | hideFilesModal |  |
+| api.js | showAppearanceModal |  |
+| api.js | hideAppearanceModal |  |
+| api.js | showProviderInfo | Shows provider information modal |
+| api.js | hideProviderInfo | Hides provider information modal |
+| api.js | showManualInput | Shows manual price input for a specific metal |
+| api.js | hideManualInput | Hides manual price input for a specific metal |
+| api.js | resetSpotPrice | Resets spot price to default or API cached value |
+| api.js | createBackupData | Exports backup data including API configuration |
+| api.js | downloadCompleteBackup | Downloads complete backup files including inventory and API configuration |
+| changeLog.js | logChange | Records a change to the change log and persists it |
+| changeLog.js | logItemChanges | Compares two item objects and logs any differences |
+| changeLog.js | renderChangeLog | Renders the change log table with all entries |
+| changeLog.js | toggleChange | Toggles a logged change between undone and redone states |
+| charts.js | generateColors | Generates a color palette for pie chart segments |
+| charts.js | getChartBackgroundColor | Gets appropriate background color for charts based on current theme |
+| charts.js | getChartTextColor | Gets appropriate text color for charts based on current theme |
+| charts.js | createPieChart | Creates a pie chart with the given data |
+| charts.js | destroyCharts | Destroys existing chart instances to prevent memory leaks |
+| detailsModal.js | getBreakdownData | Calculates breakdown data for specified metal by type and location |
+| detailsModal.js | createBreakdownElements | Creates breakdown DOM elements for display |
+| detailsModal.js | showDetailsModal | Shows the details modal for specified metal with pie charts |
+| detailsModal.js | closeDetailsModal | Closes the details modal and cleans up charts |
+| events.js | safeAttachListener | Safely attaches event listener with fallback methods |
+| events.js | setupColumnResizing | Implements dynamic column resizing for the inventory table |
+| events.js | setupEventListeners | Sets up all primary event listeners for the application |
+| events.js | updateThemeDisplay |  |
+| events.js | setupPagination | Sets up pagination event listeners |
+| events.js | setupSearch | Sets up search event listeners |
+| events.js | setupThemeToggle | Sets up theme toggle event listeners |
+| events.js | setupApiEvents | Sets up API-related event listeners |
+| file-protocol-fix.js | safeDebug |  |
+| init.js | createDummyElement | Helper function to create dummy DOM elements to prevent null reference errors |
+| init.js | safeGetElement | Safely retrieves a DOM element by ID with fallback to dummy element |
+| init.js | setupBasicEventListeners | Basic event listener setup as fallback |
+| inventory.js | createBackupZip | Creates a comprehensive backup ZIP file containing all application data |
+| inventory.js | restoreBackupZip | Restores application data from a backup ZIP file |
+| inventory.js | generateBackupHtml | Generates HTML content for backup export |
+| inventory.js | generateReadmeContent | Generates README content for backup archive |
+| inventory.js | saveInventory | Saves current inventory to localStorage |
+| inventory.js | loadInventory | Loads inventory from localStorage with comprehensive data migration |
+| inventory.js | getColor |  |
+| inventory.js | filterLink |  |
+| inventory.js | renderTable |  |
+| inventory.js | updateSummary | Calculates and updates all financial summary displays across the application |
+| inventory.js | calculateTotals | Calculates financial metrics for specified metal type |
+| inventory.js | deleteItem | Deletes inventory item at specified index after confirmation |
+| inventory.js | showNotes | Opens modal to view and edit an item's notes |
+| inventory.js | editItem | Prepares and displays edit modal for specified inventory item |
+| inventory.js | toggleCollectable | Toggles collectable status for inventory item |
+| inventory.js | startImportProgress |  |
+| inventory.js | updateImportProgress |  |
+| inventory.js | endImportProgress |  |
+| inventory.js | importCsv | Imports inventory data from CSV file with comprehensive validation and error handling |
+| inventory.js | exportCsv | Exports current inventory to CSV format |
+| inventory.js | importJson | Imports inventory data from JSON file |
+| inventory.js | exportJson | Exports current inventory to JSON format |
+| inventory.js | importExcel | Imports inventory data from Excel file |
+| inventory.js | exportExcel | Exports current inventory to Excel format |
+| inventory.js | exportPdf | Exports current inventory to PDF format |
+| pagination.js | calculateTotalPages | Calculates total number of pages based on current data |
+| pagination.js | goToPage | Navigates to specified page number |
+| search.js | filterInventory | Filters inventory based on current search query |
+| search.js | applyColumnFilter | Applies a column-specific filter and re-renders the table |
+| sorting.js | sortInventory | Sorts inventory based on current sort column and direction |
+| spot.js | saveSpotHistory | Saves spot history to localStorage |
+| spot.js | loadSpotHistory | Loads spot history from localStorage |
+| spot.js | recordSpot | Records a new spot price entry in history |
+| spot.js | fetchSpotPrice | Fetches and displays current spot prices from localStorage or defaults |
+| spot.js | updateManualSpot | Updates spot price for specified metal from user input |
+| spot.js | resetSpot | Resets spot price for specified metal to default or API cached value |
+| spot.js | resetSpotByName | Alternative reset function that works with metal name instead of key |
+| theme.js | setTheme | Sets application theme and updates localStorage |
+| theme.js | initTheme | Initializes theme based on user preference and system settings |
+| theme.js | toggleTheme | Toggles between dark and light themes |
+| theme.js | setupSystemThemeListener | Sets up system theme change listener |
+| utils.js | debugLog | Logs messages to console when DEBUG flag is enabled |
+| utils.js | getVersionString | Returns formatted version string |
+| utils.js | getBrandingName | Gets the active branding name considering domain overrides |
+| utils.js | getAppTitle | Returns full application title with version when no branding is configured |
+| utils.js | getFooterDomain | Determines active domain for footer copyright |
+| utils.js | monitorPerformance | Performance monitoring utility |
+| utils.js | getLastUpdateTime | Builds two-line HTML showing source and last sync info for a metal |
+| utils.js | pad2 | Pads a number with leading zeros to ensure two-digit format |
+| utils.js | todayStr | Returns current date as ISO string (YYYY-MM-DD) |
+| utils.js | currentMonthKey | Returns current month key in YYYY-MM format |
+| utils.js | parseDate | Parses various date formats into standard YYYY-MM-DD format |
+| utils.js | formatDisplayDate | Formats a date string into a user-friendly format |
+| utils.js | formatDollar | Formats a number as a dollar amount with two decimal places |
+| utils.js | formatLossProfit | Formats a profit/loss value with color coding |
+| utils.js | sanitizeHtml | Sanitizes text input for safe HTML display |
+| utils.js | saveData | Saves data to localStorage with JSON serialization |
+| utils.js | loadData | Loads data from localStorage with error handling |
+| utils.js | sortInventoryByDateNewestFirst | Sorts inventory by date (newest first) |
+| utils.js | validateInventoryItem | Validates inventory item data |
+| utils.js | handleError | Handles errors with user-friendly messaging |
+| utils.js | getUserFriendlyMessage | Converts technical error messages to user-friendly ones |
+| utils.js | downloadFile | Downloads a file with the specified content and filename |
+| utils.js | updateStorageStats | Updates footer with localStorage usage statistics and progress bar |
+| utils.js | downloadStorageReport | Downloads a report of all localStorage data |

--- a/index.html
+++ b/index.html
@@ -1102,6 +1102,7 @@
   >
   <div class="storage-line">
     Storage: <span id="storageUsage"></span>
+    <progress id="storageUsageBar" max="5120" value="0"></progress>
     <a href="#" id="storageReportLink">Download storage report</a>
   </div>
 </footer>

--- a/js/utils.js
+++ b/js/utils.js
@@ -477,22 +477,37 @@ const getUserFriendlyMessage = (errorMessage) => {
 
 /**
  * Updates footer with localStorage usage statistics
+ * and visual usage indicator
  */
-const updateStorageStats = async () => {
+const updateStorageStats = () => {
   try {
-    if (navigator?.storage?.estimate) {
-      const { usage, quota } = await navigator.storage.estimate();
-      const used = usage / 1024;
-      const total = quota / 1024;
-      const el = document.getElementById("storageUsage");
-      if (el) {
-        el.textContent = `${used.toFixed(1)} KB / ${total.toFixed(1)} KB`;
-      }
+    // 5MB typical localStorage limit expressed in bytes
+    const limit = 5 * 1024 * 1024;
+    let used = 0;
+
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      const value = localStorage.getItem(key);
+      // localStorage stores strings in UTF-16 (~2 bytes per character)
+      used += (key.length + (value ? value.length : 0)) * 2;
+    }
+
+    const usedKB = used / 1024;
+    const limitKB = limit / 1024;
+    const el = document.getElementById("storageUsage");
+    if (el) {
+      el.textContent = `${usedKB.toFixed(1)} KB / ${limitKB.toFixed(1)} KB`;
+    }
+
+    const bar = document.getElementById("storageUsageBar");
+    if (bar) {
+      bar.max = limitKB;
+      bar.value = usedKB;
     }
   } catch (err) {
     const el = document.getElementById("storageUsage");
     if (el) el.textContent = "Storage info unavailable";
-    console.warn("Could not estimate storage", err);
+    console.warn("Could not calculate storage", err);
   }
 };
 


### PR DESCRIPTION
## Summary
- document all JavaScript functions in docs/functionstable.md for quick reference
- link function reference table from workflow and README documentation sections
- show actual localStorage usage and limit in footer with a progress bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68983f393328832e89c0c39c4efc8e8e