### PR TITLE
feat: add storage report modal and template

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -876,6 +876,20 @@ input[type="submit"] {
   flex-direction: column;
 }
 
+/* Storage report options modal */
+#storageOptionsModal .modal-content {
+  max-width: 400px;
+  text-align: center;
+}
+#storageOptionsModal .options-buttons {
+  display: flex;
+  gap: var(--spacing);
+  justify-content: center;
+}
+#storageOptionsModal .options-buttons .btn {
+  flex: 1;
+}
+
 #apiHistoryModal .modal-header {
   background: linear-gradient(135deg, var(--primary), var(--primary-hover));
   color: white;

--- a/index.html
+++ b/index.html
@@ -1085,7 +1085,7 @@
       </div>
     </div>
     <footer class="app-footer">
-      <div class="storage-line">Storage: <span id="storageUsage"></span> <progress id="storageUsageBar" max="5120" value="0"></progress> <a href="#" id="storageReportLink">Download storage report</a></div>
+      <div class="storage-line">Storage: <span id="storageUsage"></span> <progress id="storageUsageBar" max="5120" value="0"></progress> <a href="#" id="storageReportLink">Storage report</a></div>
       <div class="footer-meta">© 2025 <span id="footerDomain">stacktrackr.com</span>. Having trouble? <a href="./archive/previous/index.html">Try the previous build</a>, or report problems on <a href="https://github.com/lbruton/StackTrackr/issues" target="_blank" rel="noopener">GitHub</a>.</div>
     </footer>
     <!-- =============================================================================

--- a/js/utils.js
+++ b/js/utils.js
@@ -512,458 +512,78 @@ const updateStorageStats = () => {
 };
 
 /**
- * Downloads a comprehensive HTML storage report with breakdown and print options
+ * Shows storage report options with view and download actions
  */
 const downloadStorageReport = () => {
-  showStorageReportModal();
-};
-
-/**
- * Shows the storage report modal with options to view/download HTML or enhanced report
- */
-const showStorageReportModal = () => {
-  // Create modal if it doesn't exist
-  let modal = document.getElementById('storageReportModal');
+  let modal = document.getElementById('storageOptionsModal');
   if (!modal) {
-    modal = createStorageReportModal();
+    modal = document.createElement('div');
+    modal.id = 'storageOptionsModal';
+    modal.className = 'modal';
+    modal.innerHTML = `
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2>Storage Report</h2>
+          <button aria-label="Close modal" class="modal-close" id="storageOptionsClose">×</button>
+        </div>
+        <div class="modal-body">
+          <div class="options-buttons">
+            <button class="btn" id="viewStorageReportBtn">👁️ View Report</button>
+            <button class="btn secondary" id="downloadStorageZipBtn">📦 Download ZIP</button>
+          </div>
+        </div>
+      </div>`;
     document.body.appendChild(modal);
+
+    const closeModal = () => {
+      modal.style.display = 'none';
+      document.body.style.overflow = '';
+    };
+
+    modal.addEventListener('click', (e) => {
+      if (e.target === modal) closeModal();
+    });
+    modal.querySelector('#storageOptionsClose').addEventListener('click', closeModal);
+
+    modal.querySelector('#viewStorageReportBtn').addEventListener('click', () => {
+      closeModal();
+      openStorageReportPopup();
+    });
+
+    modal.querySelector('#downloadStorageZipBtn').addEventListener('click', async () => {
+      closeModal();
+      try {
+        const zipContent = await generateStorageReportTar();
+        const timestamp = new Date().toISOString().split('T')[0];
+        downloadFile(`storage-report-${timestamp}.zip`, zipContent, 'application/zip');
+      } catch (error) {
+        console.error('Error creating ZIP file:', error);
+        alert('Error creating compressed report. Please try again.');
+      }
+    });
   }
-  
+
   modal.style.display = 'flex';
   document.body.style.overflow = 'hidden';
 };
 
 /**
- * Creates the enhanced storage report modal with theme support and pie chart
+ * Opens a popup window with the storage report HTML
  */
-const createStorageReportModal = () => {
-  const modal = document.createElement('div');
-  modal.id = 'storageReportModal';
-  modal.className = 'modal';
-  modal.style.display = 'none';
-  
-  modal.innerHTML = `
-    <div class="modal-content storage-report-modal-content">
-      <div class="modal-header">
-        <h2>📊 Storage Report</h2>
-        <div class="storage-report-controls">
-          <button class="btn theme-btn" id="storageThemeToggle" title="Toggle theme">🌓</button>
-          <button aria-label="Close modal" class="modal-close" id="storageReportCloseBtn">×</button>
-        </div>
-      </div>
-      <div class="modal-body storage-report-body">
-        <div class="storage-report-header">
-          <div class="storage-summary-stats">
-            <div class="stat-card">
-              <span class="stat-label">Total Used</span>
-              <span class="stat-value" id="totalStorageUsed">0 KB</span>
-            </div>
-            <div class="stat-card">
-              <span class="stat-label">Items</span>
-              <span class="stat-value" id="totalStorageItems">0</span>
-            </div>
-            <div class="stat-card">
-              <span class="stat-label">Largest</span>
-              <span class="stat-value" id="largestStorageItem">-</span>
-            </div>
-          </div>
-        </div>
-        
-        <div class="storage-visualization-section">
-          <div class="chart-container">
-            <h3>Storage Distribution</h3>
-            <canvas id="storageChart" width="300" height="300"></canvas>
-          </div>
-          
-          <div class="storage-items-table">
-            <h3>Storage Items</h3>
-            <div class="storage-items-list" id="storageItemsList">
-              <!-- Populated by JS -->
-            </div>
-          </div>
-        </div>
-        
-        <div class="storage-report-actions">
-          <button class="btn" id="downloadFullReportBtn">💾 Download HTML Report</button>
-          <button class="btn secondary" id="downloadCompressedBtn">📦 Download ZIP</button>
-          <a href="#" class="btn success" onclick="document.getElementById('storageReportModal').style.display='none'; document.body.style.overflow='';">🏠 Back to App</a>
-        </div>
-      </div>
-    </div>
-    
-    <!-- Detail modals for each storage item -->
-    <div id="storageDetailModal" class="modal storage-detail-modal" style="display: none;">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h3 id="detailModalTitle">Item Details</h3>
-          <button aria-label="Close" class="modal-close" onclick="closeStorageDetailModal();">×</button>
-        </div>
-        <div class="modal-body">
-          <div id="detailModalContent"></div>
-        </div>
-      </div>
-    </div>
-  `;
-  
-  // Set up event listeners
-  setupStorageReportEventListeners(modal);
-  
-  // Initialize report data
-  populateStorageReport(modal);
-  
-  return modal;
-};
-
-/**
- * Sets up event listeners for the storage report modal
- */
-const setupStorageReportEventListeners = (modal) => {
-  const closeBtn = modal.querySelector('#storageReportCloseBtn');
-  const themeToggle = modal.querySelector('#storageThemeToggle');
-  const downloadFullBtn = modal.querySelector('#downloadFullReportBtn');
-  const downloadCompressedBtn = modal.querySelector('#downloadCompressedBtn');
-  
-  // Close modal
-  closeBtn.addEventListener('click', () => {
-    closeStorageReportModal();
-  });
-  
-  modal.addEventListener('click', (e) => {
-    if (e.target === modal) {
-      closeStorageReportModal();
-    }
-  });
-  
-  // Theme toggle for the report
-  themeToggle.addEventListener('click', () => {
-    toggleStorageReportTheme(modal);
-  });
-  
-  // Download actions
-  downloadFullBtn.addEventListener('click', () => {
-    const htmlContent = generateStorageReportHTML();
-    const timestamp = new Date().toISOString().split('T')[0];
-    downloadFile(`storage-report-${timestamp}.html`, htmlContent, 'text/html');
-  });
-  
-  downloadCompressedBtn.addEventListener('click', async () => {
-    try {
-      const zipContent = await generateStorageReportTar();
-      const timestamp = new Date().toISOString().split('T')[0];
-      downloadFile(`storage-report-${timestamp}.zip`, zipContent, 'application/zip');
-    } catch (error) {
-      console.error('Error creating ZIP file:', error);
-      alert('Error creating compressed report. Please try the HTML option instead.');
-    }
-  });
-};
-
-/**
- * Populates the storage report with current data and creates pie chart
- */
-const populateStorageReport = (modal) => {
-  const reportData = analyzeStorageData();
-  
-  // Update summary stats
-  modal.querySelector('#totalStorageUsed').textContent = `${reportData.totalSize.toFixed(2)} KB`;
-  modal.querySelector('#totalStorageItems').textContent = reportData.items.length;
-  modal.querySelector('#largestStorageItem').textContent = 
-    reportData.largestItem ? `${getStorageItemDisplayName(reportData.largestItem.key)}` : 'None';
-  
-  // Create pie chart
-  createStoragePieChart(reportData);
-  
-  // Populate items list
-  populateStorageItemsList(reportData, modal);
-  
-  // Apply current theme
-  const currentTheme = document.documentElement.getAttribute('data-theme');
-  if (currentTheme === 'dark') {
-    modal.classList.add('storage-dark-theme');
-  }
-};
-
-/**
- * Creates an interactive pie chart showing storage distribution
- */
-const createStoragePieChart = (reportData) => {
-  const canvas = document.getElementById('storageChart');
-  if (!canvas || typeof Chart === 'undefined') {
-    console.warn('Chart.js not available or canvas not found');
-    return;
-  }
-  
-  // Destroy existing chart if it exists
-  if (window.storageChart) {
-    window.storageChart.destroy();
-  }
-  
-  const ctx = canvas.getContext('2d');
-  const isDark = document.querySelector('#storageReportModal')?.classList.contains('storage-dark-theme');
-  
-  const colors = [
-    '#007bff', '#28a745', '#ffc107', '#dc3545', '#6f42c1',
-    '#fd7e14', '#20c997', '#e83e8c', '#6c757d', '#17a2b8'
-  ];
-  
-  const data = {
-    labels: reportData.items.map(item => getStorageItemDisplayName(item.key)),
-    datasets: [{
-      data: reportData.items.map(item => item.size),
-      backgroundColor: colors.slice(0, reportData.items.length),
-      borderColor: isDark ? '#404040' : '#ffffff',
-      borderWidth: 3,
-      hoverBorderWidth: 4,
-      hoverOffset: 8
-    }]
-  };
-  
-  const options = {
-    responsive: true,
-    maintainAspectRatio: false,
-    plugins: {
-      legend: {
-        display: false // We'll create our own custom legend
-      },
-      tooltip: {
-        backgroundColor: isDark ? '#2d2d2d' : '#ffffff',
-        titleColor: isDark ? '#ffffff' : '#333333',
-        bodyColor: isDark ? '#ffffff' : '#333333',
-        borderColor: isDark ? '#6c757d' : '#dee2e6',
-        borderWidth: 1,
-        cornerRadius: 8,
-        displayColors: false,
-        callbacks: {
-          title: (context) => {
-            return getStorageItemDisplayName(reportData.items[context[0].dataIndex].key);
-          },
-          label: (context) => {
-            const item = reportData.items[context.dataIndex];
-            return [
-              `Size: ${item.size.toFixed(2)} KB`,
-              `Percentage: ${item.percentage.toFixed(1)}%`,
-              `Records: ${item.recordCount}`,
-              `Type: ${item.type}`
-            ];
-          }
-        }
-      }
-    },
-    onClick: (event, elements) => {
-      if (elements.length > 0) {
-        const index = elements[0].index;
-        showStorageItemDetail(reportData.items[index]);
-      }
-    },
-    animation: {
-      animateRotate: true,
-      animateScale: true,
-      duration: 1000,
-      easing: 'easeOutQuart'
-    },
-    interaction: {
-      intersect: false
-    }
-  };
-  
-  window.storageChart = new Chart(ctx, {
-    type: 'doughnut', // Changed from 'pie' to 'doughnut' for better visual appeal
-    data: data,
-    options: options
-  });
-  
-  // Create custom legend
-  createCustomLegend(reportData, colors, isDark);
-};
-
-/**
- * Creates a custom legend for the storage chart
- */
-const createCustomLegend = (reportData, colors, isDark) => {
-  const legendContainer = document.querySelector('#storageItemsList');
-  if (!legendContainer) return;
-  
-  // Clear existing content
-  legendContainer.innerHTML = '';
-  
-  // Add instruction text
-  const instruction = document.createElement('div');
-  instruction.className = 'legend-instruction';
-  instruction.textContent = 'Click items below or chart segments to view details';
-  legendContainer.appendChild(instruction);
-  
-  // Create legend items
-  reportData.items.forEach((item, index) => {
-    const legendItem = document.createElement('div');
-    legendItem.className = 'storage-legend-item';
-    legendItem.onclick = () => showStorageItemDetail(item);
-    
-    legendItem.innerHTML = `
-      <div class="legend-color-bar" style="background-color: ${colors[index % colors.length]}"></div>
-      <div class="legend-content">
-        <div class="legend-name">${getStorageItemDisplayName(item.key)}</div>
-        <div class="legend-stats">
-          <span class="legend-size">${item.size.toFixed(1)} KB</span>
-          <span class="legend-percentage">${item.percentage.toFixed(1)}%</span>
-          <span class="legend-records">${item.recordCount} records</span>
-        </div>
-      </div>
-      <div class="legend-arrow">›</div>
-    `;
-    
-    legendContainer.appendChild(legendItem);
-  });
-};
-
-/**
- * Populates the storage items list with clickable entries
- */
-const populateStorageItemsList = (reportData, modal) => {
-  const container = modal.querySelector('#storageItemsList');
-  
-  // This will be populated by createCustomLegend when the chart is created
-  container.innerHTML = '<div class="loading-legend">Creating interactive chart...</div>';
-};
-
-/**
- * Shows detailed information for a storage item
- */
-const showStorageItemDetail = (item) => {
-  const detailModal = document.getElementById('storageDetailModal');
-  const title = document.getElementById('detailModalTitle');
-  const content = document.getElementById('detailModalContent');
-  
-  if (!detailModal || !title || !content) return;
-  
-  title.textContent = `${getStorageItemDisplayName(item.key)} Details`;
-  content.innerHTML = generateDetailModalContent(item);
-  
-  // Apply theme to detail modal
-  const parentModal = document.getElementById('storageReportModal');
-  if (parentModal?.classList.contains('storage-dark-theme')) {
-    detailModal.classList.add('storage-dark-theme');
+const openStorageReportPopup = () => {
+  const htmlContent = generateStorageReportHTML();
+  const width = 1000;
+  const height = 800;
+  const left = window.screenX + Math.max(0, (window.innerWidth - width) / 2);
+  const top = window.screenY + Math.max(0, (window.innerHeight - height) / 2);
+  const popup = window.open('', 'storageReport', `width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes`);
+  if (popup) {
+    popup.document.write(htmlContent);
+    popup.document.close();
   } else {
-    detailModal.classList.remove('storage-dark-theme');
-  }
-  
-  detailModal.style.display = 'flex';
-};
-
-/**
- * Generates content for the detail modal
- */
-const generateDetailModalContent = (item) => {
-  let content = `
-    <div class="detail-stats">
-      <div class="detail-stat">
-        <span class="stat-label">Size:</span>
-        <span class="stat-value">${item.size.toFixed(2)} KB</span>
-      </div>
-      <div class="detail-stat">
-        <span class="stat-label">Type:</span>
-        <span class="stat-value">${item.type}</span>
-      </div>
-      <div class="detail-stat">
-        <span class="stat-label">Records:</span>
-        <span class="stat-value">${item.recordCount}</span>
-      </div>
-      <div class="detail-stat">
-        <span class="stat-label">Percentage:</span>
-        <span class="stat-value">${item.percentage.toFixed(1)}%</span>
-      </div>
-    </div>
-  `;
-  
-  // Add data preview based on type
-  if (item.parsedData && Array.isArray(item.parsedData) && item.parsedData.length > 0) {
-    if (item.key === 'precious-metals-inventory') {
-      content += generateInventoryTable(item.parsedData);
-    } else {
-      content += `<div class="data-preview"><h4>Sample Data:</h4><pre>${JSON.stringify(item.parsedData.slice(0, 3), null, 2)}${item.parsedData.length > 3 ? '\n...and ' + (item.parsedData.length - 3) + ' more items' : ''}</pre></div>`;
-    }
-  } else if (item.parsedData) {
-    content += `<div class="data-preview"><h4>Data:</h4><pre>${JSON.stringify(item.parsedData, null, 2)}</pre></div>`;
-  } else {
-    content += `<div class="data-preview"><h4>Raw Data:</h4><pre>${item.value}</pre></div>`;
-  }
-  
-  return content;
-};
-
-/**
- * Generates a table view for inventory data
- */
-const generateInventoryTable = (data) => {
-  if (!data || data.length === 0) return '<p>No inventory data found</p>';
-  
-  const headers = Object.keys(data[0]);
-  const displayLimit = 20;
-  
-  return `
-    <div class="inventory-table-container">
-      <h4>Inventory Data (showing first ${Math.min(displayLimit, data.length)} of ${data.length} items)</h4>
-      <table class="inventory-detail-table">
-        <thead>
-          <tr>${headers.map(h => `<th>${h}</th>`).join('')}</tr>
-        </thead>
-        <tbody>
-          ${data.slice(0, displayLimit).map(record => 
-            `<tr>${headers.map(h => `<td>${sanitizeHtml(String(record[h] || ''))}</td>`).join('')}</tr>`
-          ).join('')}
-        </tbody>
-      </table>
-    </div>
-  `;
-};
-
-/**
- * Closes the storage detail modal
- */
-const closeStorageDetailModal = () => {
-  const detailModal = document.getElementById('storageDetailModal');
-  if (detailModal) {
-    detailModal.style.display = 'none';
+    alert('Popup blocked. Please allow popups for this site.');
   }
 };
-
-/**
- * Toggles the theme for the storage report modal
- */
-const toggleStorageReportTheme = (modal) => {
-  const isDark = modal.classList.contains('storage-dark-theme');
-  
-  if (isDark) {
-    modal.classList.remove('storage-dark-theme');
-  } else {
-    modal.classList.add('storage-dark-theme');
-  }
-  
-  // Recreate chart with new theme
-  const reportData = analyzeStorageData();
-  createStoragePieChart(reportData);
-};
-
-/**
- * Closes the storage report modal
- */
-const closeStorageReportModal = () => {
-  const modal = document.getElementById('storageReportModal');
-  if (modal) {
-    modal.style.display = 'none';
-    document.body.style.overflow = '';
-  }
-  
-  // Destroy chart to free memory
-  if (window.storageChart) {
-    window.storageChart.destroy();
-    window.storageChart = null;
-  }
-};
-
-// Make functions globally available
-window.showStorageItemDetail = showStorageItemDetail;
-window.closeStorageDetailModal = closeStorageDetailModal;
-
 /**
  * Generates comprehensive HTML storage report with theme support
  */
@@ -990,7 +610,7 @@ const generateStorageReportHTML = () => {
                 <h1>📊 StackTrackr Storage Report</h1>
                 <div class="header-controls">
                     <button onclick="toggleTheme()" class="theme-toggle-btn">🌓</button>
-                    <a href="#" onclick="window.close(); return false;" class="back-link">🏠 Back to App</a>
+                    <button onclick="window.close(); return false;" class="close-btn" aria-label="Close report">×</button>
                 </div>
             </div>
             <div class="report-meta">
@@ -1003,7 +623,14 @@ const generateStorageReportHTML = () => {
         <div class="print-controls">
             <button onclick="window.print()" class="print-btn">🖨️ Print Report</button>
         </div>
-        
+
+        <section class="storage-chart">
+            <h2>Top Storage Items</h2>
+            <div class="chart-container">
+                <canvas id="storageChart" width="600" height="300"></canvas>
+            </div>
+        </section>
+
         <section class="storage-summary">
             <h2>Storage Overview</h2>
             <div class="summary-grid">
@@ -1018,25 +645,6 @@ const generateStorageReportHTML = () => {
                 <div class="summary-item">
                     <span class="summary-label">Largest Item:</span>
                     <span class="summary-value">${reportData.largestItem ? getStorageItemDisplayName(reportData.largestItem.key) : 'None'} ${reportData.largestItem ? '(' + reportData.largestItem.size.toFixed(2) + ' KB)' : ''}</span>
-                </div>
-            </div>
-        </section>
-        
-        <section class="storage-visualization">
-            <h2>Storage Distribution</h2>
-            <div class="chart-section">
-                <div class="chart-container">
-                    <canvas id="storageChart" width="400" height="400"></canvas>
-                </div>
-                <div class="chart-legend">
-                    <h3>Click on chart or items below for details</h3>
-                    ${reportData.items.map((item, index) => `
-                        <div class="legend-item" onclick="showItemDetail('${item.key}')" data-index="${index}">
-                            <span class="legend-color" style="background-color: ${getChartColor(index)}"></span>
-                            <span class="legend-label">${getStorageItemDisplayName(item.key)}</span>
-                            <span class="legend-value">${item.size.toFixed(1)} KB (${item.percentage.toFixed(1)}%)</span>
-                        </div>
-                    `).join('')}
                 </div>
             </div>
         </section>
@@ -1068,7 +676,6 @@ const generateStorageReportHTML = () => {
         <footer class="report-footer">
             <p>Generated by StackTrackr v${APP_VERSION} • ${new Date().getFullYear()}</p>
             <p>This report contains a snapshot of your local browser storage data.</p>
-            <p><a href="#" onclick="window.close(); return false;">🏠 Return to StackTrackr Application</a></p>
         </footer>
     </div>
     
@@ -1329,6 +936,7 @@ const getStorageReportCSS = () => {
   return `
     :root {
         --primary: #007bff;
+        --primary-hover: #0056b3;
         --success: #28a745;
         --warning: #ffc107;
         --danger: #dc3545;
@@ -1341,7 +949,7 @@ const getStorageReportCSS = () => {
         --text-secondary: #666666;
         --border: #dee2e6;
     }
-    
+
     [data-theme="dark"] {
         --bg-primary: #1a1a1a;
         --bg-secondary: #2d2d2d;
@@ -1350,6 +958,7 @@ const getStorageReportCSS = () => {
         --border: #404040;
         --light: #2d2d2d;
         --dark: #f8f9fa;
+        --primary-hover: #3395ff;
     }
     
     * {
@@ -1766,8 +1375,9 @@ const getStorageReportCSS = () => {
         align-items: center;
         gap: 1rem;
     }
-    
-    .theme-toggle-btn {
+
+    .theme-toggle-btn,
+    .close-btn {
         background: none;
         border: 1px solid var(--border);
         padding: 0.5rem;
@@ -1776,49 +1386,31 @@ const getStorageReportCSS = () => {
         font-size: 1rem;
         transition: all 0.2s ease;
     }
-    
-    .theme-toggle-btn:hover {
+
+    .theme-toggle-btn:hover,
+    .close-btn:hover {
         background: var(--bg-secondary);
     }
     
-    .back-link {
-        color: var(--success);
-        text-decoration: none;
-        font-weight: 600;
-        padding: 0.5rem 1rem;
-        border: 1px solid var(--success);
-        border-radius: 0.25rem;
-        transition: all 0.2s ease;
-    }
-    
-    .back-link:hover {
-        background: var(--success);
-        color: white;
-    }
-    
-    .storage-visualization {
+    .storage-chart {
         margin-bottom: 2rem;
+        text-align: center;
     }
-    
-    .chart-section {
-        display: grid;
-        grid-template-columns: 1fr 1fr;
-        gap: 2rem;
-        align-items: start;
+
+    .storage-chart h2 {
+        color: var(--text-primary);
+        margin-bottom: 1rem;
+        font-size: 1.5rem;
     }
-    
-    @media (max-width: 768px) {
-        .chart-section {
-            grid-template-columns: 1fr;
-        }
-    }
-    
+
     .chart-container {
         background: var(--bg-primary);
         border: 1px solid var(--border);
         border-radius: 0.5rem;
         padding: 1rem;
         text-align: center;
+        margin: 0 auto;
+        max-width: 600px;
     }
     
     .chart-legend {
@@ -1826,6 +1418,14 @@ const getStorageReportCSS = () => {
         border: 1px solid var(--border);
         border-radius: 0.5rem;
         padding: 1rem;
+        display: flex;
+        flex-direction: column;
+        height: 100%;
+    }
+
+    .legend-items {
+        overflow-y: auto;
+        flex: 1;
     }
     
     .chart-legend h3 {
@@ -1871,22 +1471,22 @@ const getStorageReportCSS = () => {
     
     .report-header {
         text-align: center;
-        border-bottom: 3px solid #007bff;
+        border-bottom: 3px solid var(--primary);
         padding-bottom: 1rem;
         margin-bottom: 2rem;
     }
-    
+
     .report-header h1 {
-        color: #007bff;
+        color: var(--primary);
         font-size: 2.5rem;
         margin-bottom: 0.5rem;
     }
-    
+
     .report-meta {
         display: flex;
         justify-content: space-between;
         font-size: 0.9rem;
-        color: #666;
+        color: var(--text-secondary);
     }
     
     .print-controls {
@@ -1895,7 +1495,7 @@ const getStorageReportCSS = () => {
     }
     
     .print-btn {
-        background: #007bff;
+        background: var(--primary);
         color: white;
         border: none;
         padding: 0.75rem 1.5rem;
@@ -1904,9 +1504,9 @@ const getStorageReportCSS = () => {
         cursor: pointer;
         transition: background 0.2s;
     }
-    
+
     .print-btn:hover {
-        background: #0056b3;
+        background: var(--primary-hover);
     }
     
     .storage-summary {
@@ -1914,7 +1514,7 @@ const getStorageReportCSS = () => {
     }
     
     .storage-summary h2 {
-        color: #333;
+        color: var(--text-primary);
         margin-bottom: 1rem;
         font-size: 1.5rem;
     }
@@ -1927,28 +1527,29 @@ const getStorageReportCSS = () => {
     }
     
     .summary-item {
-        background: #f8f9fa;
+        background: var(--bg-primary);
         padding: 1rem;
         border-radius: 0.5rem;
-        border-left: 4px solid #007bff;
+        border: 1px solid var(--border);
+        border-left: 4px solid var(--primary);
         display: flex;
         justify-content: space-between;
         align-items: center;
     }
-    
+
     .summary-label {
         font-weight: 600;
-        color: #666;
+        color: var(--text-secondary);
     }
-    
+
     .summary-value {
         font-weight: 700;
-        color: #007bff;
+        color: var(--primary);
         font-size: 1.1rem;
     }
     
     .storage-breakdown h2 {
-        color: #333;
+        color: var(--text-primary);
         margin-bottom: 1rem;
         font-size: 1.5rem;
     }
@@ -1959,10 +1560,10 @@ const getStorageReportCSS = () => {
     }
     
     .storage-item {
-        border: 1px solid #dee2e6;
+        border: 1px solid var(--border);
         border-radius: 0.5rem;
         padding: 1rem;
-        background: white;
+        background: var(--bg-primary);
         transition: box-shadow 0.2s;
     }
     
@@ -1979,7 +1580,7 @@ const getStorageReportCSS = () => {
     }
     
     .item-header h3 {
-        color: #007bff;
+        color: var(--primary);
         font-size: 1.2rem;
     }
     
@@ -1991,11 +1592,11 @@ const getStorageReportCSS = () => {
     
     .item-size {
         font-weight: 600;
-        color: #28a745;
+        color: var(--success);
     }
     
     .item-percentage {
-        background: #007bff;
+        background: var(--primary);
         color: white;
         padding: 0.25rem 0.5rem;
         border-radius: 1rem;
@@ -2003,7 +1604,7 @@ const getStorageReportCSS = () => {
     }
     
     .item-description {
-        color: #666;
+        color: var(--text-secondary);
         margin-bottom: 0.5rem;
         font-size: 0.9rem;
     }
@@ -2015,25 +1616,26 @@ const getStorageReportCSS = () => {
     }
     
     .detail-item {
-        background: #f8f9fa;
+        background: var(--bg-secondary);
         padding: 0.25rem 0.5rem;
         border-radius: 0.25rem;
         font-size: 0.8rem;
-        color: #666;
+        color: var(--text-secondary);
     }
     
     .view-details-btn {
-        background: #28a745;
+        background: var(--success);
         color: white;
         border: none;
         padding: 0.5rem 1rem;
         border-radius: 0.25rem;
         cursor: pointer;
         font-size: 0.9rem;
+        transition: filter 0.2s;
     }
-    
+
     .view-details-btn:hover {
-        background: #1e7e34;
+        filter: brightness(0.9);
     }
     
     .storage-modal {
@@ -2050,7 +1652,8 @@ const getStorageReportCSS = () => {
     }
     
     .modal-content-large {
-        background: white;
+        background: var(--bg-primary);
+        color: var(--text-primary);
         border-radius: 0.5rem;
         width: 90%;
         max-width: 800px;
@@ -2061,7 +1664,7 @@ const getStorageReportCSS = () => {
     }
     
     .modal-header {
-        background: #007bff;
+        background: var(--primary);
         color: white;
         padding: 1rem;
         display: flex;
@@ -2087,6 +1690,8 @@ const getStorageReportCSS = () => {
         padding: 1rem;
         overflow-y: auto;
         flex: 1;
+        background: var(--bg-primary);
+        color: var(--text-primary);
     }
     
     .modal-stats {
@@ -2097,21 +1702,21 @@ const getStorageReportCSS = () => {
     }
     
     .stat-item {
-        background: #f8f9fa;
+        background: var(--bg-secondary);
         padding: 0.75rem;
         border-radius: 0.25rem;
         display: flex;
         justify-content: space-between;
     }
-    
+
     .stat-label {
         font-weight: 600;
-        color: #666;
+        color: var(--text-secondary);
     }
-    
+
     .stat-value {
         font-weight: 700;
-        color: #007bff;
+        color: var(--primary);
     }
     
     .data-table-container {
@@ -2127,13 +1732,13 @@ const getStorageReportCSS = () => {
     
     .data-table th,
     .data-table td {
-        border: 1px solid #dee2e6;
+        border: 1px solid var(--border);
         padding: 0.5rem;
         text-align: left;
     }
-    
+
     .data-table th {
-        background: #f8f9fa;
+        background: var(--bg-secondary);
         font-weight: 600;
         position: sticky;
         top: 0;
@@ -2146,7 +1751,7 @@ const getStorageReportCSS = () => {
     }
     
     .data-preview {
-        background: #f8f9fa;
+        background: var(--bg-secondary);
         padding: 1rem;
         border-radius: 0.25rem;
         margin-top: 1rem;
@@ -2162,24 +1767,24 @@ const getStorageReportCSS = () => {
     
     .truncated {
         text-align: center;
-        color: #666;
+        color: var(--text-secondary);
         font-style: italic;
         margin-top: 0.5rem;
     }
-    
+
     .no-data {
         text-align: center;
-        color: #666;
+        color: var(--text-secondary);
         font-style: italic;
         padding: 2rem;
     }
-    
+
     .report-footer {
         margin-top: 3rem;
         padding-top: 1rem;
-        border-top: 1px solid #dee2e6;
+        border-top: 1px solid var(--border);
         text-align: center;
-        color: #666;
+        color: var(--text-secondary);
         font-size: 0.9rem;
     }
     
@@ -2243,6 +1848,7 @@ const getStorageReportJS = () => {
   return `
     let currentChart = null;
     let currentReportData = null;
+    let currentChartItems = [];
     
     function toggleTheme() {
         const html = document.documentElement;
@@ -2264,27 +1870,28 @@ const getStorageReportJS = () => {
             console.warn('Chart.js not available or canvas not found');
             return;
         }
-        
+
         const ctx = canvas.getContext('2d');
         const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-        
+
         const colors = [
             '#007bff', '#28a745', '#ffc107', '#dc3545', '#6f42c1',
             '#fd7e14', '#20c997', '#e83e8c', '#6c757d', '#17a2b8'
         ];
-        
+
+        const topItems = reportData.items.slice(0, 5);
+        currentChartItems = topItems;
+
         const data = {
-            labels: reportData.items.map(item => getStorageItemDisplayName(item.key)),
+            labels: topItems.map(item => getStorageItemDisplayName(item.key)),
             datasets: [{
-                data: reportData.items.map(item => item.size),
-                backgroundColor: colors.slice(0, reportData.items.length),
+                data: topItems.map(item => item.size),
+                backgroundColor: topItems.map((_, index) => colors[index % colors.length]),
                 borderColor: isDark ? '#404040' : '#ffffff',
-                borderWidth: 2,
-                hoverBorderWidth: 3,
-                hoverOffset: 10
+                borderWidth: 1
             }]
         };
-        
+
         const options = {
             responsive: true,
             maintainAspectRatio: false,
@@ -2300,7 +1907,7 @@ const getStorageReportJS = () => {
                     borderWidth: 1,
                     callbacks: {
                         label: (context) => {
-                            const item = reportData.items[context.dataIndex];
+                            const item = currentChartItems[context.dataIndex];
                             return [
                                 \`\${context.label}: \${item.size.toFixed(2)} KB\`,
                                 \`\${item.percentage.toFixed(1)}% of total\`,
@@ -2313,12 +1920,19 @@ const getStorageReportJS = () => {
             onClick: (event, elements) => {
                 if (elements.length > 0) {
                     const index = elements[0].index;
-                    showItemDetail(reportData.items[index].key);
+                    showItemDetail(currentChartItems[index].key);
                 }
             },
-            animation: {
-                animateRotate: true,
-                animateScale: true
+            scales: {
+                x: {
+                    ticks: { color: isDark ? '#ffffff' : '#000000' },
+                    grid: { color: isDark ? '#404040' : '#e0e0e0' }
+                },
+                y: {
+                    beginAtZero: true,
+                    ticks: { color: isDark ? '#ffffff' : '#000000' },
+                    grid: { color: isDark ? '#404040' : '#e0e0e0' }
+                }
             }
         };
         
@@ -2327,7 +1941,7 @@ const getStorageReportJS = () => {
         }
         
         currentChart = new Chart(ctx, {
-            type: 'pie',
+            type: 'bar',
             data: data,
             options: options
         });
@@ -2536,10 +2150,6 @@ This archive contains a complete snapshot of your StackTrackr storage data.`;
   return content;
 };
 
-// Make all storage report functions globally available
+// Make storage report functions globally available
 window.updateStorageStats = updateStorageStats;
 window.downloadStorageReport = downloadStorageReport;
-window.showStorageReportModal = showStorageReportModal;
-window.closeStorageReportModal = closeStorageReportModal;
-window.showStorageItemDetail = showStorageItemDetail;
-window.closeStorageDetailModal = closeStorageDetailModal;


### PR DESCRIPTION
## Summary
- add storage report options modal with view and zip download buttons
- rework standalone storage report template with themed bar chart and full dark/light support
- theme item detail modals to match main app styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898e25e7c60832ebeedd154a1eae68b