### PR TITLE
docs: document branch-based versioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# StackTrackr v3.03.01a
+# StackTrackr v3.03.02a
 
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
 
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
+- **v3.03.02a - Versioning Guide Refinement**: Introduced BRANCH.RELEASE.PATCH.state naming and clarified pre-release codes
 - **v3.03.01a - Comprehensive Storage Report System**: Redesigned storage reports with top-five pie chart visualization and scrollable legend
 - **v3.00.00 - Stable Release & Documentation Cleanup**: Finalized documentation and archived planning notes
 - **v3.2.07rc - Spot Timestamp Source Display**: Spot price cards now show the API provider or Manual entry along with the exact timestamp of the last update
@@ -22,6 +23,9 @@ The public hosted version of the app is available at [stackrtrackr.com](https://
 - **v3.1.9 - UI Consistency**: Clear Cache button styling improvements across themes
 - **v3.1.8 - Backup System**: Full ZIP backup functionality with restoration guides
 - **v3.1.6 - Theme Toggle**: Fixed theme management with system preference detection
+
+## 🆕 What's New in v3.03.02a
+- Clarified version naming scheme and state codes
 
 ## 🆕 What's New in v3.03.01a
 - Comprehensive storage report system featuring pie chart visualization and scrollable legend
@@ -256,7 +260,7 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: 3.03.01a
+**Current Version**: 3.03.02a
 **Last Updated**: August 9, 2025
 **Status**: Feature complete release candidate
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,18 +8,9 @@
 
 ## 📋 Version History
 
-### Version 3.00.02 – Interactive Storage Report Dashboard (2025-08-10)
-- **Interactive Dashboard**: Complete redesign of storage report from simple download options to comprehensive interactive dashboard
-  - **Real-time Pie Chart**: Chart.js-powered visualization showing storage distribution with clickable segments
-  - **Theme Toggle**: Independent dark/light mode toggle with inheritance from main application
-  - **Interactive Elements**: Click pie chart segments, legend items, or table rows to view detailed breakdowns
-  - **Auto-sizing Modal**: Responsive modal (95vw × 90vh, max 1200px × 900px) with proper centering
-  - **Themed Design**: Uses standard modal header styling consistent with other application modals
-- **Enhanced Downloads**: HTML reports now include interactive charts and theme support
-- **Navigation**: "Back to App" links in both modal and standalone HTML reports
-- **Data Exploration**: Detailed modals for each storage item with formatted tables and data previews
-- **Chart Interactivity**: Hover tooltips, legend interactions, and click-to-drill-down functionality
-- **Theme Persistence**: Selected theme preserved in exported HTML reports and ZIP archives
+### Version 3.03.02a – Versioning Guide Refinement (2025-08-10)
+- Clarified BRANCH.RELEASE.PATCH.state version scheme
+- Documented pre-release state codes and branching policy
 
 ### Version 3.03.01a – Comprehensive Storage Report System (2025-08-10)
 - **Enhanced Storage Reports**: Redesigned storage report from basic JSON export to comprehensive HTML reporting system
@@ -33,6 +24,19 @@
 - **User Experience**: Storage report link in footer now opens options modal instead of direct JSON download
 - **Professional Styling**: Consistent with application design language, responsive layout, proper typography
 - **Self-contained Reports**: HTML files include all CSS and JavaScript inline for standalone viewing
+
+### Version 3.00.02 – Interactive Storage Report Dashboard (2025-08-10)
+- **Interactive Dashboard**: Complete redesign of storage report from simple download options to comprehensive interactive dashboard
+  - **Real-time Pie Chart**: Chart.js-powered visualization showing storage distribution with clickable segments
+  - **Theme Toggle**: Independent dark/light mode toggle with inheritance from main application
+  - **Interactive Elements**: Click pie chart segments, legend items, or table rows to view detailed breakdowns
+  - **Auto-sizing Modal**: Responsive modal (95vw × 90vh, max 1200px × 900px) with proper centering
+  - **Themed Design**: Uses standard modal header styling consistent with other application modals
+- **Enhanced Downloads**: HTML reports now include interactive charts and theme support
+- **Navigation**: "Back to App" links in both modal and standalone HTML reports
+- **Data Exploration**: Detailed modals for each storage item with formatted tables and data previews
+- **Chart Interactivity**: Hover tooltips, legend interactions, and click-to-drill-down functionality
+- **Theme Persistence**: Selected theme preserved in exported HTML reports and ZIP archives
 
 ### Version 3.00.00 – Stable Release (2025-08-10)
 - Promoted release candidate features to official stable version

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,10 +1,10 @@
-# Multi-Agent Development Workflow - StackTrackr v3.03.01a
+# Multi-Agent Development Workflow - StackTrackr v3.03.02a
 
 ## 🎯 Project Overview
 
-You are contributing to the **StackTrackr v3.03.01a**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to the **StackTrackr v3.03.02a**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.03.01a (alpha)
+**Current Status**: v3.03.02a (alpha)
 **Your Role**: Complete individual 2-hour subtasks as part of a coordinated multi-agent development effort
 
 ---
@@ -291,6 +291,6 @@ Before starting ANY subtask, read these files:
 
 ---
 
-**Remember: Each subtask is designed to be completed independently while contributing to the larger v3.03.01a vision. Focus on quality over speed, and don't hesitate to coordinate with other agents when working on shared components.**
+**Remember: Each subtask is designed to be completed independently while contributing to the larger v3.03.02a vision. Focus on quality over speed, and don't hesitate to coordinate with other agents when working on shared components.**
 
 **Your contribution helps build a professional-grade inventory management system that serves users worldwide. Every subtask matters!** 🚀

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,8 +1,8 @@
 # Project Status - StackTrackr
 
-## 🎯 Current State: **ALPHA v3.03.01a** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **ALPHA v3.03.02a** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.03.01a** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.03.02a** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
 
 ## 🏗️ Architecture Overview
 
@@ -20,6 +20,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.03.02a - Versioning Guide Refinement**: Introduced BRANCH.RELEASE.PATCH.state naming and clarified pre-release codes
 - **v3.03.01a - Comprehensive Storage Report System**: Redesigned storage reports from basic JSON to professional HTML system
   - Professional HTML reports optimized for letter paper printing
   - Interactive modals with detailed breakdowns for each storage item
@@ -120,7 +121,7 @@ All data is stored locally in the browser using localStorage with:
 
 **All documentation files are current and synchronized:**
 - ✅ **STATUS.md** - Updated for v3.00.00 release
-- ✅ **CHANGELOG.md** - Current through v3.03.01a
+- ✅ **CHANGELOG.md** - Current through v3.03.02a
 - ✅ **MULTI_AGENT_WORKFLOW.md** - Comprehensive AI assistant development guide
 - ✅ **STRUCTURE.md** - Reflects streamlined project organization
 - ✅ **VERSIONING.md** - Accurate version management documentation
@@ -129,7 +130,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.03.01a (managed in `js/constants.js`)
+1. **Current Version**: 3.03.02a (managed in `js/constants.js`)
 2. **Last Change**: Comprehensive HTML storage report system with interactive modals and print optimization
 3. **Last Documentation Update**: August 10, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns
@@ -146,7 +147,7 @@ If continuing development in a new chat session:
 ```
 StackTrackr/
 ├── js/                     # Modular JavaScript (cleaned structure)
-│   ├── constants.js        # Version 3.03.01a + metal configs
+│   ├── constants.js        # Version 3.03.02a + metal configs
 │   ├── state.js           # App state + DOM caching
 │   ├── inventory.js       # Core CRUD + notes handling
 │   ├── events.js          # UI event listeners

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -7,8 +7,8 @@ The StackTrackr now uses a dynamic version management system that automatically 
 ## How It Works
 
 ### Single Source of Truth
-- Version is defined once in `js/constants.js` as `APP_VERSION = '3.03.01a'`
-- This is the ONLY place you need to update the version number
+- Version is defined once in `js/constants.js` as `APP_VERSION = '3.03.02a'`
+  - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation
 - **index.html**: JavaScript automatically updates the page title and heading
@@ -27,14 +27,14 @@ To release a new version:
 1. **Update ONLY the constants file:**
    ```javascript
    // In js/constants.js
-   const APP_VERSION = '3.03.01a';  // Change this line only
+   const APP_VERSION = '3.03.02a';  // Change this line only
    ```
 
 2. **All these will automatically update:**
-   - Page title: "StackTrackr v3.03.01a"
-   - Page heading: "StackTrackr v3.03.01a"
-   - Browser tab title: "StackTrackr v3.03.01a"
-   - App header: "StackTrackr v3.03.01a"
+   - Page title: "StackTrackr v3.03.02a"
+   - Page heading: "StackTrackr v3.03.02a"
+   - Browser tab title: "StackTrackr v3.03.02a"
+   - App header: "StackTrackr v3.03.02a"
 
 3. **Update changelog:** Add entry to `/docs/CHANGELOG.md` for documentation
 
@@ -57,35 +57,36 @@ appHeader.textContent = getAppTitle();
 - **Future-proof** - any new features can easily access current version
 
 ## Version Format
-Use semantic versioning: `MAJOR.MINOR.PATCH`
-- **MAJOR**: Breaking changes or major new features
-- **MINOR**: New features that are backwards compatible
-- **PATCH**: Bug fixes and small improvements
+StackTrackr versions follow the `BRANCH.RELEASE.PATCH.state` pattern:
 
-### Suffix Conventions
-Append letters to indicate pre-release stages:
-- `a` for alpha versions
-- `b` for beta releases
-- `rc` for release candidates
-- no suffix indicates a stable release
+- **BRANCH** – Major development branch
+- **RELEASE** – Two-digit feature release number
+- **PATCH** – Two-digit patch number for fixes
+- **state** – Optional pre-release code
+  - `a` = alpha
+  - `b` = beta
+  - `rc` = release candidate
+  - *(omit for stable builds)*
 
-### Numbering Guidelines
-- **Major**: 1-x
-- **Minor**: 1-9
-- **Patch**: 1-x (aim for fewer than 100 patches before incrementing the minor version)
+Example: `3.03.02a` → branch 3, release 03, patch 02, alpha build
+
+### Branching Policy
+- Each major **BRANCH** is developed on its own long-lived branch
+- New **RELEASE** and **PATCH** updates occur within that branch
+- Stable releases drop the state code when merged into the main line
 
 ## Example Usage in Code
 ```javascript
 // Get just the version number
-const version = APP_VERSION; // "3.03.01a"
+const version = APP_VERSION; // "3.03.02a"
 
 // Get formatted version string
-const versionString = getVersionString(); // "v3.03.01a"
-const customVersion = getVersionString('version '); // "version 3.03.01a"
+const versionString = getVersionString(); // "v3.03.02a"
+const customVersion = getVersionString('version '); // "version 3.03.02a"
 
 // Get full app title
-const title = getAppTitle(); // "StackTrackr v3.03.01a"
-const customTitle = getAppTitle('My Custom Tool'); // "My Custom Tool v3.03.01a"
+const title = getAppTitle(); // "StackTrackr v3.03.02a"
+const customTitle = getAppTitle('My Custom Tool'); // "My Custom Tool v3.03.02a"
 ```
 
 This system ensures version consistency and makes maintenance much easier!

--- a/docs/future/TURSO_SYNC_PLAN.md
+++ b/docs/future/TURSO_SYNC_PLAN.md
@@ -1,6 +1,6 @@
 # Turso Cloud Sync Implementation Plan
 
-**StackTrackr v3.2.05rc → v3.03.01a**
+**StackTrackr v3.2.05rc → v3.03.02a**
 **Date**: August 10, 2025  
 **Scope**: Provider-agnostic cloud sync system with Turso as first implementation
 
@@ -884,5 +884,5 @@ PLANETSCALE: {
 ---
 
 **Status**: Ready for implementation  
-**Target Version**: v3.03.01a
+**Target Version**: v3.03.02a
 **Priority**: High - Foundation for future premium features

--- a/js/constants.js
+++ b/js/constants.js
@@ -92,8 +92,12 @@ const API_PROVIDERS = {
 
 // =============================================================================
 
-/** @constant {string} APP_VERSION - Application version */
-const APP_VERSION = "3.03.01a";
+/**
+ * @constant {string} APP_VERSION - Application version
+ * Follows BRANCH.RELEASE.PATCH.state format
+ * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
+ */
+const APP_VERSION = "3.03.02a";
 
 /** @constant {string} BRANDING_TITLE - Optional custom application title */
 const BRANDING_TITLE = "StackTrackr";

--- a/structure.md
+++ b/structure.md
@@ -1,6 +1,6 @@
 # StackTrackr - Project Structure
 
-## Current Structure (Version 3.03.01a)
+## Current Structure (Version 3.03.02a)
 
 ```text
 ├── css/


### PR DESCRIPTION
## Summary
- outline branch.release.patch.state version scheme in VERSIONING guide
- bump app version to 3.03.02a and refresh docs

## Testing
- `node --check js/constants.js`


------
https://chatgpt.com/codex/tasks/task_e_6899097cf338832e974b28db5a9a9202