### PR TITLE
feat: add Numista CSV import parser

### DIFF
--- a/docs/FUNCTIONSTABLE.md
+++ b/docs/FUNCTIONSTABLE.md
@@ -100,6 +100,7 @@
 | inventory.js | updateImportProgress |  |
 | inventory.js | endImportProgress |  |
 | inventory.js | importCsv | Imports inventory data from CSV file with comprehensive validation and error handling |
+| inventory.js | importNumistaCsv | Imports inventory data from a Numista CSV export |
 | inventory.js | exportCsv | Exports current inventory to CSV format |
 | inventory.js | importJson | Imports inventory data from JSON file |
 | inventory.js | exportJson | Exports current inventory to JSON format |
@@ -137,6 +138,9 @@
 | utils.js | formatDollar | Formats a number as a dollar amount with two decimal places |
 | utils.js | formatLossProfit | Formats a profit/loss value with color coding |
 | utils.js | sanitizeHtml | Sanitizes text input for safe HTML display |
+| utils.js | gramsToOzt | Converts grams to troy ounces |
+| utils.js | convertToUsd | Converts amount from specified currency to USD using static rates |
+| utils.js | mapNumistaType | Maps Numista type strings to internal categories |
 | utils.js | saveData | Saves data to localStorage with JSON serialization |
 | utils.js | loadData | Loads data from localStorage with error handling |
 | utils.js | sortInventoryByDateNewestFirst | Sorts inventory by date (newest first) |

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1102,6 +1102,147 @@ const importCsv = (file) => {
 };
 
 /**
+ * Imports inventory data from a Numista CSV export
+ *
+ * Maps Numista fields to StackTrackr inventory structure:
+ * - N# number → numistaId (hidden)
+ * - Title (+ Year) → name; also stores issuedYear
+ * - Type → mapped via mapNumistaType()
+ * - Weight columns → max value converted from grams to ozt
+ * - Buying price (currency) → price in USD via convertToUsd()
+ * - Storage location / Acquisition place → defaults to "unknown" if blank
+ * - Acquisition date → parsed YYYY-MM-DD or today if blank
+ * - Notes appended with import source reference
+ *
+ * @param {File} file - CSV file from Numista
+ */
+const importNumistaCsv = (file) => {
+  try {
+    Papa.parse(file, {
+      header: true,
+      skipEmptyLines: true,
+      complete: function(results) {
+        const imported = [];
+        const skippedDetails = [];
+        const totalRows = results.data.length;
+        startImportProgress(totalRows);
+        let processed = 0;
+        let importedCount = 0;
+
+        for (const [index, row] of results.data.entries()) {
+          processed++;
+
+          const numistaId = (row['N# number'] || '').toString().trim();
+          const title = (row['Title'] || '').trim();
+          const year = (row['Year'] || '').trim();
+          const name = year.length >= 4 ? `${title} ${year}`.trim() : title;
+          const issuedYear = year.length >= 4 ? year : '';
+          const metal = (row['Metal'] || 'Silver').trim();
+          const qty = parseInt(row['Quantity'] || row['Qty'] || 1, 10);
+
+          const type = mapNumistaType(row['Type'] || '');
+
+          const weightCols = Object.keys(row).filter(k => k.toLowerCase().includes('weight'));
+          let weightGrams = 0;
+          for (const col of weightCols) {
+            const val = parseFloat(String(row[col]).replace(/[^0-9.]/g, ''));
+            if (!isNaN(val)) weightGrams = Math.max(weightGrams, val);
+          }
+          const weight = gramsToOzt(weightGrams);
+
+          const priceKey = Object.keys(row).find(k => k.startsWith('Buying price'));
+          let price = 0;
+          if (priceKey) {
+            const currencyMatch = priceKey.match(/\(([^)]+)\)/);
+            const currency = currencyMatch ? currencyMatch[1] : 'USD';
+            const amount = parseFloat(String(row[priceKey]).replace(/[^0-9.\-]/g, ''));
+            price = convertToUsd(amount, currency);
+          }
+
+          const purchaseLocRaw = row['Acquisition place'];
+          const purchaseLocation = purchaseLocRaw && purchaseLocRaw.trim() ? purchaseLocRaw.trim() : 'unknown';
+          const storageLocRaw = row['Storage location'];
+          const storageLocation = storageLocRaw && storageLocRaw.trim() ? storageLocRaw.trim() : 'unknown';
+
+          const dateStr = row['Acquisition date'] && row['Acquisition date'].trim() ? row['Acquisition date'].trim() : todayStr();
+          const date = parseDate(dateStr);
+
+          const baseNote = (row['Note'] || row['Notes'] || '').trim();
+          const notes = `${baseNote ? baseNote + ' ' : ''}(Imported from Numista.com [${numistaId}])`;
+
+          const isCollectable = false;
+          const spotPriceAtPurchase = spotPrices[metal.toLowerCase()] || 0;
+          const premiumPerOz = weight ? price / weight - spotPriceAtPurchase : 0;
+          const totalPremium = premiumPerOz * qty * weight;
+
+          const itemToValidate = {
+            metal,
+            name,
+            qty,
+            type,
+            weight,
+            price,
+            date,
+            purchaseLocation,
+            storageLocation,
+            notes,
+            spotPriceAtPurchase,
+            premiumPerOz,
+            totalPremium,
+            isCollectable,
+            numistaId,
+            issuedYear
+          };
+
+          const validation = validateInventoryItem(itemToValidate);
+          if (!validation.isValid) {
+            const reason = validation.errors.join(', ');
+            skippedDetails.push(`Row ${index + 2}: ${reason}`);
+            updateImportProgress(processed, importedCount, totalRows);
+            continue;
+          }
+
+          imported.push(itemToValidate);
+          importedCount++;
+          updateImportProgress(processed, importedCount, totalRows);
+        }
+
+        for (const err of results.errors) {
+          skippedDetails.push(`Row ${err.row + 1}: ${err.message}`);
+        }
+
+        endImportProgress();
+
+        if (skippedDetails.length > 0) {
+          alert('Skipped entries:\n' + skippedDetails.join('\n'));
+        }
+
+        if (imported.length === 0) return alert('No valid items to import.');
+
+        let msg = 'Replace current inventory with imported file?';
+        if (skippedDetails.length > 0) msg += `\n(${skippedDetails.length} rows skipped)`;
+
+        if (confirm(msg)) {
+          inventory = imported;
+          saveInventory();
+          renderTable();
+          if (typeof updateStorageStats === 'function') {
+            updateStorageStats();
+          }
+        }
+      },
+      error: function(error) {
+        endImportProgress();
+        handleError(error, 'Numista CSV import');
+      }
+    });
+  } catch (error) {
+    endImportProgress();
+    handleError(error, 'Numista CSV import initialization');
+  }
+};
+
+/**
  * Exports current inventory to CSV format
  */
 const exportCsv = () => {

--- a/js/utils.js
+++ b/js/utils.js
@@ -309,6 +309,42 @@ const sanitizeHtml = (text) => {
 };
 
 /**
+ * Converts grams to troy ounces
+ *
+ * @param {number} grams - Weight in grams
+ * @returns {number} Weight in troy ounces
+ */
+const gramsToOzt = (grams) => grams / 31.1034768;
+
+/**
+ * Converts amount from specified currency to USD using static rates
+ *
+ * @param {number} amount - Monetary amount
+ * @param {string} [currency="USD"] - Currency code of amount
+ * @returns {number} Amount converted to USD
+ */
+const convertToUsd = (amount, currency = "USD") => {
+  const rates = { USD: 1, EUR: 1.08, GBP: 1.27, CAD: 0.74 };
+  const rate = rates[currency.toUpperCase()] || 1;
+  return amount * rate;
+};
+
+/**
+ * Maps Numista type strings to internal StackTrackr categories
+ *
+ * @param {string} type - Numista type string
+ * @returns {string} Mapped internal type
+ */
+const mapNumistaType = (type = "") => {
+  const t = type.toLowerCase();
+  if (t.includes("aurum")) return "Aurum";
+  if (t.includes("note")) return "Notes";
+  if (t.includes("bar") || t.includes("round")) return "bars/rounds";
+  if (t.includes("coin")) return "coin";
+  return "other";
+};
+
+/**
  * Saves data to localStorage with JSON serialization
  *
  * @param {string} key - Storage key


### PR DESCRIPTION
## Summary
- support importing Numista CSV exports with field mapping
- add utilities for weight conversion, currency conversion and type mapping
- document new utilities in FUNCTIONSTABLE

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check js/utils.js`
- `node --check js/inventory.js`


------
https://chatgpt.com/codex/tasks/task_e_689916b36a38832ea9666b4d88efb77d