### PR TITLE
feat: add Numista CSV export

### DIFF
--- a/docs/FUNCTIONSTABLE.md
+++ b/docs/FUNCTIONSTABLE.md
@@ -101,6 +101,7 @@
 | inventory.js | endImportProgress |  |
 | inventory.js | importCsv | Imports inventory data from CSV file with comprehensive validation and error handling |
 | inventory.js | importNumistaCsv | Imports inventory data from a Numista CSV export |
+| inventory.js | exportNumistaCsv | Exports inventory data to Numista-compatible CSV format |
 | inventory.js | exportCsv | Exports current inventory to CSV format |
 | inventory.js | importJson | Imports inventory data from JSON file |
 | inventory.js | exportJson | Exports current inventory to JSON format |

--- a/js/events.js
+++ b/js/events.js
@@ -899,6 +899,14 @@ const setupEventListeners = () => {
         "PDF export",
       );
     }
+    if (elements.numistaExportBtn) {
+      safeAttachListener(
+        elements.numistaExportBtn,
+        "click",
+        exportNumistaCsv,
+        "Numista CSV export",
+      );
+    }
     if (elements.cloudSyncBtn) {
       safeAttachListener(
         elements.cloudSyncBtn,

--- a/js/init.js
+++ b/js/init.js
@@ -94,6 +94,7 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.exportJsonBtn = safeGetElement("exportJsonBtn");
     elements.exportExcelBtn = safeGetElement("exportExcelBtn");
     elements.exportPdfBtn = safeGetElement("exportPdfBtn");
+    elements.numistaExportBtn = safeGetElement("numistaExportBtn");
     elements.cloudSyncBtn = safeGetElement("cloudSyncBtn");
     elements.syncAllBtn = safeGetElement("syncAllBtn");
     elements.boatingAccidentBtn = safeGetElement("boatingAccidentBtn");

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1243,6 +1243,69 @@ const importNumistaCsv = (file) => {
 };
 
 /**
+ * Exports inventory data to a Numista compatible CSV format
+ */
+const exportNumistaCsv = () => {
+  const timestamp = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+  const headers = [
+    'N# number',
+    'Title',
+    'Year',
+    'Metal',
+    'Quantity',
+    'Type',
+    'Weight (g)',
+    'Buying price (USD)',
+    'Acquisition place',
+    'Storage location',
+    'Acquisition date',
+    'Note'
+  ];
+
+  const sortedInventory = sortInventoryByDateNewestFirst();
+  const rows = [];
+
+  for (const item of sortedInventory) {
+    let title = item.name || '';
+    let year = item.issuedYear || '';
+    if (year) {
+      const yearRegex = new RegExp(`\\s*${year}\\b`);
+      title = title.replace(yearRegex, '').trim();
+    }
+
+    const weightGrams = parseFloat(item.weight)
+      ? parseFloat(item.weight) * 31.1034768
+      : 0;
+
+    rows.push([
+      item.numistaId || '',
+      title,
+      year,
+      item.metal || '',
+      item.qty || '',
+      item.type || '',
+      weightGrams ? weightGrams.toFixed(2) : '',
+      item.price ? Number(item.price).toFixed(2) : '',
+      item.purchaseLocation || '',
+      item.storageLocation || '',
+      item.date || '',
+      item.notes || ''
+    ]);
+  }
+
+  const csv = Papa.unparse([headers, ...rows]);
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `numista_export_${timestamp}.csv`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+};
+
+/**
  * Exports current inventory to CSV format
  */
 const exportCsv = () => {

--- a/js/state.js
+++ b/js/state.js
@@ -72,6 +72,7 @@ const elements = {
   exportJsonBtn: null,
   exportExcelBtn: null,
   exportPdfBtn: null,
+  numistaExportBtn: null,
   cloudSyncBtn: null,
   syncAllBtn: null,
   


### PR DESCRIPTION
## Summary
- add `exportNumistaCsv` to build Numista-compatible CSV exports
- wire up Numista export button in Files modal
- document new export function in function table

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/inventory.js`
- `node --check js/events.js`
- `node --check js/init.js`
- `node --check js/state.js`


------
https://chatgpt.com/codex/tasks/task_e_689919d3e6dc832e9cd91c6adbd8db72