### PR TITLE
feat: add custom mapping prototype

### DIFF
--- a/docs/custom-mapping-rule-engine.md
+++ b/docs/custom-mapping-rule-engine.md
@@ -1,0 +1,29 @@
+# Custom Mapping Rule Engine Prototype
+
+This document outlines the initial design for a client‑side rule engine that maps
+incoming field names to StackTrackr's internal schema.
+
+## Design Overview
+- **Goal:** Allow users to define mapping rules using regular expressions.
+- **Approach:** Implement a lightweight module (`js/customMapping.js`) that stores
+  rules in memory. Each rule contains a regex and the target field name.
+- **Usage:** Prototype buttons in the Settings → Custom Mapping card prompt the
+  user for a regex and field, store the rule, and log existing mappings.
+
+## Research Notes
+- Evaluated client‑side rules frameworks such as
+  [json-rules-engine](https://github.com/CacheControl/json-rules-engine) and
+  [RuleJS](https://github.com/NorthwoodsSoftware/RuleJS). These libraries offer
+  powerful expression parsing but introduce significant payload size and
+  complexity for the simple mapping use case.
+- Given project constraints (no build step, minimal dependencies), a custom
+  implementation was chosen for the prototype.
+
+## Limitations
+- Rules exist only in memory; they are not persisted to `localStorage` yet.
+- No validation UI for regex patterns—invalid expressions are caught and logged.
+- Mappings apply only when manually triggered via the prototype buttons.
+- Conflicting or overlapping regex patterns are resolved by first match only.
+
+Future work may include persistent storage, UI for managing rule sets, and
+integration with import workflows.

--- a/index.html
+++ b/index.html
@@ -1445,7 +1445,14 @@
 
           <div class="settings-section">
             <h3>Custom Mapping</h3>
-            <p class="settings-subtext">Custom mapping feature coming soon.</p>
+            <p class="settings-subtext">Define regex rules to map imported fields.</p>
+            <div class="third-party-block">
+              <div class="import-export-grid">
+                <button class="btn" id="addMappingBtn">Add Mapping</button>
+                <button class="btn" id="applyMappingsBtn">Apply Mappings</button>
+                <button class="btn" id="clearMappingsBtn">Clear Mappings</button>
+              </div>
+            </div>
           </div>
 
           <div class="settings-section boating-accident-section">
@@ -1888,6 +1895,7 @@
     <script defer src="./js/api.js"></script>
     <script defer src="./js/inventory.js"></script>
     <script defer src="./js/about.js"></script>
+    <script defer src="./js/customMapping.js"></script>
     <script defer src="./js/events.js"></script>
     <script defer src="./js/init.js"></script>
   </body>

--- a/js/customMapping.js
+++ b/js/customMapping.js
@@ -1,0 +1,67 @@
+/**
+ * Custom Mapping Module
+ * Provides a simple regex-based rule engine for mapping imported
+ * field names to application fields.
+ */
+
+/**
+ * @typedef {Object} MappingRule
+ * @property {RegExp} regex Pattern to match against field names
+ * @property {string} field Target field identifier
+ */
+
+const CustomMapping = (() => {
+  /** @type {MappingRule[]} */
+  let mappings = [];
+
+  /**
+   * Adds a new mapping rule.
+   * @param {string} pattern Regex pattern as a string
+   * @param {string} field Field name to map to
+   * @returns {void}
+   */
+  function addMapping(pattern, field) {
+    try {
+      const regex = new RegExp(pattern, "i");
+      mappings.push({ regex, field });
+    } catch (error) {
+      console.warn("Invalid regex pattern:", pattern, error);
+    }
+  }
+
+  /**
+   * Attempts to map an input field name using stored rules.
+   * @param {string} name Field name to test
+   * @returns {string|null} Mapped field or null if no rule matches
+   */
+  function mapField(name) {
+    for (const rule of mappings) {
+      if (rule.regex.test(name)) {
+        return rule.field;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Removes all custom mapping rules.
+   * @returns {void}
+   */
+  function clear() {
+    mappings = [];
+  }
+
+  /**
+   * Returns a simplified view of current mappings.
+   * @returns {Array<{regex:string, field:string}>}
+   */
+  function list() {
+    return mappings.map((m) => ({ regex: m.regex.toString(), field: m.field }));
+  }
+
+  return { addMapping, mapField, clear, list };
+})();
+
+// Expose globally for prototype UI hooks
+window.CustomMapping = CustomMapping;
+

--- a/js/events.js
+++ b/js/events.js
@@ -919,6 +919,45 @@ const setupEventListeners = () => {
       );
     }
 
+    // Custom mapping buttons
+    if (elements.addMappingBtn) {
+      safeAttachListener(
+        elements.addMappingBtn,
+        "click",
+        () => {
+          const pattern = prompt("Enter regex pattern to match:");
+          const field = prompt("Enter field name to map to:");
+          if (pattern && field) {
+            CustomMapping.addMapping(pattern, field);
+            alert(`Mapping added: ${pattern} → ${field}`);
+          }
+        },
+        "Add custom mapping",
+      );
+    }
+    if (elements.applyMappingsBtn) {
+      safeAttachListener(
+        elements.applyMappingsBtn,
+        "click",
+        () => {
+          console.log("Custom mappings:", CustomMapping.list());
+          alert("Mappings applied. Check console for details.");
+        },
+        "Apply custom mappings",
+      );
+    }
+    if (elements.clearMappingsBtn) {
+      safeAttachListener(
+        elements.clearMappingsBtn,
+        "click",
+        () => {
+          CustomMapping.clear();
+          alert("Custom mappings cleared.");
+        },
+        "Clear custom mappings",
+      );
+    }
+
     const cloudSyncCloseBtn = document.getElementById("cloudSyncCloseBtn");
     if (cloudSyncCloseBtn && elements.cloudSyncModal) {
       safeAttachListener(

--- a/js/init.js
+++ b/js/init.js
@@ -97,6 +97,9 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.numistaExportBtn = safeGetElement("numistaExportBtn");
     elements.cloudSyncBtn = safeGetElement("cloudSyncBtn");
     elements.syncAllBtn = safeGetElement("syncAllBtn");
+    elements.addMappingBtn = safeGetElement("addMappingBtn");
+    elements.applyMappingsBtn = safeGetElement("applyMappingsBtn");
+    elements.clearMappingsBtn = safeGetElement("clearMappingsBtn");
     elements.boatingAccidentBtn = safeGetElement("boatingAccidentBtn");
 
     // Modal elements

--- a/js/state.js
+++ b/js/state.js
@@ -75,7 +75,12 @@ const elements = {
   numistaExportBtn: null,
   cloudSyncBtn: null,
   syncAllBtn: null,
-  
+
+  // Custom mapping buttons
+  addMappingBtn: null,
+  applyMappingsBtn: null,
+  clearMappingsBtn: null,
+
   // Emergency reset button
   boatingAccidentBtn: null,
 


### PR DESCRIPTION
## Summary
- add settings card for user-defined field mapping
- implement simple regex-based mapping engine
- document design considerations and limitations

## Testing
- `node --check js/customMapping.js`
- `node --check js/events.js`
- `node --check js/init.js`
- `node --check js/state.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68991d754eb8832e8f60b87fe6fdf272