### PR TITLE
docs: add human workflow overview

### DIFF
--- a/docs/HUMAN_WORKFLOW.md
+++ b/docs/HUMAN_WORKFLOW.md
@@ -1,0 +1,29 @@
+# Human Developer Workflow
+
+This guide summarizes the typical tools and branch strategy for human contributors to StackTrackr.
+
+## Tools
+
+### Sublime Text & GitHub Desktop (macOS)
+- Edit repository files locally with **Sublime Text**.
+- Use the **GitHub Desktop app** on macOS to stage, commit, and sync changes.
+
+### Claude.ai Local Folder Access
+- Utilize **Claude.ai's local file access** to browse documentation or code for quick references.
+
+### OpenAI Codex Integration
+- **Codex** connects directly to the main repository when deeper code generation or analysis is required.
+
+## Branch Usage
+
+- **`main`** – primary development branch containing the latest features.
+- **`cloudflare`** – deployment branch tuned for Cloudflare hosting.
+- **`release_v*`** – versioned release branches (e.g., `release_v3.03.02a`).
+
+## Hosting URLs
+
+- **Production**: [https://stacktrackr.com](https://stacktrackr.com)
+- **Cloudflare Preview**: [https://stacktrackr.pages.dev](https://stacktrackr.pages.dev) *(used for Cloudflare deployments)*
+- **Source Repository**: [https://github.com/lbruton/StackTrackr](https://github.com/lbruton/StackTrackr)
+
+For overall development workflow, see [docs/MULTI_AGENT_WORKFLOW.md](MULTI_AGENT_WORKFLOW.md).


### PR DESCRIPTION
## Summary
- document human developer tools such as Sublime Text, GitHub Desktop, Claude.ai, and Codex
- outline branch usage for `main`, `cloudflare`, and `release_v*`
- list hosting URLs for production, Cloudflare preview, and the GitHub repo

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899216a8cac832ead45dc09168260d8