### PR TITLE
chore: archive build and set version 3.03.02a

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
-# StackTrackr v3.03.03a
+# StackTrackr v3.03.02a
 
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
 
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
-- **v3.03.03a - Archive Workflow Update**: Archived previous build and added rollback footer link requirement
-- **v3.03.02a - Versioning Guide Refinement**: Introduced BRANCH.RELEASE.PATCH.state naming and clarified pre-release codes
+- **v3.03.02a - Archive Workflow Update**: Archived previous build and added rollback footer link requirement; clarified BRANCH.RELEASE.PATCH.state naming and pre-release codes
 - **v3.03.01a - Comprehensive Storage Report System**: Redesigned storage reports with top-five pie chart visualization and scrollable legend
 - **v3.00.00 - Stable Release & Documentation Cleanup**: Finalized documentation and archived planning notes
 - **v3.2.07rc - Spot Timestamp Source Display**: Spot price cards now show the API provider or Manual entry along with the exact timestamp of the last update
@@ -25,10 +24,8 @@ The public hosted version of the app is available at [stackrtrackr.com](https://
 - **v3.1.8 - Backup System**: Full ZIP backup functionality with restoration guides
 - **v3.1.6 - Theme Toggle**: Fixed theme management with system preference detection
 
-## 🆕 What's New in v3.03.03a
-- Archived previous build and added rollback footer link requirement
-
 ## 🆕 What's New in v3.03.02a
+- Archived previous build and added rollback footer link requirement
 - Clarified version naming scheme and state codes
 
 ## 🆕 What's New in v3.03.01a
@@ -264,7 +261,7 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: 3.03.03a
+**Current Version**: 3.03.02a
 **Last Updated**: August 9, 2025
 **Status**: Feature complete release candidate
 

--- a/archive/previous/js/constants.js
+++ b/archive/previous/js/constants.js
@@ -95,9 +95,9 @@ const API_PROVIDERS = {
 /**
  * @constant {string} APP_VERSION - Application version
  * Follows BRANCH.RELEASE.PATCH.state format
- * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
+ * Example: 3.03.03a → branch 3, release 03, patch 02, alpha
  */
-const APP_VERSION = "3.03.02a";
+const APP_VERSION = "3.03.03a";
 
 /** @constant {string} BRANDING_TITLE - Optional custom application title */
 const BRANDING_TITLE = "StackTrackr";

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,11 +8,9 @@
 
 ## 📋 Version History
 
-### Version 3.03.03a – Archive Workflow Update (2025-08-10)
+### Version 3.03.02a – Archive Workflow & Versioning Guide (2025-08-10)
 - Archived previous build to `archive/previous`
 - Added archived footer link back to root and updated workflow checklist
-
-### Version 3.03.02a – Versioning Guide Refinement (2025-08-10)
 - Clarified BRANCH.RELEASE.PATCH.state version scheme
 - Documented pre-release state codes and branching policy
 

--- a/docs/HUMAN_WORKFLOW.md
+++ b/docs/HUMAN_WORKFLOW.md
@@ -18,7 +18,7 @@ This guide summarizes the typical tools and branch strategy for human contributo
 
 - **`main`** – primary development branch containing the latest features.
 - **`cloudflare`** – deployment branch tuned for Cloudflare hosting.
-- **`release_v*`** – versioned release branches (e.g., `release_v3.03.03a`).
+- **`release_v*`** – versioned release branches (e.g., `release_v3.03.02a`).
 
 ## Hosting URLs
 

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,10 +1,10 @@
-# Multi-Agent Development Workflow - StackTrackr v3.03.03a
+# Multi-Agent Development Workflow - StackTrackr v3.03.02a
 
 ## 🎯 Project Overview
 
-You are contributing to the **StackTrackr v3.03.03a**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to the **StackTrackr v3.03.02a**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.03.03a (alpha)
+**Current Status**: v3.03.02a (alpha)
 **Your Role**: Complete individual 2-hour subtasks as part of a coordinated multi-agent development effort
 
 ---
@@ -306,6 +306,6 @@ Before starting ANY subtask, read these files:
 
 ---
 
-**Remember: Each subtask is designed to be completed independently while contributing to the larger v3.03.03a vision. Focus on quality over speed, and don't hesitate to coordinate with other agents when working on shared components.**
+**Remember: Each subtask is designed to be completed independently while contributing to the larger v3.03.02a vision. Focus on quality over speed, and don't hesitate to coordinate with other agents when working on shared components.**
 
 **Your contribution helps build a professional-grade inventory management system that serves users worldwide. Every subtask matters!** 🚀

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,8 +1,8 @@
 # Project Status - StackTrackr
 
-## 🎯 Current State: **ALPHA v3.03.03a** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **ALPHA v3.03.02a** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.03.03a** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.03.02a** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
 
 ## 🏗️ Architecture Overview
 
@@ -20,8 +20,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
-- **v3.03.03a - Archive Workflow Update**: Archived previous build and added rollback footer link requirement
-- **v3.03.02a - Versioning Guide Refinement**: Introduced BRANCH.RELEASE.PATCH.state naming and clarified pre-release codes
+- **v3.03.02a - Archive Workflow & Versioning Guide Update**: Archived previous build and added rollback footer link requirement; clarified BRANCH.RELEASE.PATCH.state naming and pre-release codes
 - **v3.03.01a - Comprehensive Storage Report System**: Redesigned storage reports from basic JSON to professional HTML system
   - Professional HTML reports optimized for letter paper printing
   - Interactive modals with detailed breakdowns for each storage item
@@ -122,7 +121,7 @@ All data is stored locally in the browser using localStorage with:
 
 **All documentation files are current and synchronized:**
 - ✅ **STATUS.md** - Updated for v3.00.00 release
-- ✅ **CHANGELOG.md** - Current through v3.03.03a
+- ✅ **CHANGELOG.md** - Current through v3.03.02a
 - ✅ **MULTI_AGENT_WORKFLOW.md** - Comprehensive AI assistant development guide
 - ✅ **STRUCTURE.md** - Reflects streamlined project organization
 - ✅ **VERSIONING.md** - Accurate version management documentation
@@ -131,7 +130,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.03.03a (managed in `js/constants.js`)
+1. **Current Version**: 3.03.02a (managed in `js/constants.js`)
 2. **Last Change**: Comprehensive HTML storage report system with interactive modals and print optimization
 3. **Last Documentation Update**: August 10, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns
@@ -148,7 +147,7 @@ If continuing development in a new chat session:
 ```
 StackTrackr/
 ├── js/                     # Modular JavaScript (cleaned structure)
-│   ├── constants.js        # Version 3.03.03a + metal configs
+│   ├── constants.js        # Version 3.03.02a + metal configs
 │   ├── state.js           # App state + DOM caching
 │   ├── inventory.js       # Core CRUD + notes handling
 │   ├── events.js          # UI event listeners

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -7,7 +7,7 @@ The StackTrackr now uses a dynamic version management system that automatically 
 ## How It Works
 
 ### Single Source of Truth
-- Version is defined once in `js/constants.js` as `APP_VERSION = '3.03.03a'`
+- Version is defined once in `js/constants.js` as `APP_VERSION = '3.03.02a'`
   - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation
@@ -27,14 +27,14 @@ To release a new version:
 1. **Update ONLY the constants file:**
    ```javascript
    // In js/constants.js
-   const APP_VERSION = '3.03.03a';  // Change this line only
+   const APP_VERSION = '3.03.02a';  // Change this line only
    ```
 
 2. **All these will automatically update:**
-   - Page title: "StackTrackr v3.03.03a"
-   - Page heading: "StackTrackr v3.03.03a"
-   - Browser tab title: "StackTrackr v3.03.03a"
-   - App header: "StackTrackr v3.03.03a"
+   - Page title: "StackTrackr v3.03.02a"
+   - Page heading: "StackTrackr v3.03.02a"
+   - Browser tab title: "StackTrackr v3.03.02a"
+   - App header: "StackTrackr v3.03.02a"
 
 3. **Update changelog:** Add entry to `/docs/CHANGELOG.md` for documentation
 
@@ -68,7 +68,7 @@ StackTrackr versions follow the `BRANCH.RELEASE.PATCH.state` pattern:
   - `rc` = release candidate
   - *(omit for stable builds)*
 
-Example: `3.03.03a` → branch 3, release 03, patch 02, alpha build
+Example: `3.03.02a` → branch 3, release 03, patch 02, alpha build
 
 ### Branching Policy
 - Each major **BRANCH** is developed on its own long-lived branch
@@ -78,15 +78,15 @@ Example: `3.03.03a` → branch 3, release 03, patch 02, alpha build
 ## Example Usage in Code
 ```javascript
 // Get just the version number
-const version = APP_VERSION; // "3.03.03a"
+const version = APP_VERSION; // "3.03.02a"
 
 // Get formatted version string
-const versionString = getVersionString(); // "v3.03.03a"
-const customVersion = getVersionString('version '); // "version 3.03.03a"
+const versionString = getVersionString(); // "v3.03.02a"
+const customVersion = getVersionString('version '); // "version 3.03.02a"
 
 // Get full app title
-const title = getAppTitle(); // "StackTrackr v3.03.03a"
-const customTitle = getAppTitle('My Custom Tool'); // "My Custom Tool v3.03.03a"
+const title = getAppTitle(); // "StackTrackr v3.03.02a"
+const customTitle = getAppTitle('My Custom Tool'); // "My Custom Tool v3.03.02a"
 ```
 
 This system ensures version consistency and makes maintenance much easier!

--- a/docs/future/TURSO_SYNC_PLAN.md
+++ b/docs/future/TURSO_SYNC_PLAN.md
@@ -1,6 +1,6 @@
 # Turso Cloud Sync Implementation Plan
 
-**StackTrackr v3.2.05rc → v3.03.03a**
+**StackTrackr v3.2.05rc → v3.03.02a**
 **Date**: August 10, 2025  
 **Scope**: Provider-agnostic cloud sync system with Turso as first implementation
 
@@ -884,5 +884,5 @@ PLANETSCALE: {
 ---
 
 **Status**: Ready for implementation  
-**Target Version**: v3.03.03a
+**Target Version**: v3.03.02a
 **Priority**: High - Foundation for future premium features

--- a/js/constants.js
+++ b/js/constants.js
@@ -95,9 +95,9 @@ const API_PROVIDERS = {
 /**
  * @constant {string} APP_VERSION - Application version
  * Follows BRANCH.RELEASE.PATCH.state format
- * Example: 3.03.03a → branch 3, release 03, patch 02, alpha
+ * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
-const APP_VERSION = "3.03.03a";
+const APP_VERSION = "3.03.02a";
 
 /** @constant {string} BRANDING_TITLE - Optional custom application title */
 const BRANDING_TITLE = "StackTrackr";

--- a/structure.md
+++ b/structure.md
@@ -1,6 +1,6 @@
 # StackTrackr - Project Structure
 
-## Current Structure (Version 3.03.03a)
+## Current Structure (Version 3.03.02a)
 
 ```text
 ├── css/


### PR DESCRIPTION
## Summary
- set APP_VERSION to v3.03.02a
- archive prior build and keep rollback link
- update changelog and docs to match

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899262e1cf4832ea482b4235805af1f