### PR TITLE
docs: add v3.03.06a roadmap entry

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,5 +1,10 @@
 # StackTrackr - Development Roadmap
 
+## 🔄 Patch Release Roadmap
+
+- **v3.03.05a - Column Visibility Refinement**: Fine-tune mobile column hiding rules for clarity.
+- **v3.03.06a - Responsive Inventory Table**: Implement a fully responsive inventory table that adapts layout to screen size.
+
 ## 🎯 Milestone: Version 3.5.0
 **Target: Complete UI reorganization, enhanced data management, and multi-currency support**
 


### PR DESCRIPTION
## Summary
- add patch release roadmap section
- document v3.03.06a with responsive inventory table goal

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68992bae3bcc832ea6c7dc6472574d1f