### PR TITLE
feat: replace appearance modal with theme toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,14 +77,6 @@
         <button class="btn" id="apiBtn" title="API" aria-label="API">
           API 🔌
         </button>
-        <button
-          class="btn"
-          id="appearanceBtn"
-          title="Appearance"
-          aria-label="Appearance"
-        >
-          Appearance 🎨
-        </button>
         <a
           class="btn"
           id="communityBtn"
@@ -104,6 +96,12 @@
         <button class="btn" id="filesBtn" title="Files" aria-label="Files">
           Files 📁
         </button>
+        <button
+          class="btn theme-btn"
+          id="appearanceBtn"
+          title="Theme"
+          aria-label="Theme"
+        ></button>
       </div>
     </div>
     <div class="container">
@@ -1293,35 +1291,6 @@
     </div>
     <!-- =============================================================================
        ============================================================================= -->
-
-    <div class="modal" id="appearanceModal" style="display: none">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h2>Appearance</h2>
-          <button
-            aria-label="Close modal"
-            class="modal-close"
-            id="appearanceCloseBtn"
-          >
-            ×
-          </button>
-        </div>
-        <div class="modal-body">
-          <div class="settings-section">
-            <h3>Appearance</h3>
-            <p class="settings-subtext">Set your default preference.</p>
-            <div class="theme-buttons">
-              <button class="btn theme-btn dark" id="darkModeBtn">Dark Mode</button>
-              <button class="btn theme-btn light" id="lightModeBtn">Light Mode</button>
-              <button class="btn theme-btn system" id="systemModeBtn">
-                Follow System
-              </button>
-              <div class="theme-display" id="themeDisplay"></div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
 
     <div class="modal" id="apiModal" style="display: none">
       <div class="modal-content">

--- a/js/events.js
+++ b/js/events.js
@@ -303,63 +303,6 @@ const setupEventListeners = () => {
       );
     }
 
-    // Appearance Button
-    if (elements.appearanceBtn) {
-      safeAttachListener(
-        elements.appearanceBtn,
-        "click",
-        (e) => {
-          e.preventDefault();
-          if (typeof showAppearanceModal === "function") {
-            showAppearanceModal();
-          }
-        },
-        "Appearance Button",
-      );
-    }
-
-    // Theme buttons
-    const themeDisplay = document.getElementById("themeDisplay");
-    const updateThemeDisplay = (label) => {
-      if (themeDisplay) themeDisplay.textContent = label;
-    };
-
-    const darkBtn = document.getElementById("darkModeBtn");
-    if (darkBtn) {
-      safeAttachListener(
-        darkBtn,
-        "click",
-        () => {
-          if (typeof setTheme === "function") setTheme("dark");
-          updateThemeDisplay("Dark Mode");
-        },
-        "Dark mode button",
-      );
-    }
-    const lightBtn = document.getElementById("lightModeBtn");
-    if (lightBtn) {
-      safeAttachListener(
-        lightBtn,
-        "click",
-        () => {
-          if (typeof setTheme === "function") setTheme("light");
-          updateThemeDisplay("Light Mode");
-        },
-        "Light mode button",
-      );
-    }
-    const systemBtn = document.getElementById("systemModeBtn");
-    if (systemBtn) {
-      safeAttachListener(
-        systemBtn,
-        "click",
-        () => {
-          if (typeof setTheme === "function") setTheme("system");
-          updateThemeDisplay("System");
-        },
-        "System mode button",
-      );
-    }
 
     // Details modal triggers
     if (elements.totalTitles && elements.totalTitles.length) {
@@ -1126,34 +1069,6 @@ const setupEventListeners = () => {
       );
     }
 
-    // Appearance modal close handlers
-    const appearanceModal = document.getElementById("appearanceModal");
-    const appearanceCloseBtn = document.getElementById("appearanceCloseBtn");
-    if (appearanceModal) {
-      safeAttachListener(
-        appearanceModal,
-        "click",
-        (e) => {
-          if (
-            e.target === appearanceModal &&
-            typeof hideAppearanceModal === "function"
-          ) {
-            hideAppearanceModal();
-          }
-        },
-        "Appearance modal background",
-      );
-    }
-    if (appearanceCloseBtn) {
-      safeAttachListener(
-        appearanceCloseBtn,
-        "click",
-        () => {
-          if (typeof hideAppearanceModal === "function") hideAppearanceModal();
-        },
-        "Appearance close button",
-      );
-    }
 
     // API MODAL EVENT LISTENERS
     debugLog("Setting up API modal listeners...");
@@ -1312,6 +1227,30 @@ const setupSearch = () => {
 /**
  * Sets up theme toggle event listeners
  */
+const updateThemeButton = () => {
+  const btn = elements.appearanceBtn;
+  if (!btn) return;
+  const savedTheme = localStorage.getItem(THEME_KEY);
+  const mode = savedTheme ? savedTheme : "system";
+  btn.classList.remove("dark", "light", "system");
+  btn.classList.add(mode);
+  if (mode === "dark") {
+    btn.textContent = "🌙";
+    btn.setAttribute("aria-label", "Dark mode");
+    btn.setAttribute("title", "Dark mode");
+  } else if (mode === "light") {
+    btn.textContent = "☀️";
+    btn.setAttribute("aria-label", "Light mode");
+    btn.setAttribute("title", "Light mode");
+  } else {
+    btn.textContent = "💻";
+    btn.setAttribute("aria-label", "System theme");
+    btn.setAttribute("title", "System theme");
+  }
+};
+
+window.updateThemeButton = updateThemeButton;
+
 const setupThemeToggle = () => {
   debugLog("Setting up theme toggle...");
 
@@ -1320,14 +1259,45 @@ const setupThemeToggle = () => {
     if (typeof initTheme === "function") {
       initTheme();
     } else {
-      // Fallback initialization
       const savedTheme = localStorage.getItem(THEME_KEY) || "light";
       setTheme(savedTheme);
     }
 
+    updateThemeButton();
+
     // Set up system theme change listener
     if (typeof setupSystemThemeListener === "function") {
       setupSystemThemeListener();
+    }
+
+    if (window.matchMedia) {
+      window
+        .matchMedia("(prefers-color-scheme: dark)")
+        .addEventListener("change", () => {
+          if (!localStorage.getItem(THEME_KEY)) {
+            updateThemeButton();
+          }
+        });
+    }
+
+    if (elements.appearanceBtn) {
+      safeAttachListener(
+        elements.appearanceBtn,
+        "click",
+        (e) => {
+          e.preventDefault();
+          const savedTheme = localStorage.getItem(THEME_KEY);
+          if (savedTheme === "dark") {
+            setTheme("light");
+          } else if (savedTheme === "light") {
+            setTheme("system");
+          } else {
+            setTheme("dark");
+          }
+          updateThemeButton();
+        },
+        "Theme toggle button",
+      );
     }
 
     debugLog("✓ Theme toggle setup complete");
@@ -1650,7 +1620,6 @@ const setupApiEvents = () => {
         if (e.key === "Escape") {
           const filesModal = document.getElementById("filesModal");
           const apiModal = document.getElementById("apiModal");
-          const appearanceModal = document.getElementById("appearanceModal");
           const infoModal = document.getElementById("apiInfoModal");
           const historyModal = document.getElementById("apiHistoryModal");
           const providersModal = document.getElementById("apiProvidersModal");
@@ -1672,12 +1641,6 @@ const setupApiEvents = () => {
             typeof hideApiModal === "function"
           ) {
             hideApiModal();
-          } else if (
-            appearanceModal &&
-            appearanceModal.style.display === "flex" &&
-            typeof hideAppearanceModal === "function"
-          ) {
-            hideAppearanceModal();
           } else if (
             infoModal &&
             infoModal.style.display === "flex" &&


### PR DESCRIPTION
## Summary
- replace appearance modal with header button that cycles dark, light, and system themes
- update theme button icons and classes and apply selection immediately using localStorage
- drop legacy appearance modal references in events

## Testing
- `node --check js/events.js`
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68992f043840832e81ea0dbf1c929868