### PR TITLE
feat: show storage report in modal

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ## 📋 Version History
 
+### Version 3.03.03a – Storage Report Modal (2025-08-10)
+- Storage report now opens within an in-app modal using an iframe, replacing the previous popup window
+
 ### Version 3.03.02a – Archive Workflow & Versioning Guide (2025-08-10)
 - Archived previous build to `archive/previous`
 - Added archived footer link back to root and updated workflow checklist

--- a/docs/FUNCTIONSTABLE.md
+++ b/docs/FUNCTIONSTABLE.md
@@ -153,3 +153,4 @@
 | utils.js | downloadFile | Downloads a file with the specified content and filename |
 | utils.js | updateStorageStats | Updates footer with localStorage usage statistics and progress bar |
 | utils.js | downloadStorageReport | Downloads a report of all localStorage data |
+| utils.js | openStorageReportPopup | Displays storage report HTML in a modal iframe |

--- a/docs/IMPLEMENTATION_SUMMARY.md
+++ b/docs/IMPLEMENTATION_SUMMARY.md
@@ -1,3 +1,31 @@
+# Implementation Summary: Storage Report Modal
+
+## Version Update: 3.03.02a → 3.03.03a
+
+## User Requirements Implemented
+
+- Storage report opens in an in-app modal with iframe instead of a browser popup
+- Added dedicated modal markup with close controls and theme support
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`index.html`**: Added `storageReportModal` with iframe
+2. **`js/events.js`**: Updated storage report link handler and close logic
+3. **`js/utils.js`**: Replaced popup logic with iframe injection
+4. **`js/constants.js`**: Bumped version to 3.03.03a
+5. **Documentation**: Updated `CHANGELOG.md`, `FUNCTIONSTABLE.md`, and `STATUS.md`
+
+### User Experience Improvements:
+- Consistent modal experience without relying on browser popups
+- Report respects current light/dark theme inside iframe
+
+## Testing Recommendations
+
+1. Open storage report from footer link and ensure modal displays report
+2. Verify modal closes via header button, outside click, and ESC key
+3. Toggle theme before opening to confirm iframe reflects current theme
+
 # Implementation Summary: Enhanced API Sync Caching
 
 ## Version Update: 3.1.0 → 3.1.1
@@ -62,7 +90,7 @@
 
 ### Files Modified:
 1. **`app/js/constants.js`**: Updated version to 3.1.1
-2. **`app/js/api.js`**: 
+2. **`app/js/api.js`**:
    - Enhanced `syncSpotPricesFromApi()` with cache checking
    - Added `clearApiCache()` and `refreshFromCache()` functions
    - Updated button state management and tooltips

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,8 +1,8 @@
 # Project Status - StackTrackr
 
-## 🎯 Current State: **ALPHA v3.03.02a** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **ALPHA v3.03.03a** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.03.02a** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.03.03a** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
 
 ## 🏗️ Architecture Overview
 
@@ -20,6 +20,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.03.03a - Storage Report Modal**: Storage report opens in an in-app iframe modal instead of a popup window
 - **v3.03.02a - Responsive Table Columns**: Added viewport-based column hiding and mobile-friendly pagination sizing
 - **v3.03.02a - Archive Workflow & Versioning Guide Update**: Archived previous build and added rollback footer link requirement; clarified BRANCH.RELEASE.PATCH.state naming and pre-release codes
 - **v3.03.01a - Comprehensive Storage Report System**: Redesigned storage reports from basic JSON to professional HTML system
@@ -122,7 +123,7 @@ All data is stored locally in the browser using localStorage with:
 
 **All documentation files are current and synchronized:**
 - ✅ **STATUS.md** - Updated for v3.00.00 release
-- ✅ **CHANGELOG.md** - Current through v3.03.02a
+- ✅ **CHANGELOG.md** - Current through v3.03.03a
 - ✅ **MULTI_AGENT_WORKFLOW.md** - Comprehensive AI assistant development guide
 - ✅ **STRUCTURE.md** - Reflects streamlined project organization
 - ✅ **VERSIONING.md** - Accurate version management documentation
@@ -131,8 +132,8 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.03.02a (managed in `js/constants.js`)
-2. **Last Change**: Comprehensive HTML storage report system with interactive modals and print optimization
+1. **Current Version**: 3.03.03a (managed in `js/constants.js`)
+2. **Last Change**: Storage report displayed in modal iframe, replacing popup window
 3. **Last Documentation Update**: August 10, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns
 5. **Documentation**: Comprehensive JSDoc comments throughout codebase
@@ -148,7 +149,7 @@ If continuing development in a new chat session:
 ```
 StackTrackr/
 ├── js/                     # Modular JavaScript (cleaned structure)
-│   ├── constants.js        # Version 3.03.02a + metal configs
+│   ├── constants.js        # Version 3.03.03a + metal configs
 │   ├── state.js           # App state + DOM caching
 │   ├── inventory.js       # Core CRUD + notes handling
 │   ├── events.js          # UI event listeners

--- a/index.html
+++ b/index.html
@@ -1029,6 +1029,23 @@
             </thead>
             <tbody></tbody>
           </table>
+      </div>
+    </div>
+  </div>
+
+    <!-- =============================================================================
+       STORAGE REPORT MODAL
+
+       Displays the generated storage report inside an iframe for in-app viewing.
+       ============================================================================= -->
+    <div class="modal" id="storageReportModal" style="display: none">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2>Storage Report</h2>
+          <button aria-label="Close modal" class="modal-close" id="storageReportCloseBtn">×</button>
+        </div>
+        <div class="modal-body" style="height: 80vh; padding: 0;">
+          <iframe id="storageReportFrame" style="width: 100%; height: 100%; border: none;"></iframe>
         </div>
       </div>
     </div>

--- a/js/constants.js
+++ b/js/constants.js
@@ -98,7 +98,7 @@ const API_PROVIDERS = {
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
-const APP_VERSION = "3.03.02a";
+const APP_VERSION = "3.03.03a";
 
 /** @constant {string} BRANDING_TITLE - Optional custom application title */
 const BRANDING_TITLE = "StackTrackr";

--- a/js/events.js
+++ b/js/events.js
@@ -675,8 +675,8 @@ const setupEventListeners = () => {
           "click",
           (e) => {
             e.preventDefault();
-            if (typeof downloadStorageReport === "function") {
-              downloadStorageReport();
+            if (typeof openStorageReportPopup === "function") {
+              openStorageReportPopup();
             }
           },
           "Storage report link",
@@ -1628,6 +1628,7 @@ const setupApiEvents = () => {
           const notesModal = document.getElementById("notesModal");
           const detailsModal = document.getElementById("detailsModal");
           const changeLogModal = document.getElementById("changeLogModal");
+          const storageReportModal = document.getElementById("storageReportModal");
 
           if (
             filesModal &&
@@ -1669,6 +1670,9 @@ const setupApiEvents = () => {
           notesIndex = null;
         } else if (changeLogModal && changeLogModal.style.display === "flex") {
           changeLogModal.style.display = "none";
+          document.body.style.overflow = "";
+        } else if (storageReportModal && storageReportModal.style.display === "flex") {
+          storageReportModal.style.display = "none";
           document.body.style.overflow = "";
         } else if (
           detailsModal &&

--- a/js/utils.js
+++ b/js/utils.js
@@ -604,21 +604,39 @@ const downloadStorageReport = () => {
 };
 
 /**
- * Opens a popup window with the storage report HTML
+ * Displays the storage report HTML inside a modal iframe
  */
 const openStorageReportPopup = () => {
   const htmlContent = generateStorageReportHTML();
-  const width = 1000;
-  const height = 800;
-  const left = window.screenX + Math.max(0, (window.innerWidth - width) / 2);
-  const top = window.screenY + Math.max(0, (window.innerHeight - height) / 2);
-  const popup = window.open('', 'storageReport', `width=${width},height=${height},left=${left},top=${top},resizable=yes,scrollbars=yes`);
-  if (popup) {
-    popup.document.write(htmlContent);
-    popup.document.close();
-  } else {
-    alert('Popup blocked. Please allow popups for this site.');
+  const modal = document.getElementById('storageReportModal');
+  const iframe = document.getElementById('storageReportFrame');
+
+  if (!modal || !iframe) {
+    alert('Storage report modal not found.');
+    return;
   }
+
+  iframe.srcdoc = htmlContent;
+
+  const closeBtn = document.getElementById('storageReportCloseBtn');
+
+  const closeModal = () => {
+    modal.style.display = 'none';
+    document.body.style.overflow = '';
+  };
+
+  if (!modal.dataset.initialized) {
+    modal.addEventListener('click', (e) => {
+      if (e.target === modal) closeModal();
+    });
+    if (closeBtn) {
+      closeBtn.addEventListener('click', closeModal);
+    }
+    modal.dataset.initialized = 'true';
+  }
+
+  modal.style.display = 'flex';
+  document.body.style.overflow = 'hidden';
 };
 /**
  * Generates comprehensive HTML storage report with theme support
@@ -2051,3 +2069,4 @@ This archive contains a complete snapshot of your StackTrackr storage data.`;
 // Make storage report functions globally available
 window.updateStorageStats = updateStorageStats;
 window.downloadStorageReport = downloadStorageReport;
+window.openStorageReportPopup = openStorageReportPopup;


### PR DESCRIPTION
## Summary
- show storage report inside in-app modal via iframe
- update storage report link handler and version to 3.03.03a
- document new modal and version

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689931d1bee4832e8401fb6a9401dd00