### PR TITLE
Add storage breakdown progress bar in Files modal

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -261,6 +261,28 @@ section {
   border-radius: var(--radius);
 }
 
+.files-progress {
+  margin-left: var(--spacing-sm);
+  display: flex;
+  width: 150px;
+  height: 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background-color: var(--bg-tertiary);
+}
+
+.files-progress-segment {
+  height: 100%;
+  cursor: pointer;
+  transition: var(--transition);
+}
+
+.files-progress-segment.zoomed {
+  transform: scaleY(1.5);
+  z-index: 1;
+}
+
 section:hover {
   box-shadow: var(--shadow-lg);
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ## 📋 Version History
 
+### Version 3.03.04a – Files Modal Storage Breakdown (2025-08-10)
+- Added progress bar in Files modal showing per-item storage distribution with hover tooltips and click-to-highlight
+
 ### Version 3.03.03a – Storage Report Modal (2025-08-10)
 - Storage report now opens within an in-app modal using an iframe, replacing the previous popup window
 

--- a/docs/FUNCTIONSTABLE.md
+++ b/docs/FUNCTIONSTABLE.md
@@ -98,6 +98,7 @@
 | inventory.js | showNotes | Opens modal to view and edit an item's notes |
 | inventory.js | editItem | Prepares and displays edit modal for specified inventory item |
 | inventory.js | toggleCollectable | Toggles collectable status for inventory item |
+| inventory.js | renderFilesProgress | Renders per-item storage distribution bar in Files modal |
 | inventory.js | startImportProgress |  |
 | inventory.js | updateImportProgress |  |
 | inventory.js | endImportProgress |  |

--- a/docs/IMPLEMENTATION_SUMMARY.md
+++ b/docs/IMPLEMENTATION_SUMMARY.md
@@ -1,3 +1,30 @@
+# Implementation Summary: Files Modal Storage Breakdown
+
+## Version Update: 3.03.03a → 3.03.04a
+
+## User Requirements Implemented
+
+- Added progress bar within Files modal displaying each inventory item's relative storage size with hover tooltips and click highlighting
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`index.html`**: Added Files modal progress bar markup
+2. **`js/inventory.js`**: Implemented `renderFilesProgress` function and color mapping
+3. **`js/api.js`**: Render progress bar when Files modal opens
+4. **`css/styles.css`**: Added `.files-progress` styling
+5. **`js/constants.js`**: Bumped version to 3.03.04a
+6. **Documentation**: Updated `CHANGELOG.md`, `FUNCTIONSTABLE.md`, and `STATUS.md`
+
+### User Experience Improvements:
+- Visualizes per-item storage usage directly in Files modal
+
+## Testing Recommendations
+
+1. Open Files modal and verify progress bar displays colored segments
+2. Hover over segments to see item name and size
+3. Click a segment to highlight it
+
 # Implementation Summary: Storage Report Modal
 
 ## Version Update: 3.03.02a → 3.03.03a

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,8 +1,8 @@
 # Project Status - StackTrackr
 
-## 🎯 Current State: **ALPHA v3.03.03a** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **ALPHA v3.03.04a** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.03.03a** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.03.04a** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
 
 ## 🏗️ Architecture Overview
 
@@ -20,6 +20,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.03.04a - Files Modal Storage Breakdown**: Added progress bar showing per-item storage usage with hover tooltips and click highlighting
 - **v3.03.03a - Storage Report Modal**: Storage report opens in an in-app iframe modal instead of a popup window
 - **v3.03.02a - Responsive Table Columns**: Added viewport-based column hiding and mobile-friendly pagination sizing
 - **v3.03.02a - Archive Workflow & Versioning Guide Update**: Archived previous build and added rollback footer link requirement; clarified BRANCH.RELEASE.PATCH.state naming and pre-release codes

--- a/index.html
+++ b/index.html
@@ -1363,6 +1363,10 @@
           </button>
         </div>
         <div class="modal-body">
+          <div class="storage-line">
+            Storage Breakdown:
+            <div class="files-progress" id="filesProgress"></div>
+          </div>
           <div class="settings-section">
             <h3>Import</h3>
             <p class="settings-subtext">Import your data files.</p>

--- a/js/api.js
+++ b/js/api.js
@@ -1192,6 +1192,9 @@ const showFilesModal = () => {
   const modal = document.getElementById("filesModal");
   if (modal) {
     modal.style.display = "flex";
+    if (typeof renderFilesProgress === "function") {
+      renderFilesProgress();
+    }
   }
 };
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -98,7 +98,7 @@ const API_PROVIDERS = {
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
-const APP_VERSION = "3.03.03a";
+const APP_VERSION = "3.03.04a";
 
 /** @constant {string} BRANDING_TITLE - Optional custom application title */
 const BRANDING_TITLE = "StackTrackr";

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -493,6 +493,7 @@ const METAL_COLORS = {
 const typeColors = {};
 const purchaseLocationColors = {};
 const storageLocationColors = {};
+const filesProgressColors = {};
 
 const getColor = (map, key) => {
   if (!map[key]) {
@@ -514,6 +515,36 @@ const filterLink = (field, value, color) => {
 const getTypeColor = type => getColor(typeColors, type);
 const getPurchaseLocationColor = loc => getColor(purchaseLocationColors, loc);
 const getStorageLocationColor = loc => getColor(storageLocationColors, loc);
+
+/**
+ * Renders inventory storage distribution progress bar
+ * showing each item's relative localStorage size
+ */
+const renderFilesProgress = () => {
+  const container = document.getElementById('filesProgress');
+  if (!container) return;
+  container.innerHTML = '';
+  if (inventory.length === 0) return;
+
+  const sizes = inventory.map(item => ({
+    item,
+    size: JSON.stringify(item).length * 2,
+  }));
+  const total = sizes.reduce((sum, s) => sum + s.size, 0);
+
+  sizes.forEach(({ item, size }) => {
+    const segment = document.createElement('div');
+    segment.className = 'files-progress-segment';
+    segment.style.width = `${(size / total) * 100}%`;
+    segment.style.backgroundColor = getColor(filesProgressColors, item.name);
+    segment.title = `${item.name}: ${(size / 1024).toFixed(1)} KB`;
+    segment.addEventListener('click', () => {
+      container.querySelectorAll('.files-progress-segment').forEach(seg => seg.classList.remove('zoomed'));
+      segment.classList.add('zoomed');
+    });
+    container.appendChild(segment);
+  });
+};
 
 const renderTable = () => {
   return monitorPerformance(() => {
@@ -1778,3 +1809,4 @@ window.toggleCollectable = toggleCollectable;
 window.editItem = editItem;
 window.deleteItem = deleteItem;
 window.showNotes = showNotes;
+window.renderFilesProgress = renderFilesProgress;


### PR DESCRIPTION
## Summary
- add storage breakdown progress bar within Files modal
- compute and render per-item storage usage segments with hover tooltips
- style new `.files-progress` classes for dark and light themes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689936904848832ea2ee5e90a056ab32