### PR TITLE
refactor: centralize version helpers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Version 3.03.04a – Files Modal Storage Breakdown (2025-08-10)
 - Added progress bar in Files modal showing per-item storage distribution with hover tooltips and click-to-highlight
+- Footer now uses constants.js helper to display application version dynamically
 
 ### Version 3.03.03a – Storage Report Modal (2025-08-10)
 - Storage report now opens within an in-app modal using an iframe, replacing the previous popup window
@@ -283,7 +284,7 @@
 - **Import/Export**: CSV, JSON, Excel, PDF, HTML include storage location  
 - **Backwards compatibility**: default “Unknown” for existing items  
 - **Dynamic version loading**: version auto-loads from `APP_VERSION` in `constants.js`  
-- **Utility functions**: `getVersionString()`, `getAppTitle()` in `utils.js`
+- **Utility functions**: `getVersionString()` in `constants.js`, `getAppTitle()` in `utils.js`
 
 ### Version 3.0 – UI Streamlining
 - Removed “Show Spot History” & “Clear Spot History” buttons  

--- a/docs/FUNCTIONSTABLE.md
+++ b/docs/FUNCTIONSTABLE.md
@@ -127,8 +127,9 @@
 | theme.js | initTheme | Initializes theme based on user preference and system settings |
 | theme.js | toggleTheme | Toggles between dark and light themes |
 | theme.js | setupSystemThemeListener | Sets up system theme change listener |
+| constants.js | getVersionString | Returns formatted version string |
+| constants.js | injectVersionString | Inserts formatted version string into a target element |
 | utils.js | debugLog | Logs messages to console when DEBUG flag is enabled |
-| utils.js | getVersionString | Returns formatted version string |
 | utils.js | getBrandingName | Gets the active branding name considering domain overrides |
 | utils.js | getAppTitle | Returns full application title with version when no branding is configured |
 | utils.js | getFooterDomain | Determines active domain for footer copyright |

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -7,7 +7,7 @@ The StackTrackr now uses a dynamic version management system that automatically 
 ## How It Works
 
 ### Single Source of Truth
-- Version is defined once in `js/constants.js` as `APP_VERSION = '3.03.02a'`
+- Version is defined once in `js/constants.js` as `APP_VERSION = '3.03.04a'`
   - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation
@@ -16,9 +16,11 @@ The StackTrackr now uses a dynamic version management system that automatically 
 - **Application Header**: Shows current version in the main app interface
 
 ### Utility Functions
-Two helper functions are available in `js/utils.js`:
-- `getVersionString(prefix)`: Returns formatted version (e.g., "v3.03.02a")
-- `getAppTitle(baseTitle)`: Returns full app title with version
+- `js/constants.js` provides:
+  - `getVersionString(prefix)`: Returns formatted version (e.g., "v3.03.04a")
+  - `injectVersionString(elementId, prefix)`: Inserts formatted version into a target element
+- `js/utils.js` provides:
+  - `getAppTitle(baseTitle)`: Returns full app title with version
 
 ## Updating the Version
 
@@ -27,14 +29,14 @@ To release a new version:
 1. **Update ONLY the constants file:**
    ```javascript
    // In js/constants.js
-   const APP_VERSION = '3.03.02a';  // Change this line only
+   const APP_VERSION = '3.03.04a';  // Change this line only
    ```
 
 2. **All these will automatically update:**
-   - Page title: "StackTrackr v3.03.02a"
-   - Page heading: "StackTrackr v3.03.02a"
-   - Browser tab title: "StackTrackr v3.03.02a"
-   - App header: "StackTrackr v3.03.02a"
+   - Page title: "StackTrackr v3.03.04a"
+   - Page heading: "StackTrackr v3.03.04a"
+   - Browser tab title: "StackTrackr v3.03.04a"
+   - App header: "StackTrackr v3.03.04a"
 
 3. **Update changelog:** Add entry to `/docs/CHANGELOG.md` for documentation
 
@@ -69,7 +71,7 @@ state code is appended directly to the patch number:
   - `rc` = release candidate (final verification)
   - *(omit for stable builds)*
 
-Example: `3.03.02a` → branch 3, release 03, patch 02, alpha build
+Example: `3.03.04a` → branch 3, release 03, patch 04, alpha build
 
 ### Branching Policy
 - Each major **BRANCH** corresponds to a long-lived Git branch
@@ -81,15 +83,15 @@ Example: `3.03.02a` → branch 3, release 03, patch 02, alpha build
 ## Example Usage in Code
 ```javascript
 // Get just the version number
-const version = APP_VERSION; // "3.03.02a"
+const version = APP_VERSION; // "3.03.04a"
 
 // Get formatted version string
-const versionString = getVersionString(); // "v3.03.02a"
-const customVersion = getVersionString('version '); // "version 3.03.02a"
+const versionString = getVersionString(); // "v3.03.04a"
+const customVersion = getVersionString('version '); // "version 3.03.04a"
 
 // Get full app title
-const title = getAppTitle(); // "StackTrackr v3.03.02a"
-const customTitle = getAppTitle('My Custom Tool'); // "My Custom Tool v3.03.02a"
+const title = getAppTitle(); // "StackTrackr v3.03.04a"
+const customTitle = getAppTitle('My Custom Tool'); // "My Custom Tool v3.03.04a"
 ```
 
 This system ensures version consistency and makes maintenance much easier!

--- a/js/constants.js
+++ b/js/constants.js
@@ -100,6 +100,27 @@ const API_PROVIDERS = {
  */
 const APP_VERSION = "3.03.04a";
 
+/**
+ * Returns formatted version string
+ *
+ * @param {string} [prefix="v"] - Prefix to add before version
+ * @returns {string} Formatted version string (e.g., "v3.03.04a")
+ */
+const getVersionString = (prefix = "v") => `${prefix}${APP_VERSION}`;
+
+/**
+ * Inserts formatted version string into a target element
+ *
+ * @param {string} elementId - ID of the element to update
+ * @param {string} [prefix="v"] - Prefix to add before version
+ */
+const injectVersionString = (elementId, prefix = "v") => {
+  const el = document.getElementById(elementId);
+  if (el) {
+    el.textContent = getVersionString(prefix);
+  }
+};
+
 /** @constant {string} BRANDING_TITLE - Optional custom application title */
 const BRANDING_TITLE = "StackTrackr";
 

--- a/js/init.js
+++ b/js/init.js
@@ -279,10 +279,7 @@ document.addEventListener("DOMContentLoaded", () => {
     if (aboutVersion) {
       aboutVersion.textContent = `v${APP_VERSION}`;
     }
-    const footerVersion = document.getElementById("footerVersion");
-    if (footerVersion) {
-      footerVersion.textContent = getVersionString();
-    }
+    injectVersionString("footerVersion");
     const footerDomainEl = document.getElementById("footerDomain");
     if (footerDomainEl) {
       footerDomainEl.textContent = getFooterDomain();

--- a/js/utils.js
+++ b/js/utils.js
@@ -11,14 +11,6 @@ const debugLog = (...args) => {
   }
 };
 /**
- * Returns formatted version string
- *
- * @param {string} [prefix='v'] - Prefix to add before version
- * @returns {string} Formatted version string (e.g., "v3.03.02a")
- */
-const getVersionString = (prefix = "v") => `${prefix}${APP_VERSION}`;
-
-/**
  * Gets the active branding name considering domain overrides
  *
  * @returns {string} Active branding name


### PR DESCRIPTION
## Summary
- centralize version helpers in constants.js
- use new helper to inject dynamic footer version
- document version helper changes across docs

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899385fdc58832ebf374c754fd408a4