### PR TITLE
Refactor settings modal with card layout

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1085,8 +1085,31 @@ input[type="submit"] {
   gap: var(--spacing);
 }
 
-#filesModal .settings-section {
-  margin-top: 0;
+
+.settings-card-grid {
+  display: grid;
+  gap: var(--spacing);
+}
+
+@media (min-width: 600px) {
+  .settings-card-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.settings-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--spacing-lg);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing);
+}
+
+.settings-card:hover {
+  box-shadow: var(--shadow-lg);
 }
 
 /* Cloud Sync modal layout */
@@ -2362,7 +2385,6 @@ input:disabled + .slider {
    ============================================================================= */
 
 .boating-accident-section {
-  margin-top: var(--spacing-xl);
   text-align: center;
 }
 

--- a/index.html
+++ b/index.html
@@ -1367,91 +1367,93 @@
             Storage Breakdown:
             <div class="files-progress" id="filesProgress"></div>
           </div>
-          <div class="settings-section">
-            <h3>Import</h3>
-            <p class="settings-subtext">Import your data files.</p>
-            <div class="import-block">
-              <div class="import-export-grid">
-                <label class="btn" id="importCsvBtn">
-                  Import CSV <span class="import-icon">⬇️</span>
-                  <input accept=".csv" hidden id="importCsvFile" type="file" />
-                </label>
-                <label class="btn" id="importJsonBtn">
-                  Import JSON <span class="import-icon">⬇️</span>
-                  <input accept=".json" hidden id="importJsonFile" type="file" />
-                </label>
-                <label class="btn" id="importExcelBtn">
-                  Import Excel <span class="import-icon">⬇️</span>
-                  <input
-                    accept=".xlsx,.xls"
-                    hidden
-                    id="importExcelFile"
-                    type="file"
-                  />
-                </label>
-                <button class="btn secondary" id="cloudSyncBtn">Cloud Sync ☁️</button>
-              </div>
-              <progress
-                class="import-progress"
-                id="importProgress"
-                value="0"
-                max="0"
-              ></progress>
-              <div class="import-progress-text" id="importProgressText"></div>
-            </div>
-          </div>
-
-          <div class="settings-section">
-            <h3>Export</h3>
-            <p class="settings-subtext">Export your data files.</p>
-            <div class="export-block">
-              <div class="import-export-grid">
-                <button class="btn" id="exportCsvBtn">
-                  Export CSV <span class="export-icon">⬆️</span>
-                </button>
-                <button class="btn" id="exportJsonBtn">
-                  Export JSON <span class="export-icon">⬆️</span>
-                </button>
-                <button class="btn" id="exportExcelBtn">
-                  Export Excel <span class="export-icon">⬆️</span>
-                </button>
-                <button class="btn" id="exportPdfBtn">
-                  Export PDF <span class="export-icon">⬆️</span>
-                </button>
+          <div class="settings-card-grid">
+            <div class="settings-card">
+              <h3>Import</h3>
+              <p class="settings-subtext">Import your data files.</p>
+              <div class="import-block">
+                <div class="import-export-grid">
+                  <label class="btn" id="importCsvBtn">
+                    Import CSV <span class="import-icon">⬇️</span>
+                    <input accept=".csv" hidden id="importCsvFile" type="file" />
+                  </label>
+                  <label class="btn" id="importJsonBtn">
+                    Import JSON <span class="import-icon">⬇️</span>
+                    <input accept=".json" hidden id="importJsonFile" type="file" />
+                  </label>
+                  <label class="btn" id="importExcelBtn">
+                    Import Excel <span class="import-icon">⬇️</span>
+                    <input
+                      accept=".xlsx,.xls"
+                      hidden
+                      id="importExcelFile"
+                      type="file"
+                    />
+                  </label>
+                  <button class="btn secondary" id="cloudSyncBtn">Cloud Sync ☁️</button>
+                </div>
+                <progress
+                  class="import-progress"
+                  id="importProgress"
+                  value="0"
+                  max="0"
+                ></progress>
+                <div class="import-progress-text" id="importProgressText"></div>
               </div>
             </div>
-          </div>
 
-          <div class="settings-section">
-            <h3>Third-Party</h3>
-            <p class="settings-subtext">Connect with external services like Numista.</p>
-            <div class="third-party-block">
-              <div class="import-export-grid">
-                <button class="btn" id="numistaImportBtn">Import from Numista</button>
-                <button class="btn" id="numistaExportBtn">Export to Numista</button>
+            <div class="settings-card">
+              <h3>Export</h3>
+              <p class="settings-subtext">Export your data files.</p>
+              <div class="export-block">
+                <div class="import-export-grid">
+                  <button class="btn" id="exportCsvBtn">
+                    Export CSV <span class="export-icon">⬆️</span>
+                  </button>
+                  <button class="btn" id="exportJsonBtn">
+                    Export JSON <span class="export-icon">⬆️</span>
+                  </button>
+                  <button class="btn" id="exportExcelBtn">
+                    Export Excel <span class="export-icon">⬆️</span>
+                  </button>
+                  <button class="btn" id="exportPdfBtn">
+                    Export PDF <span class="export-icon">⬆️</span>
+                  </button>
+                </div>
               </div>
             </div>
-          </div>
 
-          <div class="settings-section">
-            <h3>Custom Mapping</h3>
-            <p class="settings-subtext">Define regex rules to map imported fields.</p>
-            <div class="third-party-block">
-              <div class="import-export-grid">
-                <button class="btn" id="addMappingBtn">Add Mapping</button>
-                <button class="btn" id="applyMappingsBtn">Apply Mappings</button>
-                <button class="btn" id="clearMappingsBtn">Clear Mappings</button>
+            <div class="settings-card">
+              <h3>Third-Party</h3>
+              <p class="settings-subtext">Connect with external services like Numista.</p>
+              <div class="third-party-block">
+                <div class="import-export-grid">
+                  <button class="btn" id="numistaImportBtn">Import from Numista</button>
+                  <button class="btn" id="numistaExportBtn">Export to Numista</button>
+                </div>
               </div>
             </div>
-          </div>
 
-          <div class="settings-section boating-accident-section">
-            <h3>Clear All Data</h3>
-            <p class="settings-subtext">Clear all data from the app.</p>
-            <div class="backup-buttons">
-              <button class="btn danger" id="boatingAccidentBtn">
-                🏴‍☠️ So, you've been in a boating accident? 🏴‍☠️
-              </button>
+            <div class="settings-card">
+              <h3>Custom Mapping</h3>
+              <p class="settings-subtext">Define regex rules to map imported fields.</p>
+              <div class="third-party-block">
+                <div class="import-export-grid">
+                  <button class="btn" id="addMappingBtn">Add Mapping</button>
+                  <button class="btn" id="applyMappingsBtn">Apply Mappings</button>
+                  <button class="btn" id="clearMappingsBtn">Clear Mappings</button>
+                </div>
+              </div>
+            </div>
+
+            <div class="settings-card boating-accident-section">
+              <h3>Clear All Data</h3>
+              <p class="settings-subtext">Clear all data from the app.</p>
+              <div class="backup-buttons">
+                <button class="btn danger" id="boatingAccidentBtn">
+                  🏴‍☠️ So, you've been in a boating accident? 🏴‍☠️
+                </button>
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Replace settings modal sections with card-based grid
- Keep Cloud Sync within Import card and maintain Boating Accident button
- Add responsive card styling with drop shadows

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68993ad6ec38832e8ea2a78157c11178