### PR TITLE
feat: handle purchase price for Numista import

### DIFF
--- a/docs/FUNCTIONSTABLE.md
+++ b/docs/FUNCTIONSTABLE.md
@@ -143,9 +143,9 @@
 | utils.js | formatDollar | Formats a number as a dollar amount with two decimal places |
 | utils.js | formatLossProfit | Formats a profit/loss value with color coding |
 | utils.js | sanitizeHtml | Sanitizes text input for safe HTML display |
-| utils.js | gramsToOzt | Converts grams to troy ounces |
+| utils.js | gramsToOzt | Converts grams to troy ounces (ozt) |
 | utils.js | convertToUsd | Converts amount from specified currency to USD using static rates |
-| utils.js | mapNumistaType | Maps Numista type strings to internal categories |
+| utils.js | mapNumistaType | Maps Numista type strings to internal categories (coin, Aurum, Notes, bars/rounds, other) |
 | utils.js | saveData | Saves data to localStorage with JSON serialization |
 | utils.js | loadData | Loads data from localStorage with error handling |
 | utils.js | sortInventoryByDateNewestFirst | Sorts inventory by date (newest first) |

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1183,12 +1183,12 @@ const importNumistaCsv = (file) => {
           const weight = gramsToOzt(weightGrams);
 
           const priceKey = Object.keys(row).find(k => k.startsWith('Buying price'));
-          let price = 0;
+          let purchasePrice = 0;
           if (priceKey) {
             const currencyMatch = priceKey.match(/\(([^)]+)\)/);
             const currency = currencyMatch ? currencyMatch[1] : 'USD';
             const amount = parseFloat(String(row[priceKey]).replace(/[^0-9.\-]/g, ''));
-            price = convertToUsd(amount, currency);
+            purchasePrice = convertToUsd(amount, currency);
           }
 
           const purchaseLocRaw = row['Acquisition place'];
@@ -1204,7 +1204,7 @@ const importNumistaCsv = (file) => {
 
           const isCollectable = false;
           const spotPriceAtPurchase = spotPrices[metal.toLowerCase()] || 0;
-          const premiumPerOz = weight ? price / weight - spotPriceAtPurchase : 0;
+          const premiumPerOz = weight ? purchasePrice / weight - spotPriceAtPurchase : 0;
           const totalPremium = premiumPerOz * qty * weight;
 
           const itemToValidate = {
@@ -1213,7 +1213,8 @@ const importNumistaCsv = (file) => {
             qty,
             type,
             weight,
-            price,
+            price: purchasePrice,
+            purchasePrice,
             date,
             purchaseLocation,
             storageLocation,
@@ -1317,7 +1318,7 @@ const exportNumistaCsv = () => {
       item.qty || '',
       item.type || '',
       weightGrams ? weightGrams.toFixed(2) : '',
-      item.price ? Number(item.price).toFixed(2) : '',
+      (item.purchasePrice ?? item.price) ? Number(item.purchasePrice ?? item.price).toFixed(2) : '',
       item.purchaseLocation || '',
       item.storageLocation || '',
       item.date || '',


### PR DESCRIPTION
## Summary
- capture Numista buying price as `purchasePrice` with currency conversion
- include purchasePrice in Numista CSV exports
- document Numista utility helpers in FUNCTIONSTABLE

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/inventory.js`
- `node --check js/utils.js`


------
https://chatgpt.com/codex/tasks/task_e_68993c1c80b0832e84510d623dadd090