### PR TITLE
docs: clean up changelog roadmap reference

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,10 +1,6 @@
 # StackTrackr — Changelog
 
-## 🚀 Roadmap (Future Versions)
-
-*All major planned features have been implemented! The tool now includes comprehensive inventory management with storage location tracking, multi-format import/export, advanced analytics, and a modern modular architecture.*
-
----
+For upcoming work, see [ROADMAP](ROADMAP.md).
 
 ## 📋 Version History
 


### PR DESCRIPTION
## Summary
- remove outdated roadmap section from changelog
- link to ROADMAP.md for future work details

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689942ddecac832ea73ed75b6a972e1d