### PR TITLE
docs: streamline multi-agent patch workflow

### DIFF
--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -5,56 +5,57 @@
 You are contributing to the **StackTrackr v3.03.02a**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
 **Current Status**: v3.03.02a (alpha)
-**Your Role**: Complete individual 2-hour subtasks as part of a coordinated multi-agent development effort
+**Your Role**: Complete focused v3.03.x patch tasks as part of a coordinated multi-agent development effort
 
 ---
 
 ## 🏗️ Multi-Agent Workflow
 
 ### **How This Works**
-- **70 total subtasks** across 4 development phases
-- Each subtask designed for **~2 hour completion**
-- **Multiple agents work in parallel** on different subtasks
+- Development progresses through incremental **v3.03.x patch releases**
+- Each patch entry is designed for **~2 hour completion**
+- **Multiple agents work in parallel** on different patch entries
 - **Coordination system** prevents conflicts and ensures quality
-- **Task IDs** (1A, 2B, 3C, etc.) track progress and assignments
+- **Roadmap entries** track progress and assignments
 
 ### **Your Responsibilities**
-1. **Pick up an available subtask** from the roadmap
-2. **Check dependencies** before starting work
-3. **Complete the subtask** following quality standards
+1. **Pick up an available patch entry** from the roadmap
+2. **Check dependencies or prerequisites** before starting work
+3. **Complete the patch** following quality standards
 4. **Test your changes** thoroughly
-5. **Document your work** and any findings
-6. **Mark the subtask as complete**
+5. **Bump the version and update all docs** after completing the patch
+6. **Document your work** and any findings
+7. **Mark the patch entry as complete** in the roadmap
 
 ---
 
 ## 📋 How to Get Started
 
 ### **Step 1: Read the Documentation**
-Before starting ANY subtask, read these files:
-- `docs/ROADMAP.md` - Complete development roadmap with all subtasks
+Before starting any patch entry, read these files:
+- `docs/ROADMAP.md` - Patch release roadmap (v3.03.x entries)
 - `docs/archive/notes/V3.2.0-PLANNING-NOTES.md` - Technical implementation details
 - `docs/STATUS.md` - Current project status
 - `docs/STRUCTURE.md` - Project architecture and file organization
 - `docs/FUNCTIONSTABLE.md` - Reference table of all JavaScript functions
 
-### **Step 2: Choose Your Subtask**
-1. **Review available subtasks** in `docs/ROADMAP.md`
-2. **Check dependencies** - some subtasks require others to complete first
-3. **Verify file conflicts** - avoid working on high-conflict files simultaneously
+### **Step 2: Choose Your Patch Entry**
+1. **Review available patch entries** in `docs/ROADMAP.md`
+2. **Check dependencies** – some patches require others to complete first
+3. **Verify file conflicts** – avoid working on high-conflict files simultaneously
 4. **Announce your choice** if coordinating with other agents
 
 ### **Step 3: Understand the Context**
 - **Read the current codebase** in the relevant files
 - **Understand existing patterns** and architecture
-- **Review related subtasks** to understand the bigger picture
-- **Check for any existing work** that might affect your subtask
+- **Review related patches** to understand the bigger picture
+- **Check for any existing work** that might affect your patch
 
 ---
 
-## 🎯 Subtask Execution Guidelines
+## 🎯 Patch Execution Guidelines
 
-### **Quality Standards (Required for Every Subtask)**
+### **Quality Standards (Required for Every Patch)**
 
 #### ✅ **Functional Testing**
 - Verify your changes work as intended
@@ -85,7 +86,7 @@ Before starting ANY subtask, read these files:
 - Add any new configuration to constants.js
 - Update planning notes if you discover issues
 - Document any architectural decisions
-- For every release, update:
+- For every completed patch, **bump the version** and update:
   - `docs/FUNCTIONSTABLE.md`
   - `docs/CHANGELOG.md`
   - `docs/IMPLEMENTATION_SUMMARY.md`
@@ -96,19 +97,19 @@ Before starting ANY subtask, read these files:
 ### **File Modification Guidelines**
 
 #### **HIGH CONFLICT RISK FILES** ⚠️ (Coordinate Carefully)
-- `index.html` - Multiple subtasks modify this
-- `events.js` - Multiple subtasks add event handlers
-- `css/styles.css` - Multiple subtasks add styling
+- `index.html` - Frequently modified
+- `events.js` - Central event handler logic
+- `css/styles.css` - Shared styling
 
 **When working on these files:**
-- Check with other agents working nearby subtasks
+- Check with other agents working nearby patches
 - Make focused, minimal changes
 - Test thoroughly for conflicts
 - Document exactly what you changed
 
 #### **MEDIUM CONFLICT RISK FILES** ⚠️
-- `api.js` - Modified in Phases 1 and 4
-- `inventory.js` - Modified in Phases 3 and 4
+- `api.js` - API integration logic
+- `inventory.js` - Core data management
 
 #### **LOW CONFLICT RISK FILES** ✅ (Safe for Parallel Work)
 - Documentation files (.md)
@@ -118,63 +119,11 @@ Before starting ANY subtask, read these files:
 
 ---
 
-## 📖 Phase-Specific Guidelines
-
-### **PHASE 1: Documentation & API Tracking** (Subtasks 1A-2F)
-- **Focus**: Documentation updates and API usage tracking
-- **Low Risk**: Mostly safe for parallel work after initial audits
-- **Key Files**: Documentation files, `api.js`, `constants.js`
-- **Testing**: Verify documentation accuracy, test API tracking functionality
-
-### **PHASE 2: UI Improvements** (Subtasks 3A-5I)  
-- **Focus**: CSV import feedback, Add Item modal, DATA button reorganization
-- **High Risk**: Heavy `index.html` and `events.js` modifications
-- **Key Files**: `index.html`, `events.js`, `css/styles.css`, `inventory.js`
-- **Testing**: Comprehensive UI testing, modal behavior, responsive design
-
-### **PHASE 3: Data Management** (Subtasks 6A-7I)
-- **Focus**: Spot price display fixes and restore functionality  
-- **Medium Risk**: Core functionality changes
-- **Key Files**: `inventory.js`, new restore components
-- **Testing**: Data integrity, backup/restore workflows, spot price accuracy
-
-### **PHASE 4: Advanced Features** (Subtasks 8A-9J)
-- **Focus**: Multi-currency support and encrypted backups
-- **High Complexity**: Research-heavy, security considerations
-- **Key Files**: `api.js`, `inventory.js`, `constants.js`
-- **Testing**: Currency conversion accuracy, encryption/decryption workflows
-
----
-
-## 🚨 Critical Dependencies to Check
-
-### **Before Starting Any Subtask:**
-
-#### **Phase 1 Dependencies:**
-- **1A** must complete before 1B-1F (audit before changes)
-- **2A** must complete before 2B-2F (design before implementation)
-
-#### **Phase 2 Dependencies:**
-- **4A-4B** before 4C-4G (design before implementation)
-- **5A-5B** before 5C-5I (design before implementation)  
-- **4G** depends on 5I (ADD button placement after cleanup)
-
-#### **Phase 3 Dependencies:**
-- **6A-6B** before 6C-6F (analysis before fixes)
-- **7A** before 7B-7I (design before implementation)
-
-#### **Phase 4 Dependencies:**
-- **8A-8B** before 8C-8K (research before implementation)
-- **9A-9B** before 9C-9J (research before implementation)
-- **9D** depends on 7B (backup encryption needs restore parsing)
-
----
-
-## 📝 Subtask Completion Checklist
+## 📝 Patch Completion Checklist
 
 ### **Before You Start:**
 - [ ] Read all relevant documentation
-- [ ] Understand the subtask requirements
+- [ ] Understand the patch requirements
 - [ ] Check dependencies are met
 - [ ] Verify no file conflicts with other agents
 - [ ] Review related code sections
@@ -195,10 +144,10 @@ Before starting ANY subtask, read these files:
 - [ ] **File cleanup** - Removed debug code, organized changes?
 
 ### **After Completion:**
-- [ ] Mark subtask as complete in coordination system
-- [ ] Document any findings that affect other subtasks  
+- [ ] Bump the version and update all docs
+- [ ] Mark the patch entry as complete in the roadmap
+- [ ] Document any findings that affect other patches
 - [ ] Note any changes to original requirements
-- [ ] Update version references if needed
 - [ ] Archive the previous build in `/archive/previous` and ensure its `index.html` footer links back to `/`
 
 ---
@@ -256,12 +205,12 @@ Before starting ANY subtask, read these files:
 
 ### **When to Coordinate:**
 - Working on HIGH CONFLICT RISK files
-- Discovering issues that affect other subtasks
+- Discovering issues that affect other patches
 - Finding bugs or architectural problems
 - Needing to modify shared components
 
 ### **What to Document:**
-- Any deviations from original subtask requirements
+- Any deviations from original patch requirements
 - Performance issues discovered
 - Browser compatibility problems
 - Dependencies that weren't anticipated
@@ -278,7 +227,7 @@ Before starting ANY subtask, read these files:
 ## ⚡ Quick Reference
 
 ### **Essential Files:**
-- `docs/ROADMAP.md` - Your subtask list
+- `docs/ROADMAP.md` - Patch release list
 - `docs/archive/notes/V3.2.0-PLANNING-NOTES.md` - Implementation details
 - `docs/FUNCTIONSTABLE.md` - Lookup table for all functions
 - `index.html` - Main application
@@ -297,6 +246,7 @@ Before starting ANY subtask, read these files:
 ✅ Functional ✅ Integration ✅ Code Quality ✅ Browser Testing ✅ Documentation
 
 ### Release Documentation Checklist
+- [ ] Bump `APP_VERSION` and version references
 - [ ] Update `docs/FUNCTIONSTABLE.md`
 - [ ] Update `docs/CHANGELOG.md`
 - [ ] Update `docs/IMPLEMENTATION_SUMMARY.md`
@@ -306,6 +256,6 @@ Before starting ANY subtask, read these files:
 
 ---
 
-**Remember: Each subtask is designed to be completed independently while contributing to the larger v3.03.02a vision. Focus on quality over speed, and don't hesitate to coordinate with other agents when working on shared components.**
+**Remember: Each patch entry is designed to be completed independently while contributing to the larger v3.03.02a vision. Focus on quality over speed, and don't hesitate to coordinate with other agents when working on shared components.**
 
-**Your contribution helps build a professional-grade inventory management system that serves users worldwide. Every subtask matters!** 🚀
+**Your contribution helps build a professional-grade inventory management system that serves users worldwide. Every patch matters!** 🚀


### PR DESCRIPTION
## Summary
- Revise multi-agent workflow to focus on v3.03.x patch releases instead of 70 subtasks and phases
- Guide contributors to bump version, update all project docs, and check off roadmap entries when completing a patch
- Simplify conflict guidance and completion checklist for patch-based development

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689944f592d8832ebb1b22f046e44bb8