### PR TITLE
docs: mark v3.03.06a as latest release and refresh archive

### DIFF
--- a/archive/previous/js/constants.js
+++ b/archive/previous/js/constants.js
@@ -98,13 +98,13 @@ const API_PROVIDERS = {
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
-const APP_VERSION = "3.03.04a";
+const APP_VERSION = "3.03.06a";
 
 /**
  * Returns formatted version string
  *
  * @param {string} [prefix="v"] - Prefix to add before version
- * @returns {string} Formatted version string (e.g., "v3.03.04a")
+ * @returns {string} Formatted version string (e.g., "v3.03.06a")
  */
 const getVersionString = (prefix = "v") => `${prefix}${APP_VERSION}`;
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,7 @@
 # StackTrackr — Changelog
 
+> **Latest release: v3.03.06a**
+
 For upcoming work, see [ROADMAP](ROADMAP.md).
 
 ## 📋 Version History

--- a/docs/FUNCTIONSTABLE.md
+++ b/docs/FUNCTIONSTABLE.md
@@ -1,5 +1,7 @@
 # Function Reference
 
+> **Latest release: v3.03.06a**
+
 | File | Function | Description |
 |------|----------|-------------|
 | about.js | showAboutModal | Shows the About modal and populates it with current data |

--- a/docs/IMPLEMENTATION_SUMMARY.md
+++ b/docs/IMPLEMENTATION_SUMMARY.md
@@ -1,5 +1,7 @@
 # Implementation Summary: Documentation Sweep & Archive Update
 
+> **Latest release: v3.03.06a**
+
 ## Version Update: 3.03.05a → 3.03.06a
 
 ## User Requirements Implemented

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,5 +1,7 @@
 # Multi-Agent Development Workflow - StackTrackr v3.03.06a
 
+> **Latest release: v3.03.06a**
+
 ## 🎯 Project Overview
 
 You are contributing to the **StackTrackr v3.03.06a**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,5 +1,7 @@
 # Project Status - StackTrackr
 
+> **Latest release: v3.03.06a**
+
 ## 🎯 Current State: **ALPHA v3.03.06a** ✅ MAINTAINED & OPTIMIZED
 
 **StackTrackr v3.03.06a** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -1,5 +1,7 @@
 # Project Structure
 
+> **Latest release: v3.03.06a**
+
 The repository is organized as follows:
 
 ```text

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,5 +1,7 @@
 # Dynamic Version Management System
 
+> **Latest release: v3.03.06a**
+
 ## Overview 
 
 The StackTrackr now uses a dynamic version management system that automatically updates version numbers throughout the application from a single source of truth.


### PR DESCRIPTION
## Summary
- flag v3.03.06a as the latest release across documentation
- refresh archived build and ensure footer links back to current version

## Testing
- `node -e "const fs=require('fs');const match=fs.readFileSync('js/constants.js','utf8').match(/APP_VERSION = \"([^\"]+)\"/); console.log(match[1]);"`
- `node -e "const fs=require('fs');const match=fs.readFileSync('archive/previous/js/constants.js','utf8').match(/APP_VERSION = \"([^\"]+)\"/); console.log(match[1]);"`


------
https://chatgpt.com/codex/tasks/task_e_6899498239e4832e82c118e1b1f74431