### PR TITLE
Restyle inventory controls and reposition change log label

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2106,17 +2106,17 @@ td input:checked + .slider:before {
 
 .items-per-page {
   display: flex;
-  justify-content: flex-end;
   align-items: center;
   gap: var(--spacing-sm);
-  margin-left: auto;
 }
 
 .table-controls {
   display: flex;
   align-items: center;
-  margin-bottom: var(--spacing-sm);
+  justify-content: space-between;
   gap: var(--spacing-lg);
+  margin: var(--spacing-sm) 0;
+  flex-wrap: wrap;
 }
 
 .items-label {
@@ -2125,10 +2125,18 @@ td input:checked + .slider:before {
   color: var(--text-muted);
 }
 
+.change-log-label {
+  font-weight: 700;
+  color: var(--primary);
+  cursor: pointer;
+}
+
 .table-disclaimer {
   font-size: 0.75rem;
   color: var(--text-muted);
   font-style: italic;
+  flex: 1;
+  text-align: center;
 }
 
 .pagination-select {

--- a/index.html
+++ b/index.html
@@ -407,22 +407,6 @@
          Pagination controls limit display to selected items per page
          ============================================================================= -->
         <section class="table-section">
-          <div class="table-controls">
-            <button id="changeLogBtn" class="btn">Change Log</button>
-            <span class="table-disclaimer"
-              >All data is stored locally. Back up often.</span
-          >
-          <div class="items-per-page">
-            <span class="items-label">Items:</span>
-            <select class="pagination-select" id="itemsPerPage">
-              <option selected value="10">10</option>
-              <option value="15">15</option>
-              <option value="25">25</option>
-              <option value="50">50</option>
-              <option value="100">100</option>
-            </select>
-          </div>
-          </div>
           <table id="inventoryTable">
           <thead>
             <tr>
@@ -444,6 +428,22 @@
           </thead>
           <tbody></tbody>
         </table>
+          <div class="table-controls">
+            <span id="changeLogBtn" class="change-log-label">Change Log</span>
+            <span class="table-disclaimer"
+              >All data is stored locally. Back up often.</span
+            >
+            <div class="items-per-page">
+              <span class="items-label">Items:</span>
+              <select class="pagination-select" id="itemsPerPage">
+                <option selected value="10">10</option>
+                <option value="15">15</option>
+                <option value="25">25</option>
+                <option value="50">50</option>
+                <option value="100">100</option>
+              </select>
+            </div>
+          </div>
         <!-- Pagination Controls -->
         <section class="pagination-section">
           <div class="pagination-container">


### PR DESCRIPTION
## Summary
- Replace Change Log button with bold label and move controls below inventory table
- Center local data warning and align items-per-page dropdown with new layout
- Update table control styling for spacing and typography

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68994d7ba0f4832eb15d2a0ab1e8db4e