### PR TITLE
feat(files): add storage breakdown tooltips

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -270,6 +270,7 @@ section {
   border-radius: var(--radius);
   overflow: hidden;
   background-color: var(--bg-tertiary);
+  position: relative;
 }
 
 .files-progress-segment {
@@ -280,7 +281,28 @@ section {
 
 .files-progress-segment.zoomed {
   transform: scaleY(1.5);
+  box-shadow: 0 0 0 2px var(--border);
   z-index: 1;
+}
+
+.files-progress-tooltip {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  padding: var(--spacing-xs) var(--spacing-sm);
+  background-color: var(--bg-primary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 0.75rem;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transform: translate(-50%, -0.25rem);
+  transition: var(--transition);
+}
+
+.files-progress-tooltip.show {
+  opacity: 1;
 }
 
 section:hover {

--- a/index.html
+++ b/index.html
@@ -1359,7 +1359,9 @@
         <div class="modal-body">
           <div class="storage-line">
             Storage Breakdown:
-            <div class="files-progress" id="filesProgress"></div>
+            <div class="files-progress" id="filesProgress">
+              <div class="files-progress-tooltip" id="filesProgressTooltip"></div>
+            </div>
           </div>
           <div class="settings-card-grid">
             <div class="settings-card">

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -526,6 +526,20 @@ const renderFilesProgress = () => {
   container.innerHTML = '';
   if (inventory.length === 0) return;
 
+  const tooltip = document.createElement('div');
+  tooltip.className = 'files-progress-tooltip';
+  container.appendChild(tooltip);
+
+  const showTooltip = (segment, text) => {
+    tooltip.textContent = text;
+    const rect = segment.getBoundingClientRect();
+    const parentRect = container.getBoundingClientRect();
+    tooltip.style.left = `${rect.left - parentRect.left + rect.width / 2}px`;
+    tooltip.classList.add('show');
+  };
+
+  const hideTooltip = () => tooltip.classList.remove('show');
+
   const sizes = inventory.map(item => ({
     item,
     size: JSON.stringify(item).length * 2,
@@ -537,7 +551,10 @@ const renderFilesProgress = () => {
     segment.className = 'files-progress-segment';
     segment.style.width = `${(size / total) * 100}%`;
     segment.style.backgroundColor = getColor(filesProgressColors, item.name);
-    segment.title = `${item.name}: ${(size / 1024).toFixed(1)} KB`;
+    const text = `${item.name}: ${(size / 1024).toFixed(1)} KB`;
+    segment.title = text;
+    segment.addEventListener('mouseenter', () => showTooltip(segment, text));
+    segment.addEventListener('mouseleave', hideTooltip);
     segment.addEventListener('click', () => {
       container.querySelectorAll('.files-progress-segment').forEach(seg => seg.classList.remove('zoomed'));
       segment.classList.add('zoomed');


### PR DESCRIPTION
## Summary
- enhance Files modal storage breakdown with tooltip overlay and click highlight
- add tooltip styling for footer progress segments
- compute tooltip positions and content from inventory sizes

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68995006c09c832ead6051700819a9cd