### PR TITLE
feat: replace appearance modal with inline theme toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# StackTrackr v3.03.06a
+# StackTrackr v3.03.07a
 
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
 
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
+- **v3.03.07a - Theme Toggle Improvements**: Removed appearance modal and added three-state Dark/Light/System toggle with localStorage persistence
 - **v3.03.06a - Documentation Sweep & Archive Update**: Version references synchronized and archived footer links back to current version
 - **v3.03.05a - Custom Mapping Rule Engine**: Added regex-based mapping module with Add/Apply/Clear controls
 - **v3.03.02a - Archive Workflow Update**: Archived previous build and added rollback footer link requirement; clarified BRANCH.RELEASE.PATCH.state naming and pre-release codes
@@ -25,6 +26,9 @@ The public hosted version of the app is available at [stackrtrackr.com](https://
 - **v3.1.9 - UI Consistency**: Clear Cache button styling improvements across themes
 - **v3.1.8 - Backup System**: Full ZIP backup functionality with restoration guides
 - **v3.1.6 - Theme Toggle**: Fixed theme management with system preference detection
+
+## 🆕 What's New in v3.03.07a
+- Theme toggle cycles Dark/Light/System without modal and saves preference
 
 ## 🆕 What's New in v3.03.06a
 - Documentation sweep across project and archived build footer update
@@ -269,7 +273,7 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: 3.03.06a
+**Current Version**: 3.03.07a
 **Last Updated**: August 9, 2025
 **Status**: Feature complete release candidate
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -1035,7 +1035,6 @@ input[type="submit"] {
 }
 
 /* Settings-style modal layout */
-#appearanceModal .modal-content,
 #apiModal .modal-content,
 #filesModal .modal-content {
   max-width: 750px;
@@ -1046,7 +1045,6 @@ input[type="submit"] {
   overflow: hidden;
 }
 
-#appearanceModal .modal-header,
 #apiModal .modal-header,
 #filesModal .modal-header {
   background: linear-gradient(135deg, var(--primary), var(--primary-hover));
@@ -1057,7 +1055,6 @@ input[type="submit"] {
   box-shadow: var(--shadow);
 }
 
-#appearanceModal .modal-header h2,
 #apiModal .modal-header h2,
 #filesModal .modal-header h2 {
   margin: 0;
@@ -1065,7 +1062,6 @@ input[type="submit"] {
   text-align: center;
 }
 
-#appearanceModal .modal-body,
 #apiModal .modal-body,
 #filesModal .modal-body {
   padding: var(--spacing-xl);
@@ -1075,27 +1071,23 @@ input[type="submit"] {
   scrollbar-color: var(--primary) var(--bg-secondary);
 }
 
-#appearanceModal .modal-body::-webkit-scrollbar,
 #apiModal .modal-body::-webkit-scrollbar,
 #filesModal .modal-body::-webkit-scrollbar {
   width: 8px;
 }
 
-#appearanceModal .modal-body::-webkit-scrollbar-track,
 #apiModal .modal-body::-webkit-scrollbar-track,
 #filesModal .modal-body::-webkit-scrollbar-track {
   background: var(--bg-secondary);
   border-radius: var(--radius);
 }
 
-#appearanceModal .modal-body::-webkit-scrollbar-thumb,
 #apiModal .modal-body::-webkit-scrollbar-thumb,
 #filesModal .modal-body::-webkit-scrollbar-thumb {
   background-color: var(--primary);
   border-radius: var(--radius);
 }
 
-#appearanceModal .modal-body::-webkit-scrollbar-thumb:hover,
 #apiModal .modal-body::-webkit-scrollbar-thumb:hover,
 #filesModal .modal-body::-webkit-scrollbar-thumb:hover {
   background-color: var(--primary-hover);

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,10 +1,13 @@
 # StackTrackr — Changelog
 
-> **Latest release: v3.03.06a**
+> **Latest release: v3.03.07a**
 
 For upcoming work, see [ROADMAP](ROADMAP.md).
 
 ## 📋 Version History
+
+### Version 3.03.07a – Theme Toggle Improvements (2025-08-10)
+- Removed appearance modal and implemented three-state Dark/Light/System toggle with localStorage persistence
 
 ### Version 3.03.06a – Documentation Sweep & Archive Update (2025-08-10)
 - Synchronized version references and workflow docs for the 3.03.06a release

--- a/docs/FUNCTIONSTABLE.md
+++ b/docs/FUNCTIONSTABLE.md
@@ -1,6 +1,6 @@
 # Function Reference
 
-> **Latest release: v3.03.06a**
+> **Latest release: v3.03.07a**
 
 | File | Function | Description |
 |------|----------|-------------|
@@ -49,8 +49,6 @@
 | api.js | hideApiModal | Hides API modal |
 | api.js | showFilesModal |  |
 | api.js | hideFilesModal |  |
-| api.js | showAppearanceModal |  |
-| api.js | hideAppearanceModal |  |
 | api.js | showProviderInfo | Shows provider information modal |
 | api.js | hideProviderInfo | Hides provider information modal |
 | api.js | showManualInput | Shows manual price input for a specific metal |

--- a/docs/HUMAN_WORKFLOW.md
+++ b/docs/HUMAN_WORKFLOW.md
@@ -2,7 +2,7 @@
 
 This guide summarizes the typical tools and branch strategy for human contributors to StackTrackr.
 
-**Current Release:** v3.03.06a
+**Current Release:** v3.03.07a
 
 ## Tools
 

--- a/docs/IMPLEMENTATION_SUMMARY.md
+++ b/docs/IMPLEMENTATION_SUMMARY.md
@@ -1,3 +1,28 @@
+# Implementation Summary: Theme Toggle Improvements
+
+> **Latest release: v3.03.07a**
+
+## Version Update: 3.03.06a → 3.03.07a
+
+## User Requirements Implemented
+
+- Removed appearance modal and added inline theme toggle cycling Dark → Light → System
+- Persisted theme preference in localStorage with immediate application
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`js/api.js`**: Removed appearance modal handlers
+2. **`js/state.js`**: Dropped appearanceModal reference
+3. **`js/init.js`**: Added three-state toggle fallback
+4. **`css/styles.css`**: Removed appearance modal styles
+5. **`js/constants.js`**: Bumped version to 3.03.07a
+6. **Documentation**: Updated references in README and docs
+
+### User Experience Improvements:
+- Theme button cycles through Dark, Light, and System modes
+- Selection persists via localStorage and applies instantly
+
 # Implementation Summary: Documentation Sweep & Archive Update
 
 > **Latest release: v3.03.06a**

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,12 +1,12 @@
-# Multi-Agent Development Workflow - StackTrackr v3.03.06a
+# Multi-Agent Development Workflow - StackTrackr v3.03.07a
 
-> **Latest release: v3.03.06a**
+> **Latest release: v3.03.07a**
 
 ## 🎯 Project Overview
 
-You are contributing to the **StackTrackr v3.03.06a**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to the **StackTrackr v3.03.07a**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.03.06a (alpha)
+**Current Status**: v3.03.07a (alpha)
 **Your Role**: Complete focused v3.03.x patch tasks as part of a coordinated multi-agent development effort
 
 ---
@@ -258,6 +258,6 @@ Before starting any patch entry, read these files:
 
 ---
 
-**Remember: Each patch entry is designed to be completed independently while contributing to the larger v3.03.06a vision. Focus on quality over speed, and don't hesitate to coordinate with other agents when working on shared components.**
+**Remember: Each patch entry is designed to be completed independently while contributing to the larger v3.03.07a vision. Focus on quality over speed, and don't hesitate to coordinate with other agents when working on shared components.**
 
 **Your contribution helps build a professional-grade inventory management system that serves users worldwide. Every patch matters!** 🚀

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,9 +2,9 @@
 
 This roadmap outlines upcoming patch releases for the v3.03.x series.
 
-- **v3.03.07a** – Multi-currency support for international users.
-- **v3.03.08a** – Enhanced backup encryption for sensitive data.
-- **v3.03.09a** – Additional API provider integrations.
-- **v3.03.10a** – Advanced reporting and analytics features.
-- **v3.03.11a** – Mobile application companion.
+- **v3.03.08a** – Multi-currency support for international users.
+- **v3.03.09a** – Enhanced backup encryption for sensitive data.
+- **v3.03.10a** – Additional API provider integrations.
+- **v3.03.11a** – Advanced reporting and analytics features.
+- **v3.03.12a** – Mobile application companion.
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,10 +1,10 @@
 # Project Status - StackTrackr
 
-> **Latest release: v3.03.06a**
+> **Latest release: v3.03.07a**
 
-## 🎯 Current State: **ALPHA v3.03.06a** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **ALPHA v3.03.07a** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.03.06a** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.03.07a** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
 
 ## 🏗️ Architecture Overview
 
@@ -22,6 +22,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.03.07a - Theme Toggle Improvements**: Replaced appearance modal with three-state Dark/Light/System toggle
 - **v3.03.06a - Documentation Sweep & Archive Update**: Version references synchronized across docs and archived build footer links back to current version
 - **v3.03.05a - Custom Mapping Rule Engine**: Prototype regex-based field mapping with Add/Apply/Clear controls in Settings
 - **v3.03.04a - Files Modal Storage Breakdown**: Added progress bar showing per-item storage usage with hover tooltips and click highlighting
@@ -127,8 +128,8 @@ All data is stored locally in the browser using localStorage with:
 ## 📚 Documentation Status (Updated: August 10, 2025)
 
 **All documentation files are current and synchronized:**
-- ✅ **STATUS.md** - Updated for v3.03.06a release
-- ✅ **CHANGELOG.md** - Current through v3.03.06a
+- ✅ **STATUS.md** - Updated for v3.03.07a release
+- ✅ **CHANGELOG.md** - Current through v3.03.07a
 - ✅ **MULTI_AGENT_WORKFLOW.md** - Comprehensive AI assistant development guide
 - ✅ **STRUCTURE.md** - Reflects streamlined project organization
 - ✅ **VERSIONING.md** - Accurate version management documentation
@@ -137,7 +138,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.03.06a (managed in `js/constants.js`)
+1. **Current Version**: 3.03.07a (managed in `js/constants.js`)
 2. **Last Change**: Documentation sweep and archive update
 3. **Last Documentation Update**: August 10, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns
@@ -154,7 +155,7 @@ If continuing development in a new chat session:
 ```
 StackTrackr/
 ├── js/                     # Modular JavaScript (cleaned structure)
-│   ├── constants.js        # Version 3.03.06a + metal configs
+│   ├── constants.js        # Version 3.03.07a + metal configs
 │   ├── state.js           # App state + DOM caching
 │   ├── inventory.js       # Core CRUD + notes handling
 │   ├── events.js          # UI event listeners

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -1,6 +1,6 @@
 # Project Structure
 
-> **Latest release: v3.03.06a**
+> **Latest release: v3.03.07a**
 
 The repository is organized as follows:
 

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.03.06a**
+> **Latest release: v3.03.07a**
 
 ## Overview 
 
@@ -9,7 +9,7 @@ The StackTrackr now uses a dynamic version management system that automatically 
 ## How It Works
 
 ### Single Source of Truth
-- Version is defined once in `js/constants.js` as `APP_VERSION = '3.03.06a'`
+- Version is defined once in `js/constants.js` as `APP_VERSION = '3.03.07a'`
   - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation
@@ -19,7 +19,7 @@ The StackTrackr now uses a dynamic version management system that automatically 
 
 ### Utility Functions
 - `js/constants.js` provides:
-  - `getVersionString(prefix)`: Returns formatted version (e.g., "v3.03.06a")
+  - `getVersionString(prefix)`: Returns formatted version (e.g., "v3.03.07a")
   - `injectVersionString(elementId, prefix)`: Inserts formatted version into a target element
 - `js/utils.js` provides:
   - `getAppTitle(baseTitle)`: Returns full app title with version
@@ -31,14 +31,14 @@ To release a new version:
 1. **Update ONLY the constants file:**
    ```javascript
    // In js/constants.js
-   const APP_VERSION = '3.03.06a';  // Change this line only
+   const APP_VERSION = '3.03.07a';  // Change this line only
    ```
 
 2. **All these will automatically update:**
-   - Page title: "StackTrackr v3.03.06a"
-   - Page heading: "StackTrackr v3.03.06a"
-   - Browser tab title: "StackTrackr v3.03.06a"
-   - App header: "StackTrackr v3.03.06a"
+   - Page title: "StackTrackr v3.03.07a"
+   - Page heading: "StackTrackr v3.03.07a"
+   - Browser tab title: "StackTrackr v3.03.07a"
+   - App header: "StackTrackr v3.03.07a"
 
 3. **Update changelog:** Add entry to `/docs/CHANGELOG.md` for documentation
 
@@ -73,7 +73,7 @@ state code is appended directly to the patch number:
   - `rc` = release candidate (final verification)
   - *(omit for stable builds)*
 
-Example: `3.03.06a` → branch 3, release 03, patch 06, alpha build
+Example: `3.03.07a` → branch 3, release 03, patch 07, alpha build
 
 ### Branching Policy
 - Each major **BRANCH** corresponds to a long-lived Git branch
@@ -85,15 +85,15 @@ Example: `3.03.06a` → branch 3, release 03, patch 06, alpha build
 ## Example Usage in Code
 ```javascript
 // Get just the version number
-const version = APP_VERSION; // "3.03.06a"
+const version = APP_VERSION; // "3.03.07a"
 
 // Get formatted version string
-const versionString = getVersionString(); // "v3.03.06a"
-const customVersion = getVersionString('version '); // "version 3.03.06a"
+const versionString = getVersionString(); // "v3.03.07a"
+const customVersion = getVersionString('version '); // "version 3.03.07a"
 
 // Get full app title
-const title = getAppTitle(); // "StackTrackr v3.03.06a"
-const customTitle = getAppTitle('My Custom Tool'); // "My Custom Tool v3.03.06a"
+const title = getAppTitle(); // "StackTrackr v3.03.07a"
+const customTitle = getAppTitle('My Custom Tool'); // "My Custom Tool v3.03.07a"
 ```
 
 This system ensures version consistency and makes maintenance much easier!

--- a/js/api.js
+++ b/js/api.js
@@ -1205,29 +1205,6 @@ const hideFilesModal = () => {
   }
 };
 
-const showAppearanceModal = () => {
-  const modal = document.getElementById("appearanceModal");
-  if (!modal) return;
-  const savedTheme = localStorage.getItem(THEME_KEY);
-  const themeValue = savedTheme ? savedTheme : "system";
-  const themeDisplay = document.getElementById("themeDisplay");
-  if (themeDisplay) {
-    themeDisplay.textContent =
-      themeValue === "dark"
-        ? "Dark Mode"
-        : themeValue === "light"
-          ? "Light Mode"
-          : "System";
-  }
-  modal.style.display = "flex";
-};
-
-const hideAppearanceModal = () => {
-  const modal = document.getElementById("appearanceModal");
-  if (modal) {
-    modal.style.display = "none";
-  }
-};
 
 /**
  * Shows provider information modal
@@ -1275,14 +1252,12 @@ const hideProviderInfo = () => {
 };
 
 // Make modal controls available globally
-window.showApiModal = showApiModal;
-window.hideApiModal = hideApiModal;
-window.showFilesModal = showFilesModal;
-window.hideFilesModal = hideFilesModal;
-window.showAppearanceModal = showAppearanceModal;
-window.hideAppearanceModal = hideAppearanceModal;
-window.showProviderInfo = showProviderInfo;
-window.hideProviderInfo = hideProviderInfo;
+  window.showApiModal = showApiModal;
+  window.hideApiModal = hideApiModal;
+  window.showFilesModal = showFilesModal;
+  window.hideFilesModal = hideFilesModal;
+  window.showProviderInfo = showProviderInfo;
+  window.hideProviderInfo = hideProviderInfo;
 
 window.handleProviderSync = handleProviderSync;
 window.clearApiKey = clearApiKey;

--- a/js/constants.js
+++ b/js/constants.js
@@ -98,13 +98,13 @@ const API_PROVIDERS = {
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
-const APP_VERSION = "3.03.06a";
+const APP_VERSION = "3.03.07a";
 
 /**
  * Returns formatted version string
  *
  * @param {string} [prefix="v"] - Prefix to add before version
- * @returns {string} Formatted version string (e.g., "v3.03.06a")
+ * @returns {string} Formatted version string (e.g., "v3.03.07a")
  */
 const getVersionString = (prefix = "v") => `${prefix}${APP_VERSION}`;
 

--- a/js/init.js
+++ b/js/init.js
@@ -104,7 +104,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Modal elements
     debugLog("Phase 4: Initializing modal elements...");
-    elements.appearanceModal = safeGetElement("appearanceModal");
     elements.apiModal = safeGetElement("apiModal");
     elements.filesModal = safeGetElement("filesModal");
     elements.apiInfoModal = safeGetElement("apiInfoModal");
@@ -377,12 +376,21 @@ function setupBasicEventListeners() {
     };
   }
 
-  // Appearance button
+  // Appearance button (three-state theme toggle)
   const appearanceBtn = document.getElementById("appearanceBtn");
   if (appearanceBtn) {
-    appearanceBtn.onclick = function () {
-      if (typeof showAppearanceModal === "function") {
-        showAppearanceModal();
+    appearanceBtn.onclick = function (e) {
+      e.preventDefault();
+      const savedTheme = localStorage.getItem(THEME_KEY);
+      if (savedTheme === "dark") {
+        setTheme("light");
+      } else if (savedTheme === "light") {
+        setTheme("system");
+      } else {
+        setTheme("dark");
+      }
+      if (typeof updateThemeButton === "function") {
+        updateThemeButton();
       }
     };
   }

--- a/js/state.js
+++ b/js/state.js
@@ -157,7 +157,6 @@ const elements = {
   appearanceBtn: null,
   apiBtn: null,
   filesBtn: null,
-  appearanceModal: null,
   apiModal: null,
   filesModal: null,
   apiInfoModal: null,

--- a/structure.md
+++ b/structure.md
@@ -1,6 +1,6 @@
 # StackTrackr - Project Structure
 
-## Current Structure (Version 3.03.06a)
+## Current Structure (Version 3.03.07a)
 
 ```text
 ├── css/


### PR DESCRIPTION
## Summary
- remove unused Appearance modal styles and handlers
- convert theme switcher to a Dark/Light/System toggle with live localStorage persistence
- bump app version to v3.03.07a and refresh docs

## Testing
- `npm test` *(fails: could not read package.json)*
- `node --check js/api.js js/state.js js/init.js js/constants.js`


------
https://chatgpt.com/codex/tasks/task_e_68995264443c832ea8be95c56dbba889