### PR TITLE
docs: add UI style guide

### DIFF
--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -39,6 +39,7 @@ Before starting any patch entry, read these files:
 - `docs/archive/notes/V3.2.0-PLANNING-NOTES.md` - Technical implementation details
 - `docs/STATUS.md` - Current project status
 - `docs/STRUCTURE.md` - Project architecture and file organization
+- `docs/UI_STYLE_GUIDE.md` - UI color, typography, and component conventions
 - `docs/FUNCTIONSTABLE.md` - Reference table of all JavaScript functions
 
 ### **Step 2: Choose Your Patch Entry**

--- a/docs/STRUCTURE.md
+++ b/docs/STRUCTURE.md
@@ -23,7 +23,7 @@ The repository is organized as follows:
 
 - **css/** – Contains the global `styles.css` stylesheet.
 - **debug/** – Holds temporary debugging files.
-- **docs/** – Changelogs, workflow notes, roadmap, and future planning documentation.
+- **docs/** – Changelogs, workflow notes, roadmap, and future planning documentation. Includes the [UI Style Guide](UI_STYLE_GUIDE.md).
 - **archive/** – Contains the last stable build for users needing a fallback.
 - **js/** – All JavaScript modules powering the application, including `customMapping.js` for regex-based field mapping.
 - **index.html** – Entry point and user interface for the tool.

--- a/docs/UI_STYLE_GUIDE.md
+++ b/docs/UI_STYLE_GUIDE.md
@@ -1,0 +1,82 @@
+# UI Style Guide
+
+This guide summarizes the visual design conventions used throughout StackTrackr. It references existing CSS variables from [`css/styles.css`](../css/styles.css) and component patterns in `index.html`.
+
+## Color Palette
+
+StackTrackr uses CSS custom properties to centralize theming:
+
+- **Primary:** `var(--primary)` / hover `var(--primary-hover)`
+- **Secondary:** `var(--secondary)` / hover `var(--secondary-hover)`
+- **Success:** `var(--success)` / hover `var(--success-hover)`
+- **Warning:** `var(--warning)` / hover `var(--warning-hover)`
+- **Danger:** `var(--danger)` / hover `var(--danger-hover)`
+- **Backgrounds:** `var(--bg-primary)`, `var(--bg-secondary)`, `var(--bg-tertiary)`
+- **Text:** `var(--text-primary)`, `var(--text-secondary)`, `var(--text-muted)`
+
+Dark mode provides parallel variables under the `[data-theme="dark"]` selector.
+
+## Typography
+
+- Global font stack is defined on the `html` element (`Inter`, system sans-serif fallbacks).
+- Headings:
+  - `h1`: `1.875rem` and colored with `var(--primary)`
+  - `h2`: `1.25rem`, `var(--text-primary)`
+- Labels use `font-weight: 500` at `0.875rem`.
+
+## Spacing & Layout
+
+Reusable spacing tokens ensure consistent rhythm:
+
+- `--spacing-sm: 0.4rem`
+- `--spacing: 0.75rem`
+- `--spacing-lg: 1.25rem`
+- `--spacing-xl: 1.5rem`
+- Border radii: `--radius` and `--radius-lg`
+
+## Header
+
+The main application header uses the `.app-header` container with a gradient title:
+
+```html
+<div class="app-header">
+  <div class="app-title">
+    <h1>StackTrackr</h1>
+    <p class="app-subtitle">The open source precious metals tracking tool.</p>
+  </div>
+  <!-- action buttons -->
+</div>
+```
+
+`css/styles.css` applies background `var(--bg-card)`, border `var(--border)`, spacing, and shadow.
+
+## Modals
+
+All dialogs follow a consistent structure:
+
+```html
+<div class="modal" id="exampleModal">
+  <div class="modal-content">
+    <div class="modal-header">
+      <button class="modal-close">×</button>
+    </div>
+    <div class="modal-body">...</div>
+  </div>
+</div>
+```
+
+Key styles:
+
+- `.modal` centers content with a translucent backdrop.
+- `.modal-content` uses `var(--bg-card)`, `var(--border)`, and `var(--radius-lg)`.
+- `.modal-close` is absolutely positioned in the header with hover feedback.
+
+## Buttons
+
+The `.btn` class provides the base button style with variant modifiers:
+
+- Default buttons use `var(--primary)` with hover state `var(--primary-hover)`.
+- Variants: `.success`, `.danger`, `.secondary`, `.warning`, and `.premium` map to their respective color variables.
+- Buttons include a subtle shine effect via the `::before` pseudo-element and use `var(--radius)` for rounded corners.
+
+Use these guidelines to keep new UI elements consistent with the existing design system.


### PR DESCRIPTION
## Summary
- document color palette, typography, spacing, modal/header conventions, and button variants in new UI style guide
- link UI style guide from structure and multi-agent workflow docs for visibility

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68995506bb34832eb03ba62fe5d9cf93