### PR TITLE
Normalize documentation links to lowercase

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ The public hosted version of the app is available at [stackrtrackr.com](https://
   - Enhanced click-to-sort functionality for all table columns
   - Added dedicated Notes button for easy access to item notes
 - **Documentation Consolidation**: Improved AI assistant guidance and development workflow
-  - Removed redundant `docs/LLM.md` file (archived to `docs/archive/llm.md`)
+  - Removed redundant `docs/llm.md` file (archived to `docs/archive/llm.md`)
   - Replaced with comprehensive `docs/MULTI_AGENT_WORKFLOW.md`
   - Enhanced multi-agent coordination protocols and quality standards
   - Streamlined documentation structure eliminates redundancy
@@ -227,7 +227,7 @@ Each inventory item includes:
 - The root `index.html` hosts the main application interface.
 
 ## Documentation
-- **[docs/README.md](docs/README.md)** - Detailed project information.
+- **[README.md](README.md)** - Detailed project information.
 - **[docs/MULTI_AGENT_WORKFLOW.md](docs/MULTI_AGENT_WORKFLOW.md)** - AI assistant development workflow.
 - **[docs/changelog.md](docs/changelog.md)** - Version history and features.
 - **[docs/status.md](docs/status.md)** - Current project status.

--- a/docs/archive/llm.md
+++ b/docs/archive/llm.md
@@ -4,7 +4,7 @@
 >  
 > **LLM INSTRUCTION**: After any code change, verify and update these files:
 > ```
-> docs/README.md               — User guidance, features, installation, contribution
+> README.md                     — User guidance, features, installation, contribution
 > docs/archive/llm.md          — This AI assistant guide (you are here)
 > docs/changelog.md            — Version history with dates and notes
 > docs/status.md               — Current status and feature coverage

--- a/docs/archive/notes/documentation-consolidation.md
+++ b/docs/archive/notes/documentation-consolidation.md
@@ -1,12 +1,12 @@
-# Documentation Consolidation - LLM.md Removal
+# Documentation Consolidation - llm.md Removal
 
 ## Change Summary
 **Date**: August 8, 2025  
-**Action**: Removed redundant `docs/LLM.md` file  
+**Action**: Removed redundant `docs/llm.md` file
 **Reason**: Superseded by more comprehensive `docs/MULTI_AGENT_WORKFLOW.md`
 
 ## Analysis
-The original `docs/LLM.md` served as a general AI assistant guide but contained:
+The original `docs/llm.md` served as a general AI assistant guide but contained:
 - ❌ Outdated version references (v3.1.9)
 - ❌ Limited actionable guidance
 - ❌ Significant overlap with new workflow documentation
@@ -14,7 +14,7 @@ The original `docs/LLM.md` served as a general AI assistant guide but contained:
 
 ## Replacement
 `docs/MULTI_AGENT_WORKFLOW.md` provides:
-- ✅ **Complete project context** - Everything from LLM.md plus more
+- ✅ **Complete project context** - Everything from llm.md plus more
 - ✅ **Current v3.2.07rc focus** - Up-to-date technical information
 - ✅ **Actionable workflow guidance** - Specific step-by-step processes
 - ✅ **Quality standards** - Testing and validation protocols
@@ -22,13 +22,13 @@ The original `docs/LLM.md` served as a general AI assistant guide but contained:
 - ✅ **Comprehensive architecture** - Detailed technical context
 
 ## File Location
-- **Removed**: `docs/LLM.md` 
+- **Removed**: `docs/llm.md`
 - **Archived**: `docs/archive/llm.md` (for historical reference)
 - **Primary Guide**: `docs/MULTI_AGENT_WORKFLOW.md`
 
 ## Documentation Updates Needed
 - ✅ No cross-references found that need updating
-- ✅ No workflow documents reference LLM.md
+- ✅ No workflow documents reference llm.md
 - ✅ Clean removal with no breaking references
 
 ## Future AI Assistant Handoffs

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -149,7 +149,7 @@ For upcoming work, see [roadmap](roadmap.md).
   - Enhanced click-to-sort functionality across all table columns
   - Added dedicated Notes button for quick access to item notes
 - **Documentation Improvement**: Consolidated AI assistant guidance into comprehensive workflow system
-  - Removed redundant `docs/LLM.md` file (archived to `docs/archive/llm.md`)
+  - Removed redundant `docs/llm.md` file (archived to `docs/archive/llm.md`)
   - Replaced with enhanced `docs/MULTI_AGENT_WORKFLOW.md` providing complete project context
   - Improved multi-agent coordination protocols and quality standards
   - Updated workflow guidance with actionable step-by-step processes
@@ -273,11 +273,11 @@ For upcoming work, see [roadmap](roadmap.md).
 - **Code Quality Improvements**:  
   - JSDoc for new functions  
   - Modular architecture and separation of concerns  
-- **Documentation Updates**: Corrected version refs in LLM.md and structure.md; removed stale links
+- **Documentation Updates**: Corrected version refs in llm.md and structure.md; removed stale links
 
 ### Version 3.0.3 – Documentation Restructure (2025-08-06)
 - Moved docs to `/docs/`  
-- Updated `structure.md` & `docs/README.md`
+- Updated `structure.md` & `README.md`
 - Fixed broken internal links  
 - No functional changes
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -51,7 +51,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
   - Color-coded table items for better visual organization
   - Enhanced click-to-sort functionality across all table columns
   - Added dedicated Notes button for quick access to item notes
-  - Removed redundant `docs/LLM.md` file (archived to `docs/archive/llm.md`)
+  - Removed redundant `docs/llm.md` file (archived to `docs/archive/llm.md`)
   - Replaced with comprehensive `docs/MULTI_AGENT_WORKFLOW.md`
   - Enhanced multi-agent coordination protocols and quality standards
   - Streamlined documentation structure eliminates redundancy


### PR DESCRIPTION
## Summary
- Remove legacy `docs/LLM.md` references, switching to lowercase `llm.md`
- Fix outdated `docs/README.md` link and align doc references with current structure

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68995cce6424832eae6ce3c6744f9857