### PR TITLE
Enhance version update modal with roadmap and privacy notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# StackTrackr v3.03.08b
+# StackTrackr v3.03.08c
 
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
 
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
+- **v3.03.08c - Version Modal Enhancements**: Version change dialog now includes privacy notice, resources, and roadmap
 - **v3.03.08b - Files Modal Simplification**: Removed storage breakdown progress bar for cleaner file management
 - **v3.03.08a - Version Update Changelog Modal**: Displays release notes when the app version changes
 - **v3.03.07b - Documentation Normalization**: Renamed documentation files to lowercase and updated all internal references
@@ -29,6 +30,11 @@ The public hosted version of the app is available at [stackrtrackr.com](https://
 - **v3.1.9 - UI Consistency**: Clear Cache button styling improvements across themes
 - **v3.1.8 - Backup System**: Full ZIP backup functionality with restoration guides
 - **v3.1.6 - Theme Toggle**: Fixed theme management with system preference detection
+
+## 🆕 What's New in v3.03.08c
+- Version change dialog now includes privacy notice and upcoming roadmap
+- About modal no longer shows Key Features section
+- Version notice only appears for users with existing data
 
 ## 🆕 What's New in v3.03.08b
 - Files modal no longer displays storage breakdown progress bar
@@ -285,7 +291,7 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: 3.03.08b
+**Current Version**: 3.03.08c
 **Last Updated**: August 10, 2025
 **Status**: Feature complete release candidate
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -1694,48 +1694,6 @@ td input:checked + .slider:before {
   border: 1px solid var(--border);
 }
 
-.about-features {
-  margin-bottom: var(--spacing-xl);
-}
-
-.features-title {
-  font-size: 1.25rem;
-  font-weight: 600;
-  color: var(--primary);
-  margin-bottom: var(--spacing);
-  text-align: center;
-}
-
-.features-grid {
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: var(--spacing-sm);
-  margin-bottom: var(--spacing);
-}
-
-@media (max-width: 768px) {
-  .features-grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-
-.feature-item {
-  background: var(--bg-secondary);
-  padding: var(--spacing);
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  font-weight: 500;
-  color: var(--text-primary);
-  text-align: center;
-  transition: var(--transition);
-}
-
-.feature-item:hover {
-  background: var(--bg-tertiary);
-  border-color: var(--primary);
-  transform: translateY(-2px);
-  box-shadow: var(--shadow);
-}
 
 .about-alert {
   background: linear-gradient(135deg, #fef2f2, #fff8f8);
@@ -1915,10 +1873,6 @@ td input:checked + .slider:before {
 
   .about-title {
     font-size: 1.5rem;
-  }
-
-  .features-grid {
-    grid-template-columns: 1fr;
   }
 
   .resources-grid {

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,12 +1,12 @@
-# Multi-Agent Development Workflow - StackTrackr v3.03.08b
+# Multi-Agent Development Workflow - StackTrackr v3.03.08c
 
-> **Latest release: v3.03.08b**
+> **Latest release: v3.03.08c**
 
 ## 🎯 Project Overview
 
-You are contributing to the **StackTrackr v3.03.07b**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to the **StackTrackr v3.03.08c**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.03.07b (beta)
+**Current Status**: v3.03.08c (beta)
 **Your Role**: Complete focused v3.03.x patch tasks as part of a coordinated multi-agent development effort
 
 ---
@@ -259,6 +259,6 @@ Before starting any patch entry, read these files:
 
 ---
 
-**Remember: Each patch entry is designed to be completed independently while contributing to the larger v3.03.07b vision. Focus on quality over speed, and don't hesitate to coordinate with other agents when working on shared components.**
+**Remember: Each patch entry is designed to be completed independently while contributing to the larger v3.03.08c vision. Focus on quality over speed, and don't hesitate to coordinate with other agents when working on shared components.**
 
 **Your contribution helps build a professional-grade inventory management system that serves users worldwide. Every patch matters!** 🚀

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,10 +1,16 @@
 # StackTrackr — Changelog
 
-> **Latest release: v3.03.08b**
+> **Latest release: v3.03.08c**
 
 For upcoming work, see [roadmap](roadmap.md).
 
 ## 📋 Version History
+
+### Version 3.03.08c – Version Modal Enhancements (2025-08-10)
+- Added privacy notice, resources, and roadmap to version change modal
+- Roadmap sections now list upcoming updates
+- Removed Key Features section from About modal
+- Version notice only appears for existing users with saved data
 
 ### Version 3.03.08b – Files Modal Simplification (2025-08-10)
 - Removed storage breakdown progress bar from Files modal for a cleaner interface

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,6 +1,6 @@
 # Function Reference
 
-> **Latest release: v3.03.08b**
+> **Latest release: v3.03.08c**
 
 | File | Function | Description |
 |------|----------|-------------|
@@ -13,6 +13,7 @@
 | about.js | populateAckModal | Populates the acknowledgment modal with version information |
 | about.js | loadChangelog | Loads changelog information from docs/changelog.md and populates the About modal |
 | about.js | extractChangelogItems | Extracts changelog items from content, filtering for meaningful changes |
+| about.js | loadRoadmap | Loads roadmap information and populates roadmap lists in modals |
 | about.js | showFullChangelog | Shows full changelog in a new window or navigates to documentation |
 | about.js | setupAboutModalEvents | Sets up event listeners for about modal elements |
 | about.js | setupAckModalEvents | Sets up event listeners for acknowledgment modal elements |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,27 +1,35 @@
+# Implementation Summary: Version Modal Enhancements
+
+> **Latest release: v3.03.08c**
+
+## Version Update: 3.03.08b → 3.03.08c
+
+## User Requirements Implemented
+
+- Added privacy notice, resources, and roadmap to version change modal
+- Roadmap sections now list upcoming updates
+- Removed Key Features section from About modal
+- Version notice shown only when existing data is present
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`index.html`**: Expanded version modal, removed Key Features, added roadmap list
+2. **`css/styles.css`**: Removed feature styling
+3. **`js/about.js`**: Added `loadRoadmap` and event hooks
+4. **`js/versionCheck.js`**: Show ack modal for new users and populate roadmap
+5. **`js/init.js`**: Removed automatic ack modal call
+6. **`js/constants.js`**: Bumped version to 3.03.08c
+7. **Documentation**: Updated `changelog.md`, `functionstable.md`, `implementation_summary.md`, `status.md`, `roadmap.md`, `structure.md`, `MULTI_AGENT_WORKFLOW.md`, and `README.md`
+
+### User Experience Improvements:
+- Version updates provide full context and resources
+
 # Implementation Summary: Files Modal Simplification
 
 > **Latest release: v3.03.08b**
 
 ## Version Update: 3.03.08a → 3.03.08b
-
-## User Requirements Implemented
-
-- Removed storage breakdown progress bar from Files modal
-
-## Technical Changes Made
-
-### Files Modified:
-1. **`index.html`**: Removed Files modal storage breakdown markup
-2. **`js/inventory.js`**: Removed `renderFilesProgress` function and color mapping
-3. **`js/api.js`**: Simplified `showFilesModal` by removing progress rendering
-4. **`css/styles.css`**: Removed `.files-progress` styling
-5. **`js/constants.js`**: Bumped version to 3.03.08b
-6. **Documentation**: Updated `changelog.md`, `functionstable.md`, `implementation_summary.md`, `status.md`, `roadmap.md`, `structure.md`, and `README.md`
-
-### User Experience Improvements:
-- Files modal focuses on import/export actions without storage distraction
-
-# Implementation Summary: Version Update Changelog Modal
 
 > **Latest release: v3.03.08a**
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,6 +5,7 @@ This roadmap outlines upcoming patch releases for the v3.03.x series.
 - **v3.03.07b** – Documentation normalization and reference cleanup *(completed)*
 - **v3.03.08a** – Version update changelog modal *(completed)*
 - **v3.03.08b** – Files modal storage breakdown removal *(completed)*
+- **v3.03.08c** – Version modal enhancements *(completed)*
 - **v3.03.09a** – Multi-currency support for international users.
 - **v3.03.10a** – Enhanced backup encryption for sensitive data.
 - **v3.03.11a** – Additional API provider integrations.

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,10 +1,10 @@
 # Project Status - StackTrackr
 
-> **Latest release: v3.03.08b**
+> **Latest release: v3.03.08c**
 
-## 🎯 Current State: **BETA v3.03.08b** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.03.08c** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.03.08b** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.03.08c** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
 
 ## 🏗️ Architecture Overview
 
@@ -23,6 +23,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.03.08c - Version Modal Enhancements**: Version change dialog now includes privacy notice, resources, and roadmap
 - **v3.03.08b - Files Modal Simplification**: Removed storage breakdown progress bar for streamlined file management
 - **v3.03.08a - Version Update Changelog Modal**: Notifies users of new releases with modal displaying latest changes
 - **v3.03.07b - Documentation Normalization**: Converted documentation filenames to lowercase and updated references

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,6 +1,6 @@
 # Project Structure
 
-> **Latest release: v3.03.08b**
+> **Latest release: v3.03.08c**
 
 The repository is organized as follows:
 

--- a/index.html
+++ b/index.html
@@ -1253,39 +1253,16 @@
               </p>
             </div>
           </div>
-          <!-- Key Features -->
-          <div class="about-features">
-            <div class="features-title">✨ Key Features</div>
-            <div class="features-grid">
-              <div class="feature-item">📊 Live Spot Price Tracking</div>
-              <div class="feature-item">💰 Premium & Profit Calculations</div>
-              <div class="feature-item">📈 Advanced Analytics & Charts</div>
-              <div class="feature-item">📁 Multi-Format Import/Export</div>
-              <div class="feature-item">🔍 Real-time Search & Filtering</div>
-              <div class="feature-item">🏦 Storage Location Tracking</div>
-              <div class="feature-item">🎨 Dark/Light Theme Support</div>
-              <div class="feature-item">🔒 100% Local Storage</div>
-            </div>
-          </div>
-
           <!-- What's New and Roadmap -->
           <div class="about-info-grid">
             <div class="about-section">
-              <div class="section-title">
-                🚀 What's New in <span id="aboutCurrentVersion"></span>
-              </div>
+              <div class="section-title">🚀 What's New in <span id="aboutCurrentVersion"></span></div>
               <ul id="aboutChangelogLatest" class="changelog-list"></ul>
             </div>
 
             <div class="about-section" id="aboutRoadmapSection">
               <div class="section-title">🗺️ Development Roadmap</div>
-              <p>
-                See the
-                <a href="docs/roadmap.md" target="_blank" rel="noopener"
-                  >project roadmap</a
-                >
-                for upcoming patch plans.
-              </p>
+              <ul id="aboutRoadmapList" class="changelog-list"></ul>
             </div>
           </div>
 
@@ -1315,13 +1292,72 @@
     <div class="modal" id="versionModal" style="display: none">
       <div class="modal-content about-modal-content">
         <div class="modal-header about-modal-header">
-          <h1 class="about-title">
-            What's New <span id="versionModalVersion"></span>
-          </h1>
+          <h1 class="about-title">What's New <span id="versionModalVersion"></span></h1>
           <button aria-label="Close modal" class="modal-close" id="versionCloseBtn">×</button>
         </div>
         <div class="modal-body about-modal-body">
-          <div id="versionChanges"></div>
+          <div class="about-alert">
+            <div class="alert-header">
+              <span class="alert-icon">⚠️</span>
+              <strong>Important Privacy &amp; Data Notice</strong>
+            </div>
+            <div class="alert-content">
+              <p>
+                <strong>Your Privacy is Protected:</strong> All data is stored locally in your browser using localStorage and
+                <em>never transmitted to any server</em>. Your precious metals inventory information remains completely private
+                and under your control.
+              </p>
+
+              <p>
+                <strong>Data Backup Responsibility:</strong> Since data is stored locally, it will be lost if you clear browser
+                history, reset browser data, or use private browsing mode. Remember to export your data regularly to keep a
+                copy.
+              </p>
+
+              <p>
+                <strong>Use at Your Own Risk:</strong> This tool is provided for informational and organizational purposes only.
+                The developer assumes no responsibility for any financial decisions, investment choices, or data loss. Always
+                verify spot prices and calculations independently.
+              </p>
+
+              <p>
+                <strong>Spot Price Accuracy:</strong> Prices displayed are for reference only and may not reflect real-time
+                market conditions. Always confirm current pricing with your dealer or official market sources before making
+                transactions.
+              </p>
+            </div>
+          </div>
+
+          <div class="about-info-grid">
+            <div class="about-section">
+              <div class="section-title">🚀 What's New</div>
+              <div id="versionChanges"></div>
+            </div>
+
+            <div class="about-section">
+              <div class="section-title">🗺️ Development Roadmap</div>
+              <ul id="versionRoadmapList" class="changelog-list"></ul>
+            </div>
+          </div>
+
+          <div class="about-section">
+            <div class="section-title">📄 Resources &amp; Links</div>
+            <div class="resources-grid">
+              <a class="resource-btn" href="sample.csv" download="sample.csv">
+                📄 Download Sample Data
+              </a>
+              <a
+                class="resource-btn"
+                href="https://github.com/lbruton/Precious-Metals-Inventory"
+                target="_blank"
+                rel="noopener"
+              >
+                📁 View Source Code
+              </a>
+              <button class="resource-btn" id="versionShowChangelogBtn">📜 View Full Changelog</button>
+            </div>
+          </div>
+
           <div class="alert-actions">
             <button class="btn btn-primary" id="versionAcceptBtn">Accept and continue</button>
           </div>

--- a/js/about.js
+++ b/js/about.js
@@ -76,6 +76,7 @@ const populateAboutModal = () => {
 
   // Load changelog data
   loadChangelog();
+  loadRoadmap();
 };
 
 /**
@@ -176,6 +177,41 @@ const extractChangelogItems = (content) => {
 };
 
 /**
+ * Loads roadmap information and populates roadmap lists in modals
+ */
+const loadRoadmap = async () => {
+  const targets = [
+    document.getElementById("aboutRoadmapList"),
+    document.getElementById("versionRoadmapList"),
+  ].filter(Boolean);
+  if (!targets.length) return;
+
+  try {
+    const res = await fetch("docs/roadmap.md");
+    if (!res.ok) throw new Error("roadmap.md not found");
+    const text = await res.text();
+    const lines = text
+      .split("\n")
+      .filter((l) => l.trim().startsWith("-"))
+      .filter((l) => !l.toLowerCase().includes("completed"))
+      .slice(0, 3)
+      .map((l) => l.replace(/^[-*]\s*/, ""));
+    const items = lines
+      .map((l) => {
+        const safe = sanitizeHtml(l).replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>");
+        return `<li>${safe}</li>`;
+      })
+      .join("");
+    targets.forEach((el) => (el.innerHTML = items));
+  } catch (e) {
+    console.warn("Could not load roadmap", e);
+    targets.forEach(
+      (el) => (el.innerHTML = "<li>Roadmap information unavailable</li>")
+    );
+  }
+};
+
+/**
  * Shows full changelog in a new window or navigates to documentation
  */
 const showFullChangelog = () => {
@@ -198,6 +234,9 @@ const setupAboutModalEvents = () => {
   const aboutShowChangelogBtn = document.getElementById(
     "aboutShowChangelogBtn",
   );
+  const versionShowChangelogBtn = document.getElementById(
+    "versionShowChangelogBtn",
+  );
   const aboutModal = document.getElementById("aboutModal");
 
   // Close button
@@ -208,6 +247,10 @@ const setupAboutModalEvents = () => {
   // Show changelog button
   if (aboutShowChangelogBtn) {
     aboutShowChangelogBtn.addEventListener("click", showFullChangelog);
+  }
+
+  if (versionShowChangelogBtn) {
+    versionShowChangelogBtn.addEventListener("click", showFullChangelog);
   }
 
   // Click outside to close
@@ -274,4 +317,5 @@ if (typeof window !== "undefined") {
   window.setupAckModalEvents = setupAckModalEvents;
   window.populateAboutModal = populateAboutModal;
   window.populateAckModal = populateAckModal;
+  window.loadRoadmap = loadRoadmap;
 }

--- a/js/constants.js
+++ b/js/constants.js
@@ -98,7 +98,7 @@ const API_PROVIDERS = {
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
-const APP_VERSION = "3.03.08b";
+const APP_VERSION = "3.03.08c";
 
 /**
  * Returns formatted version string

--- a/js/init.js
+++ b/js/init.js
@@ -138,9 +138,6 @@ document.addEventListener("DOMContentLoaded", () => {
     if (typeof setupAckModalEvents === "function") {
       setupAckModalEvents();
     }
-    if (typeof showAckModal === "function") {
-      showAckModal();
-    }
     if (typeof setupAboutModalEvents === "function") {
       setupAboutModalEvents();
     }

--- a/js/versionCheck.js
+++ b/js/versionCheck.js
@@ -6,6 +6,14 @@
  * Compares stored version with current and shows changelog modal if needed
  */
 const checkVersionChange = () => {
+  const hasData = !!localStorage.getItem(LS_KEY);
+  if (!hasData) {
+    if (typeof showAckModal === "function") {
+      showAckModal();
+    }
+    return;
+  }
+
   const acknowledged = localStorage.getItem(VERSION_ACK_KEY);
   const current = localStorage.getItem(APP_VERSION_KEY) || APP_VERSION;
   if (acknowledged === current) return;
@@ -61,6 +69,9 @@ const populateVersionModal = (version, html) => {
   modal.style.display = "block";
   document.body.style.overflow = "hidden";
   setupVersionModalEvents(version);
+  if (typeof loadRoadmap === "function") {
+    loadRoadmap();
+  }
 };
 
 /**

--- a/structure.md
+++ b/structure.md
@@ -1,6 +1,6 @@
 # StackTrackr - Project Structure
 
-## Current Structure (Version 3.03.08b)
+## Current Structure (Version 3.03.08c)
 
 ```text
 ├── css/


### PR DESCRIPTION
## Summary
- show privacy & data notice, resources, and roadmap items in version change modal
- drop obsolete Key Features block from About page and display upcoming roadmap entries
- only display version change modal for users with existing data

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689969bdb408832ea7f1114bbcc02a01