### PR TITLE
docs: remove deprecated roadmap items

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,9 +7,6 @@ This roadmap outlines upcoming patch releases for the v3.03.x series.
 - **v3.03.08b** – Files modal storage breakdown removal *(completed)*
 - **v3.03.08d** – Version modal centering *(completed)*
 - **v3.03.08c** – Version modal enhancements *(completed)*
-- **v3.03.09a** – Multi-currency support for international users.
-- **v3.03.10a** – Enhanced backup encryption for sensitive data.
-- **v3.03.11a** – Additional API provider integrations.
 - **v3.03.12a** – Advanced reporting and analytics features.
 - **v3.03.13a** – Mobile application companion.
 


### PR DESCRIPTION
## Summary
- remove roadmap entries for v3.03.09a multi-currency support, v3.03.10a enhanced backup encryption, and v3.03.11a additional API provider integrations

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689976459f88832eac60eebb1c151e39