### PR TITLE
feat: sanitize CSV import fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# StackTrackr v3.03.08e
+# StackTrackr v3.03.08f
 
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
 
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
+- **v3.03.08f - CSV import field sanitization**: Invalid fields are blanked and users can merge or override during import
 - **v3.03.08e - Numista CSV storage**: Stores raw Numista CSV and classifies metals by composition
 - **v3.03.08d - Version Modal Centering**: Version change dialog now properly centers in the viewport
 - **v3.03.08c - Version Modal Enhancements**: Version change dialog now includes privacy notice, resources, and roadmap
@@ -32,6 +33,9 @@ The public hosted version of the app is available at [stackrtrackr.com](https://
 - **v3.1.9 - UI Consistency**: Clear Cache button styling improvements across themes
 - **v3.1.8 - Backup System**: Full ZIP backup functionality with restoration guides
 - **v3.1.6 - Theme Toggle**: Fixed theme management with system preference detection
+
+## 🆕 What's New in v3.03.08f
+- CSV import accepts rows with bad data and lets you merge or override existing inventory
 
 ## 🆕 What's New in v3.03.08e
 - Imported Numista CSV preserved in localStorage with improved metal mapping

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,6 +1,6 @@
 # Multi-Agent Development Workflow - StackTrackr v3.03.08e
 
-> **Latest release: v3.03.08e**
+> **Latest release: v3.03.08f**
 
 ## 🎯 Project Overview
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,10 +1,14 @@
 # StackTrackr — Changelog
 
-> **Latest release: v3.03.08e**
+> **Latest release: v3.03.08f**
 
 For upcoming work, see [roadmap](roadmap.md).
 
 ## 📋 Version History
+
+### Version 3.03.08f – CSV import field sanitization (2025-08-10)
+- CSV imports now leave invalid fields blank instead of skipping rows
+- Users can choose to merge imported data with existing inventory or override it
 
 ### Version 3.03.08e – Numista CSV storage (2025-08-10)
 - Stores imported Numista CSV in raw form within localStorage

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,6 +1,6 @@
 # Function Reference
 
-> **Latest release: v3.03.08e**
+> **Latest release: v3.03.08f**
 
 | File | Function | Description |
 |------|----------|-------------|
@@ -154,6 +154,7 @@
 | utils.js | loadData | Loads data from localStorage with error handling |
 | utils.js | sortInventoryByDateNewestFirst | Sorts inventory by date (newest first) |
 | utils.js | validateInventoryItem | Validates inventory item data |
+| utils.js | sanitizeImportedItem | Coerces invalid imported fields to safe defaults |
 | utils.js | handleError | Handles errors with user-friendly messaging |
 | utils.js | getUserFriendlyMessage | Converts technical error messages to user-friendly ones |
 | utils.js | downloadFile | Downloads a file with the specified content and filename |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,3 +1,25 @@
+# Implementation Summary: CSV Import Field Sanitization
+
+> **Latest release: v3.03.08f**
+
+## Version Update: 3.03.08e → 3.03.08f
+
+## User Requirements Implemented
+
+- Leave invalid CSV fields blank instead of rejecting rows
+- Allow users to merge imported data or override existing inventory
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`js/utils.js`**: Added `sanitizeImportedItem` helper and improved `formatDollar`
+2. **`js/inventory.js`**: CSV and Numista importers sanitize fields and support merge/override
+3. **`js/constants.js`**: Bumped version to 3.03.08f
+4. **Documentation**: Updated changelog, function table, implementation summary, status, roadmap, structure, and README
+
+### User Experience Improvements:
+- Imports no longer fail due to bad data; users choose how to integrate items
+
 # Implementation Summary: Numista CSV Storage
 
 > **Latest release: v3.03.08e**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,6 +8,7 @@ This roadmap outlines upcoming patch releases for the v3.03.x series.
 - **v3.03.08d** – Version modal centering *(completed)*
 - **v3.03.08c** – Version modal enhancements *(completed)*
 - **v3.03.08e** – Numista CSV storage and metal classification *(completed)*
+- **v3.03.08f** – CSV import field sanitization and merge option *(completed)*
 - **v3.03.12a** – Advanced reporting and analytics features.
 - **v3.03.13a** – Mobile application companion.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,10 +1,10 @@
 # Project Status - StackTrackr
 
-> **Latest release: v3.03.08e**
+> **Latest release: v3.03.08f**
 
-## 🎯 Current State: **BETA v3.03.08e** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.03.08f** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.03.08e** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.03.08f** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
 
 ## 🏗️ Architecture Overview
 
@@ -22,6 +22,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 - `utils.js` - Helper functions and formatters
 
 ## ✨ Latest Changes
+- **v3.03.08f - CSV import field sanitization**: Invalid fields are blanked and users can merge or override during import
 - **v3.03.08e - Numista CSV storage**: Stores raw Numista CSV and classifies metals by composition
 - **v3.03.08d - Version Modal Centering**: Version change dialog now appears centered on the screen
 - **v3.03.08c - Version Modal Enhancements**: Version change dialog now includes privacy notice, resources, and roadmap
@@ -134,8 +135,8 @@ All data is stored locally in the browser using localStorage with:
 ## 📚 Documentation Status (Updated: August 10, 2025)
 
 **All documentation files are current and synchronized:**
- - ✅ **status.md** - Updated for v3.03.08e release
- - ✅ **changelog.md** - Current through v3.03.08e
+ - ✅ **status.md** - Updated for v3.03.08f release
+ - ✅ **changelog.md** - Current through v3.03.08f
 - ✅ **MULTI_AGENT_WORKFLOW.md** - Comprehensive AI assistant development guide
 - ✅ **structure.md** - Reflects streamlined project organization
 - ✅ **versioning.md** - Accurate version management documentation

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,6 +1,6 @@
 # Project Structure
 
-> **Latest release: v3.03.08e**
+> **Latest release: v3.03.08f**
 
 The repository is organized as follows:
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.03.07b**
+> **Latest release: v3.03.08f**
 
 ## Overview 
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -98,7 +98,7 @@ const API_PROVIDERS = {
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
-const APP_VERSION = "3.03.08e";
+const APP_VERSION = "3.03.08f";
 
 /**
  * Returns formatted version string

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -981,116 +981,90 @@ const importCsv = (file) => {
       header: true,
       skipEmptyLines: true,
       complete: function(results) {
-      const imported = [];
-      const skippedDetails = [];
-      const totalRows = results.data.length;
-      startImportProgress(totalRows);
-      let processed = 0;
-      let importedCount = 0;
+        const imported = [];
+        const totalRows = results.data.length;
+        startImportProgress(totalRows);
+        let processed = 0;
+        let importedCount = 0;
 
-      for (const [index, row] of results.data.entries()) {
-        processed++;
-        const metal = row['Metal'] || 'Silver';
-        const name = row['Name'] || row['name'];
-        const qty = parseInt(row['Qty'] || row['qty'] || 1, 10);
-        const type = row['Type'] || row['type'] || 'Other';
-        const weight = parseFloat(row['Weight(oz)'] || row['weight']);
-        const priceStr = row['Purchase Price'] || row['price'];
-        let price = parseFloat(
-          typeof priceStr === "string"
-            ? priceStr.replace(/[^0-9.-]+/g, "")
-            : priceStr,
-        );
-        if (price < 0) price = 0;
-        const purchaseLocation = row['Purchase Location'] || "Unknown";
-        const storageLocation = row['Storage Location'] || "Unknown";
-        const notes = row['Notes'] || "";
-        const date = parseDate(row['Date']); // Using the new date parser
+        for (const row of results.data) {
+          processed++;
+          const metal = row['Metal'] || 'Silver';
+          const name = row['Name'] || row['name'];
+          const qty = row['Qty'] || row['qty'] || 1;
+          const type = row['Type'] || row['type'] || 'Other';
+          const weight = row['Weight(oz)'] || row['weight'];
+          const priceStr = row['Purchase Price'] || row['price'];
+          let price = typeof priceStr === 'string'
+            ? parseFloat(priceStr.replace(/[^\d.-]+/g, ''))
+            : parseFloat(priceStr);
+          if (price < 0) price = 0;
+          const purchaseLocation = row['Purchase Location'] || 'Unknown';
+          const storageLocation = row['Storage Location'] || 'Unknown';
+          const notes = row['Notes'] || '';
+          const date = parseDate(row['Date']);
 
-        // Get collectable status
-        const isCollectable = row['Collectable'] === 'Yes' || row['Collectable'] === 'true' || row['isCollectable'] === 'true';
+          const isCollectable = row['Collectable'] === 'Yes' || row['Collectable'] === 'true' || row['isCollectable'] === 'true';
 
-        // Get spot price from CSV if available
-        let spotPriceAtPurchase;
-        if (row['Spot Price ($/oz)']) {
-          // Extract numeric value from formatted string like "$1,234.56"
-          const spotStr = row['Spot Price ($/oz)'].toString();
-          spotPriceAtPurchase = parseFloat(spotStr.replace(/[^0-9.-]+/g, ""));
-        } else if (row['spotPriceAtPurchase']) {
-          spotPriceAtPurchase = parseFloat(row['spotPriceAtPurchase']);
-        } else {
-          // Fall back to current spot price if not in CSV and not collectable
-          const metalKey = metal.toLowerCase();
-          spotPriceAtPurchase = isCollectable ? 0 : spotPrices[metalKey];
-        }
+          let spotPriceAtPurchase;
+          if (row['Spot Price ($/oz)']) {
+            const spotStr = row['Spot Price ($/oz)'].toString();
+            spotPriceAtPurchase = parseFloat(spotStr.replace(/[^0-9.-]+/g, ''));
+          } else if (row['spotPriceAtPurchase']) {
+            spotPriceAtPurchase = parseFloat(row['spotPriceAtPurchase']);
+          } else {
+            const metalKey = metal.toLowerCase();
+            spotPriceAtPurchase = isCollectable ? 0 : spotPrices[metalKey];
+          }
 
-        // Calculate premium per ounce (only for non-collectible items)
-        let premiumPerOz = 0;
-        let totalPremium = 0;
+          let premiumPerOz = 0;
+          let totalPremium = 0;
+          if (!isCollectable) {
+            const pricePerOz = price / parseFloat(weight);
+            premiumPerOz = pricePerOz - spotPriceAtPurchase;
+            totalPremium = premiumPerOz * parseFloat(qty) * parseFloat(weight);
+          }
 
-        if (!isCollectable) {
-          const pricePerOz = price / weight;
-          premiumPerOz = pricePerOz - spotPriceAtPurchase;
-          totalPremium = premiumPerOz * qty * weight;
-        }
+          const item = sanitizeImportedItem({
+            metal,
+            name,
+            qty,
+            type,
+            weight,
+            price,
+            date,
+            purchaseLocation,
+            storageLocation,
+            notes,
+            spotPriceAtPurchase,
+            premiumPerOz,
+            totalPremium,
+            isCollectable
+          });
 
-        // Create item object for validation
-        const itemToValidate = {
-          metal,
-          name,
-          qty,
-          type,
-          weight,
-          price,
-          date,
-          purchaseLocation,
-          storageLocation,
-          notes,
-          spotPriceAtPurchase,
-          premiumPerOz,
-          totalPremium,
-          isCollectable
-        };
-
-        // Validate the item
-        const validation = validateInventoryItem(itemToValidate);
-        if (!validation.isValid) {
-          const reason = validation.errors.join(', ');
-          skippedDetails.push(`Row ${index + 2}: ${reason}`);
+          imported.push(item);
+          importedCount++;
           updateImportProgress(processed, importedCount, totalRows);
-          continue;
         }
 
-        imported.push(itemToValidate);
-        importedCount++;
-        updateImportProgress(processed, importedCount, totalRows);
-      }
+        endImportProgress();
 
-      for (const err of results.errors) {
-        skippedDetails.push(`Row ${err.row + 1}: ${err.message}`);
-      }
+        if (imported.length === 0) return alert('No items to import.');
 
-      endImportProgress();
+        const override = confirm(`Import ${imported.length} items?\nOK = Override, Cancel = Merge`);
+        if (override) {
+          inventory = imported;
+        } else {
+          inventory = inventory.concat(imported);
+        }
 
-      if (skippedDetails.length > 0) {
-        alert('Skipped entries:\n' + skippedDetails.join('\n'));
-      }
-
-      if (imported.length === 0) return alert("No valid items to import.");
-
-      let msg = "Replace current inventory with imported file?";
-      if (skippedDetails.length > 0) msg += `\n(${skippedDetails.length} rows skipped)`;
-
-      if (confirm(msg)) {
-        inventory = imported;
         saveInventory();
         renderTable();
-        if (typeof updateStorageStats === "function") {
+        if (typeof updateStorageStats === 'function') {
           updateStorageStats();
         }
-      }
 
-        this.value = "";
+        this.value = '';
       },
       error: function(error) {
         endImportProgress();
@@ -1130,7 +1104,6 @@ const importNumistaCsv = (file) => {
         const results = Papa.parse(storedCsv, { header: true, skipEmptyLines: true });
         const rawTable = results.data;
         const imported = [];
-        const skippedDetails = [];
         const totalRows = rawTable.length;
         startImportProgress(totalRows);
         let processed = 0;
@@ -1144,7 +1117,7 @@ const importNumistaCsv = (file) => {
           return "";
         };
 
-        for (const [index, row] of rawTable.entries()) {
+        for (const row of rawTable) {
           processed++;
 
           const numistaId = (getValue(row, ['N# number', 'Numista #', 'Numista number', 'Numista id']) || '').toString().trim();
@@ -1192,7 +1165,7 @@ const importNumistaCsv = (file) => {
           const premiumPerOz = weight ? purchasePrice / weight - spotPriceAtPurchase : 0;
           const totalPremium = premiumPerOz * qty * weight;
 
-          const itemToValidate = {
+          const item = sanitizeImportedItem({
             metal,
             name,
             qty,
@@ -1210,43 +1183,28 @@ const importNumistaCsv = (file) => {
             isCollectable,
             numistaId,
             issuedYear
-          };
+          });
 
-          const validation = validateInventoryItem(itemToValidate);
-          if (!validation.isValid) {
-            const reason = validation.errors.join(', ');
-            skippedDetails.push(`Row ${index + 2}: ${reason}`);
-            updateImportProgress(processed, importedCount, totalRows);
-            continue;
-          }
-
-          imported.push(itemToValidate);
+          imported.push(item);
           importedCount++;
           updateImportProgress(processed, importedCount, totalRows);
         }
 
-        for (const err of results.errors) {
-          skippedDetails.push(`Row ${err.row + 1}: ${err.message}`);
-        }
-
         endImportProgress();
 
-        if (skippedDetails.length > 0) {
-          alert('Skipped entries:\n' + skippedDetails.join('\n'));
+        if (imported.length === 0) return alert('No items to import.');
+
+        const override = confirm(`Import ${imported.length} items?\nOK = Override, Cancel = Merge`);
+        if (override) {
+          inventory = imported;
+        } else {
+          inventory = inventory.concat(imported);
         }
 
-        if (imported.length === 0) return alert('No valid items to import.');
-
-        let msg = 'Replace current inventory with imported file?';
-        if (skippedDetails.length > 0) msg += `\n(${skippedDetails.length} rows skipped)`;
-
-        if (confirm(msg)) {
-          inventory = imported;
-          saveInventory();
-          renderTable();
-          if (typeof updateStorageStats === 'function') {
-            updateStorageStats();
-          }
+        saveInventory();
+        renderTable();
+        if (typeof updateStorageStats === 'function') {
+          updateStorageStats();
         }
       } catch (error) {
         endImportProgress();

--- a/js/utils.js
+++ b/js/utils.js
@@ -268,7 +268,11 @@ const formatDisplayDate = (dateStr) => {
  * @param {number|string} n - Number to format
  * @returns {string} Formatted dollar string (e.g., "$1,234.56")
  */
-const formatDollar = (n) => `$${parseFloat(n).toFixed(2)}`;
+const formatDollar = (n) => {
+  const num = parseFloat(n);
+  if (isNaN(num)) return "";
+  return `$${num.toFixed(2)}`;
+};
 
 /**
  * Formats a profit/loss value with color coding
@@ -447,6 +451,48 @@ const validateInventoryItem = (item) => {
     isValid: errors.length === 0,
     errors,
   };
+};
+
+/**
+ * Sanitizes imported inventory data, coercing invalid fields to safe defaults.
+ *
+ * String fields default to an empty string and numeric fields become null when
+ * parsing fails. This allows imports to proceed even when some fields are
+ * malformed.
+ *
+ * @param {Object} item - Raw item data from an import process
+ * @returns {Object} Sanitized item
+ */
+const sanitizeImportedItem = (item) => {
+  const sanitized = { ...item };
+
+  // Metal must be one of the supported types; otherwise blank
+  if (!['Silver', 'Gold', 'Platinum', 'Palladium'].includes(sanitized.metal)) {
+    sanitized.metal = '';
+  }
+
+  // Ensure numeric fields parse correctly
+  const numFields = ['qty', 'weight', 'price', 'spotPriceAtPurchase'];
+  for (const field of numFields) {
+    if (sanitized[field] !== undefined) {
+      const parsed = parseFloat(sanitized[field]);
+      sanitized[field] = isNaN(parsed) ? null : parsed;
+    }
+  }
+
+  // Normalize string fields
+  const strFields = ['name', 'type', 'purchaseLocation', 'storageLocation', 'notes'];
+  for (const field of strFields) {
+    if (typeof sanitized[field] !== 'string') sanitized[field] = '';
+  }
+
+  // Reset premium calculations if price or weight are missing
+  if (!sanitized.price || !sanitized.weight) {
+    sanitized.premiumPerOz = 0;
+    sanitized.totalPremium = 0;
+  }
+
+  return sanitized;
 };
 
 /**


### PR DESCRIPTION
## Summary
- leave invalid CSV fields blank instead of rejecting rows
- ask user whether to merge or override existing inventory
- bump version to v3.03.08f and document changes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -e "const fs=require('fs');const csv=fs.readFileSync('docs/numista.csv','utf8');console.log(csv.split('\n').length);"`


------
https://chatgpt.com/codex/tasks/task_e_68997d0cfeb8832ea6d04e1a282915fa