### PR TITLE
refactor: improve change log and add catalog mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# StackTrackr v3.03.08f
+# StackTrackr v3.03.08g
 
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
 
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
+- **v3.03.08g - Change log & catalog improvements**: Condensed change log, undo from edit modal, and catalog mapping
 - **v3.03.08f - CSV import field sanitization**: Invalid fields are blanked and users can merge or override during import
 - **v3.03.08e - Numista CSV storage**: Stores raw Numista CSV and classifies metals by composition
 - **v3.03.08d - Version Modal Centering**: Version change dialog now properly centers in the viewport
@@ -33,6 +34,10 @@ The public hosted version of the app is available at [stackrtrackr.com](https://
 - **v3.1.9 - UI Consistency**: Clear Cache button styling improvements across themes
 - **v3.1.8 - Backup System**: Full ZIP backup functionality with restoration guides
 - **v3.1.6 - Theme Toggle**: Fixed theme management with system preference detection
+
+## 🆕 What's New in v3.03.08g
+- Change log rows open the edit modal with an undo option
+- Items gain catalog field tied to unique S# values
 
 ## 🆕 What's New in v3.03.08f
 - CSV import accepts rows with bad data and lets you merge or override existing inventory

--- a/css/styles.css
+++ b/css/styles.css
@@ -45,6 +45,7 @@
   /* Component Spacing */
   --radius: 8px;
   --radius-lg: 12px;
+  --spacing-xs: 0.2rem;
   --spacing-sm: 0.4rem;
   --spacing: 0.75rem;
   --spacing-lg: 1.25rem;
@@ -1148,7 +1149,8 @@ input[type="submit"] {
 /* Standardized modal layout for change log and details views */
 /* shared modal content structure */
 #changeLogModal .modal-content,
-#detailsModal .modal-content {
+#detailsModal .modal-content,
+#editModal .modal-content {
   display: flex;
   flex-direction: column;
   padding: 0;
@@ -1163,7 +1165,8 @@ input[type="submit"] {
 
 #changeLogModal .modal-header,
 #detailsModal .modal-header,
-#storageReportModal .modal-header {
+#storageReportModal .modal-header,
+#editModal .modal-header {
   background: linear-gradient(135deg, var(--primary), var(--primary-hover));
   color: white;
   padding: var(--spacing-xl);
@@ -1174,14 +1177,16 @@ input[type="submit"] {
 
 #changeLogModal .modal-header h2,
 #detailsModal .modal-header h2,
-#storageReportModal .modal-header h2 {
+#storageReportModal .modal-header h2,
+#editModal .modal-header h2 {
   margin: 0;
   color: white;
   text-align: center;
 }
 
-#changeLogModal .modal-body {
-  padding: var(--spacing-xl);
+#changeLogModal .modal-body,
+#editModal .modal-body {
+  padding: var(--spacing);
   overflow: auto;
   flex: 1;
 }
@@ -1207,8 +1212,9 @@ input[type="submit"] {
 
 #changeLogTable th,
 #changeLogTable td {
-  padding: var(--spacing-sm);
+  padding: var(--spacing-xs);
   text-align: left;
+  font-size: 0.75rem;
 }
 
 #changeLogTable td {
@@ -1219,11 +1225,18 @@ input[type="submit"] {
 
 #changeLogTable th:last-child,
 #changeLogTable td:last-child {
-  width: 8rem;
+  width: 5rem;
 }
 
 #changeLogTable td.action-cell {
   white-space: nowrap;
+}
+
+@media (max-width: 600px) {
+  #changeLogTable th,
+  #changeLogTable td {
+    font-size: 0.6rem;
+  }
 }
 
 #detailsModal {
@@ -2285,6 +2298,18 @@ input:disabled + .slider {
   margin-top: 0;
   text-align: left;
   font-style: italic;
+}
+
+.collectable-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: var(--spacing);
+  margin-bottom: var(--spacing);
+}
+
+.collectable-card .collectable-note {
+  margin-top: var(--spacing-xs);
 }
 
 /* =============================================================================

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,6 +1,6 @@
 # Multi-Agent Development Workflow - StackTrackr v3.03.08e
 
-> **Latest release: v3.03.08f**
+> **Latest release: v3.03.08g**
 
 ## 🎯 Project Overview
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,10 +1,15 @@
 # StackTrackr — Changelog
 
-> **Latest release: v3.03.08f**
+> **Latest release: v3.03.08g**
 
 For upcoming work, see [roadmap](roadmap.md).
 
 ## 📋 Version History
+
+### Version 3.03.08g – Change log table & catalog indexing (2025-08-10)
+- Change log rows open edit modal and table is more compact
+- Edit modal gains catalog field and undo button
+- Items now receive unique serial numbers with catalog mapping
 
 ### Version 3.03.08f – CSV import field sanitization (2025-08-10)
 - CSV imports now leave invalid fields blank instead of skipping rows

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,6 +1,6 @@
 # Function Reference
 
-> **Latest release: v3.03.08f**
+> **Latest release: v3.03.08g**
 
 | File | Function | Description |
 |------|----------|-------------|
@@ -90,6 +90,7 @@
 | inventory.js | generateReadmeContent | Generates README content for backup archive |
 | inventory.js | saveInventory | Saves current inventory to localStorage |
 | inventory.js | loadInventory | Loads inventory from localStorage with comprehensive data migration |
+| inventory.js | getNextSerial | Generates a unique serial number for inventory items |
 | inventory.js | getColor |  |
 | inventory.js | filterLink |  |
 | inventory.js | renderTable |  |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,3 +1,30 @@
+# Implementation Summary: Change Log Refinements & Catalog Indexing
+
+> **Latest release: v3.03.08g**
+
+## Version Update: 3.03.08f → 3.03.08g
+
+## User Requirements Implemented
+
+- Condensed change log with row-click editing and undo option in edit modal
+- Collectable toggle moved to themed card with added catalog field
+- Unique S# tracking mapped to Numista catalog numbers
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`css/styles.css`**: Condensed change log table, themed edit modal, collectable card styling
+2. **`index.html`**: Added catalog field, undo button, and collectable card; renamed change log action column
+3. **`js/changeLog.js`**: Row click editing and undo button adjustments
+4. **`js/inventory.js`**: Serial generation and catalog mapping persisted
+5. **`js/events.js`**: Serial assignment and undo button logic
+6. **`js/init.js`, `js/state.js`, `js/constants.js`**: New elements and constants for catalog support
+7. **Documentation**: Updated changelog, function table, implementation summary, status, roadmap, and structure
+
+### User Experience Improvements:
+- Faster editing from change log and consistent modal styling
+- Catalog tracking enables grouping items by Numista number
+
 # Implementation Summary: CSV Import Field Sanitization
 
 > **Latest release: v3.03.08f**
@@ -7,7 +34,7 @@
 ## User Requirements Implemented
 
 - Leave invalid CSV fields blank instead of rejecting rows
-- Allow users to merge imported data or override existing inventory
+- Allow users to merge imported data with existing inventory or override it
 
 ## Technical Changes Made
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,6 +9,7 @@ This roadmap outlines upcoming patch releases for the v3.03.x series.
 - **v3.03.08c** – Version modal enhancements *(completed)*
 - **v3.03.08e** – Numista CSV storage and metal classification *(completed)*
 - **v3.03.08f** – CSV import field sanitization and merge option *(completed)*
+- **v3.03.08g** – Change log table refinement and catalog mapping *(completed)*
 - **v3.03.12a** – Advanced reporting and analytics features.
 - **v3.03.13a** – Mobile application companion.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,10 +1,10 @@
 # Project Status - StackTrackr
 
-> **Latest release: v3.03.08f**
+> **Latest release: v3.03.08g**
 
-## 🎯 Current State: **BETA v3.03.08f** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.03.08g** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.03.08f** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.03.08g** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
 
 ## 🏗️ Architecture Overview
 
@@ -22,6 +22,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 - `utils.js` - Helper functions and formatters
 
 ## ✨ Latest Changes
+- **v3.03.08g - Change log & catalog improvements**: Condensed change log with row-click editing and catalog mapping
 - **v3.03.08f - CSV import field sanitization**: Invalid fields are blanked and users can merge or override during import
 - **v3.03.08e - Numista CSV storage**: Stores raw Numista CSV and classifies metals by composition
 - **v3.03.08d - Version Modal Centering**: Version change dialog now appears centered on the screen
@@ -135,8 +136,8 @@ All data is stored locally in the browser using localStorage with:
 ## 📚 Documentation Status (Updated: August 10, 2025)
 
 **All documentation files are current and synchronized:**
- - ✅ **status.md** - Updated for v3.03.08f release
- - ✅ **changelog.md** - Current through v3.03.08f
+ - ✅ **status.md** - Updated for v3.03.08g release
+ - ✅ **changelog.md** - Current through v3.03.08g
 - ✅ **MULTI_AGENT_WORKFLOW.md** - Comprehensive AI assistant development guide
 - ✅ **structure.md** - Reflects streamlined project organization
 - ✅ **versioning.md** - Accurate version management documentation

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,6 +1,6 @@
 # Project Structure
 
-> **Latest release: v3.03.08f**
+> **Latest release: v3.03.08g**
 
 The repository is organized as follows:
 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.03.08f**
+> **Latest release: v3.03.08g**
 
 ## Overview 
 

--- a/index.html
+++ b/index.html
@@ -861,6 +861,17 @@
         </div>
         <div class="modal-body">
         <form id="editForm">
+          <div class="collectable-card">
+            <div style="display:flex;align-items:center;gap:var(--spacing);">
+              <label for="editCollectable" style="margin:0;">Collectable Item</label>
+              <label class="switch">
+                <input id="editCollectable" type="checkbox" />
+                <span class="slider"></span>
+              </label>
+            </div>
+            <p class="collectable-note">Collectable items may have additional numismatic value beyond their metal content</p>
+          </div>
+          <input type="hidden" id="editSerial" />
           <!-- First row of edit form fields -->
           <div class="grid grid-2">
             <div>
@@ -945,7 +956,7 @@
               <input id="editDate" required="" type="date" />
             </div>
           </div>
-          <!-- Spot price and collectable toggle -->
+          <!-- Spot price and catalog field -->
           <div class="grid grid-2">
             <div>
               <label for="editSpotPrice">Spot Price ($/oz)</label>
@@ -959,19 +970,14 @@
                 />
               </div>
             </div>
-            <div class="collectable-toggle">
-              <label for="editCollectable">Collectable Item</label>
-              <label class="switch">
-                <input id="editCollectable" type="checkbox" />
-                <span class="slider"></span>
-              </label>
-              <span class="collectable-note"
-                >Collectable items may have additional numismatic value beyond their metal content</span
-              >
+            <div>
+              <label for="editCatalog">Catalog (N#)</label>
+              <input id="editCatalog" type="text" placeholder="Numista catalog #" />
             </div>
           </div>
           <!-- Form action buttons -->
           <div style="margin-top: 1rem; text-align: right">
+            <button class="btn" id="undoChangeBtn" type="button" style="display:none">Undo</button>
             <button class="btn" id="cancelEdit" type="button">Cancel</button>
             <button class="btn premium" type="submit">Save Changes</button>
           </div>
@@ -1024,7 +1030,7 @@
                 <th>Field</th>
                 <th>Old Value</th>
                 <th>New Value</th>
-                <th>Action</th>
+                <th>Undo</th>
               </tr>
             </thead>
             <tbody></tbody>

--- a/js/changeLog.js
+++ b/js/changeLog.js
@@ -68,13 +68,13 @@ const renderChangeLog = () => {
       const globalIndex = changeLog.length - 1 - i;
       const actionLabel = entry.undone ? 'Redo' : 'Undo';
       return `
-      <tr>
+      <tr onclick="editFromChangeLog(${entry.idx}, ${globalIndex})">
         <td title="${new Date(entry.timestamp).toLocaleString()}">${new Date(entry.timestamp).toLocaleString()}</td>
         <td title="${sanitizeHtml(entry.itemName)}">${sanitizeHtml(entry.itemName)}</td>
         <td title="${sanitizeHtml(entry.field)}">${sanitizeHtml(entry.field)}</td>
         <td title="${sanitizeHtml(String(entry.oldValue))}">${sanitizeHtml(String(entry.oldValue))}</td>
         <td title="${sanitizeHtml(String(entry.newValue))}">${sanitizeHtml(String(entry.newValue))}</td>
-        <td class="action-cell"><button class="btn action-btn" style="margin:1px;" onclick="editFromChangeLog(${entry.idx})">Edit</button><button class="btn action-btn" style="margin:1px;" onclick="toggleChange(${globalIndex})">${actionLabel}</button></td>
+        <td class="action-cell"><button class="btn action-btn" style="margin:1px;" onclick="event.stopPropagation(); toggleChange(${globalIndex})">${actionLabel}</button></td>
       </tr>`;
     });
 
@@ -90,11 +90,17 @@ const toggleChange = (logIdx) => {
   if (!entry) return;
   if (entry.field === 'Deleted') {
     if (entry.undone) {
-      inventory.splice(entry.idx, 1);
+      const removed = inventory.splice(entry.idx, 1)[0];
+      if (removed && removed.serial) {
+        delete catalogMap[removed.serial];
+      }
       entry.undone = false;
     } else {
       const restored = JSON.parse(entry.oldValue || '{}');
       inventory.splice(entry.idx, 0, restored);
+      if (restored.serial) {
+        catalogMap[restored.serial] = restored.numistaId || "";
+      }
       entry.undone = true;
     }
   } else {
@@ -107,6 +113,9 @@ const toggleChange = (logIdx) => {
       item[entry.field] = entry.oldValue;
       entry.undone = true;
     }
+    if (item.serial) {
+      catalogMap[item.serial] = item.numistaId || "";
+    }
   }
   saveInventory();
   renderTable();
@@ -118,11 +127,11 @@ window.logChange = logChange;
 window.logItemChanges = logItemChanges;
 window.renderChangeLog = renderChangeLog;
 window.toggleChange = toggleChange;
-window.editFromChangeLog = (idx) => {
+window.editFromChangeLog = (idx, logIdx) => {
   const modal = document.getElementById('changeLogModal');
   if (modal) {
     modal.style.display = 'none';
   }
   document.body.style.overflow = '';
-  editItem(idx);
+  editItem(idx, logIdx);
 };

--- a/js/constants.js
+++ b/js/constants.js
@@ -98,7 +98,7 @@ const API_PROVIDERS = {
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
-const APP_VERSION = "3.03.08f";
+const APP_VERSION = "3.03.08g";
 
 /**
  * Returns formatted version string
@@ -168,6 +168,12 @@ const BRANDING_DOMAIN_OVERRIDE =
 
 /** @constant {string} LS_KEY - LocalStorage key for inventory data */
 const LS_KEY = "metalInventory";
+
+/** @constant {string} SERIAL_KEY - LocalStorage key for inventory serial counter */
+const SERIAL_KEY = "inventorySerial";
+
+/** @constant {string} CATALOG_MAP_KEY - LocalStorage key for S#/N# associations */
+const CATALOG_MAP_KEY = "catalogMap";
 
 /** @constant {string} NUMISTA_RAW_KEY - LocalStorage key for raw Numista CSV data */
 const NUMISTA_RAW_KEY = "numistaRawData";

--- a/js/events.js
+++ b/js/events.js
@@ -421,6 +421,7 @@ const setupEventListeners = () => {
             totalPremium = premiumPerOz * qty * weight;
           }
 
+          const serial = getNextSerial();
           inventory.push({
             metal,
             name,
@@ -436,8 +437,11 @@ const setupEventListeners = () => {
             premiumPerOz,
             totalPremium,
             isCollectable,
+            serial,
+            numistaId: "",
           });
 
+          catalogMap[serial] = "";
           saveInventory();
           renderTable();
           this.reset();
@@ -515,9 +519,11 @@ const setupEventListeners = () => {
           }
 
           const oldItem = { ...inventory[editingIndex] };
+          const serial = oldItem.serial;
 
-          // Update the item
+          // Update the item preserving serial
           inventory[editingIndex] = {
+            ...oldItem,
             metal,
             name,
             qty,
@@ -532,8 +538,10 @@ const setupEventListeners = () => {
             premiumPerOz,
             totalPremium,
             isCollectable,
+            numistaId: elements.editCatalog.value.trim(),
           };
 
+          catalogMap[serial] = inventory[editingIndex].numistaId;
           saveInventory();
           renderTable();
           logItemChanges(oldItem, inventory[editingIndex]);
@@ -541,8 +549,26 @@ const setupEventListeners = () => {
           // Close modal
           elements.editModal.style.display = "none";
           editingIndex = null;
+          editingChangeLogIndex = null;
         },
         "Edit form",
+      );
+    }
+
+    if (elements.undoChangeBtn) {
+      safeAttachListener(
+        elements.undoChangeBtn,
+        "click",
+        () => {
+          if (editingChangeLogIndex !== null) {
+            toggleChange(editingChangeLogIndex);
+            elements.editModal.style.display = "none";
+            editingIndex = null;
+            editingChangeLogIndex = null;
+            renderChangeLog();
+          }
+        },
+        "Undo change button",
       );
     }
 
@@ -554,6 +580,7 @@ const setupEventListeners = () => {
         function () {
           elements.editModal.style.display = "none";
           editingIndex = null;
+          editingChangeLogIndex = null;
         },
         "Cancel edit button",
       );
@@ -566,6 +593,7 @@ const setupEventListeners = () => {
         () => {
           elements.editModal.style.display = "none";
           editingIndex = null;
+          editingChangeLogIndex = null;
         },
         "Edit modal close button",
       );

--- a/js/init.js
+++ b/js/init.js
@@ -130,6 +130,9 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.editNotes = safeGetElement("editNotes");
     elements.editDate = safeGetElement("editDate");
     elements.editSpotPrice = safeGetElement("editSpotPrice");
+    elements.editCatalog = safeGetElement("editCatalog");
+    elements.undoChangeBtn = safeGetElement("undoChangeBtn");
+    elements.editSerial = safeGetElement("editSerial");
 
     elements.addModal = safeGetElement("addModal");
     elements.addCloseBtn = safeGetElement("addCloseBtn");

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -401,10 +401,23 @@ Store this archive in a secure location for data protection.
 
 // =============================================================================
 
+let catalogMap = loadData(CATALOG_MAP_KEY, {});
+window.catalogMap = catalogMap;
+
+const getNextSerial = () => {
+  const next = (parseInt(localStorage.getItem(SERIAL_KEY) || '0', 10) + 1);
+  localStorage.setItem(SERIAL_KEY, next);
+  return next;
+};
+window.getNextSerial = getNextSerial;
+
 /**
  * Saves current inventory to localStorage
  */
-const saveInventory = () => saveData(LS_KEY, inventory);
+const saveInventory = () => {
+  saveData(LS_KEY, inventory);
+  saveData(CATALOG_MAP_KEY, catalogMap);
+};
 
 /**
  * Loads inventory from localStorage with comprehensive data migration
@@ -456,6 +469,18 @@ const loadInventory = () => {
       isCollectable: item.isCollectable !== undefined ? item.isCollectable : false
     };
   });
+
+  let serialCounter = parseInt(localStorage.getItem(SERIAL_KEY) || '0', 10);
+  inventory.forEach(item => {
+    if (!item.serial) {
+      serialCounter += 1;
+      item.serial = serialCounter;
+    }
+    item.numistaId = item.numistaId || catalogMap[item.serial] || "";
+    catalogMap[item.serial] = item.numistaId;
+  });
+  localStorage.setItem(SERIAL_KEY, serialCounter);
+  saveData(CATALOG_MAP_KEY, catalogMap);
 };
 
 /**
@@ -846,8 +871,9 @@ const showNotes = (idx) => {
  *
  * @param {number} idx - Index of item to edit
  */
-const editItem = (idx) => {
+const editItem = (idx, logIdx = null) => {
   editingIndex = idx;
+  editingChangeLogIndex = logIdx;
   const item = inventory[idx];
 
   // Populate edit form
@@ -868,7 +894,14 @@ const editItem = (idx) => {
   
   elements.editDate.value = item.date;
   elements.editSpotPrice.value = item.spotPriceAtPurchase;
+  elements.editCatalog.value = item.numistaId || "";
+  elements.editSerial.value = item.serial;
   document.getElementById("editCollectable").checked = item.isCollectable;
+
+  if (elements.undoChangeBtn) {
+    elements.undoChangeBtn.style.display =
+      logIdx !== null ? "inline-block" : "none";
+  }
 
   // Show modal
   elements.editModal.style.display = 'flex';

--- a/js/state.js
+++ b/js/state.js
@@ -9,6 +9,8 @@ let sortDirection = "asc"; // 'asc' or 'desc' - current sort direction
 let editingIndex = null;
 /** @type {number|null} Index of item whose notes are being edited */
 let notesIndex = null;
+/** @type {number|null} Change log entry currently being edited */
+let editingChangeLogIndex = null;
 
 /** @type {Object} Pagination state */
 let currentPage = 1; // Current page number (1-based)
@@ -100,6 +102,9 @@ const elements = {
   editNotes: null,
   editDate: null,
   editSpotPrice: null,
+  editCatalog: null,
+  undoChangeBtn: null,
+  editSerial: null,
   editCloseBtn: null,
 
   // Notes modal elements


### PR DESCRIPTION
## Summary
- Condense change log table and open edits by row click while keeping per-entry undo controls
- Theme edit modal with collectable card, catalog field, and undo button
- Track items via unique serial numbers and map to Numista catalog IDs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68997f08e714832ebaa9908a6a1b1e77