### PR TITLE
Refine table controls and import options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-# StackTrackr v3.03.08g
+# StackTrackr v3.03.08h
 
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
 
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
+- **v3.03.08h - Table controls & import options**: Compact table controls, uniform pagination buttons, import Override/Merge menus, and Backup/Restore placeholder
 - **v3.03.08g - Change log & catalog improvements**: Condensed change log, undo from edit modal, and catalog mapping
 - **v3.03.08f - CSV import field sanitization**: Invalid fields are blanked and users can merge or override during import
 - **v3.03.08e - Numista CSV storage**: Stores raw Numista CSV and classifies metals by composition

--- a/css/styles.css
+++ b/css/styles.css
@@ -2024,8 +2024,8 @@ td input:checked + .slider:before {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: var(--spacing-sm);
-  padding: 0.25rem 0;
+  gap: var(--spacing-xs);
+  padding: 0.125rem 0;
 }
 
 .pagination-buttons {
@@ -2054,12 +2054,16 @@ td input:checked + .slider:before {
   gap: var(--spacing-sm);
 }
 
+.table-controls-section {
+  margin: var(--spacing-xs) 0;
+}
+
 .table-controls {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: var(--spacing-lg);
-  margin: var(--spacing-sm) 0;
+  gap: var(--spacing);
+  margin: 0;
   flex-wrap: wrap;
 }
 
@@ -2085,12 +2089,12 @@ td input:checked + .slider:before {
 
 .pagination-select {
   width: 6rem;
-  height: 2.75rem;
+  height: 1.375rem;
 }
 
 .pagination-btn {
-  min-width: 2.5rem;
-  height: 2.5rem;
+  min-width: 2rem;
+  height: 1.25rem;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -2102,6 +2106,7 @@ td input:checked + .slider:before {
   transition: var(--transition);
   cursor: pointer;
   padding: 0;
+  font-size: 0.75rem;
 }
 
 .pagination-btn.active {
@@ -2119,6 +2124,33 @@ td input:checked + .slider:before {
 .pagination-btn:disabled {
   opacity: 0.5;
   cursor: not-allowed;
+}
+
+.import-dropdown-wrapper {
+  position: relative;
+  display: inline-block;
+}
+
+.import-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  display: none;
+  flex-direction: column;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-top: var(--spacing-xs);
+  z-index: 20;
+}
+
+.import-dropdown.show {
+  display: flex;
+}
+
+.import-dropdown .btn {
+  width: 100%;
+  margin: 0;
 }
 
 
@@ -2545,7 +2577,7 @@ input:disabled + .slider {
   }
 
   .pagination-btn {
-    padding: 0.25rem 0.4rem;
+    padding: 0;
     font-size: 0.7rem;
   }
 }

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,6 +1,6 @@
 # Multi-Agent Development Workflow - StackTrackr v3.03.08e
 
-> **Latest release: v3.03.08g**
+> **Latest release: v3.03.08h**
 
 ## 🎯 Project Overview
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,10 +1,16 @@
 # StackTrackr — Changelog
 
-> **Latest release: v3.03.08g**
+> **Latest release: v3.03.08h**
 
 For upcoming work, see [roadmap](roadmap.md).
 
 ## 📋 Version History
+
+### Version 3.03.08h – UI compactness & import options (2025-08-10)
+- Moved change log, disclaimer, and items selector into a compact section below the table
+- Pagination controls slimmed down with uniform buttons
+- CSV imports now choose Override or Merge from dropdown menus
+- Files modal gains Backup/Restore placeholder card
 
 ### Version 3.03.08g – Change log table & catalog indexing (2025-08-10)
 - Change log rows open edit modal and table is more compact

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,6 +1,6 @@
 # Function Reference
 
-> **Latest release: v3.03.08g**
+> **Latest release: v3.03.08h**
 
 | File | Function | Description |
 |------|----------|-------------|
@@ -103,8 +103,8 @@
 | inventory.js | startImportProgress |  |
 | inventory.js | updateImportProgress |  |
 | inventory.js | endImportProgress |  |
-| inventory.js | importCsv | Imports inventory data from CSV file with comprehensive validation and error handling |
-| inventory.js | importNumistaCsv | Imports inventory data from a Numista CSV export |
+| inventory.js | importCsv | Imports inventory data from CSV file with comprehensive validation; supports override or merge modes |
+| inventory.js | importNumistaCsv | Imports inventory data from a Numista CSV export with override or merge modes |
 | inventory.js | exportCsv | Exports current inventory to CSV format |
 | inventory.js | importJson | Imports inventory data from JSON file |
 | inventory.js | exportJson | Exports current inventory to JSON format |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,3 +1,31 @@
+# Implementation Summary: Table Controls & Import Options
+
+> **Latest release: v3.03.08h**
+
+## Version Update: 3.03.08g → 3.03.08h
+
+## User Requirements Implemented
+
+- Grouped change log label, disclaimer, and items selector into dedicated section below the table
+- Slimmed pagination controls with uniform buttons
+- CSV import buttons provide Override or Merge options via dropdown menus
+- Files page adds Backup/Restore placeholder card
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`index.html`**: Reorganized table controls, added import dropdowns, and new Backup/Restore card
+2. **`css/styles.css`**: Compact control styling, pagination sizing, and dropdown menu styles
+3. **`js/state.js`, `js/init.js`, `js/events.js`**: New elements and listeners for import mode selection
+4. **`js/inventory.js`**: Importers accept override parameter instead of confirm prompt
+5. **`js/constants.js`**: Bumped version to 3.03.08h
+6. **Documentation**: Updated changelog, function table, implementation summary, status, roadmap, structure, and README
+
+### User Experience Improvements:
+- Cleaner layout with controls below the table
+- Clear import choice without a confusing confirm dialog
+- Backup/Restore section signals forthcoming features
+
 # Implementation Summary: Change Log Refinements & Catalog Indexing
 
 > **Latest release: v3.03.08g**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,6 +10,7 @@ This roadmap outlines upcoming patch releases for the v3.03.x series.
 - **v3.03.08e** – Numista CSV storage and metal classification *(completed)*
 - **v3.03.08f** – CSV import field sanitization and merge option *(completed)*
 - **v3.03.08g** – Change log table refinement and catalog mapping *(completed)*
+- **v3.03.08h** – Table control compactness and import options *(completed)*
 - **v3.03.12a** – Advanced reporting and analytics features.
 - **v3.03.13a** – Mobile application companion.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,10 +1,10 @@
 # Project Status - StackTrackr
 
-> **Latest release: v3.03.08g**
+> **Latest release: v3.03.08h**
 
-## 🎯 Current State: **BETA v3.03.08g** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.03.08h** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.03.08g** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.03.08h** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
 
 ## 🏗️ Architecture Overview
 
@@ -22,6 +22,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 - `utils.js` - Helper functions and formatters
 
 ## ✨ Latest Changes
+- **v3.03.08h - Table controls & import options**: Grouped controls below the table, compact pagination, import Override/Merge menus, and Backup/Restore placeholder
 - **v3.03.08g - Change log & catalog improvements**: Condensed change log with row-click editing and catalog mapping
 - **v3.03.08f - CSV import field sanitization**: Invalid fields are blanked and users can merge or override during import
 - **v3.03.08e - Numista CSV storage**: Stores raw Numista CSV and classifies metals by composition

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,6 +1,6 @@
 # Project Structure
 
-> **Latest release: v3.03.08g**
+> **Latest release: v3.03.08h**
 
 The repository is organized as follows:
 

--- a/index.html
+++ b/index.html
@@ -428,24 +428,27 @@
           </thead>
           <tbody></tbody>
         </table>
-          <div class="table-controls">
-            <span id="changeLogBtn" class="change-log-label">Change Log</span>
-            <span class="table-disclaimer"
-              >All data is stored locally. Back up often.</span
-            >
-            <div class="items-per-page">
-              <span class="items-label">Items:</span>
-              <select class="pagination-select" id="itemsPerPage">
-                <option selected value="10">10</option>
-                <option value="15">15</option>
-                <option value="25">25</option>
-                <option value="50">50</option>
-                <option value="100">100</option>
-              </select>
-            </div>
+      </section>
+      <section class="table-controls-section">
+        <div class="table-controls">
+          <span id="changeLogBtn" class="change-log-label">Change Log</span>
+          <span class="table-disclaimer"
+            >All data is stored locally. Back up often.</span
+          >
+          <div class="items-per-page">
+            <span class="items-label">Items:</span>
+            <select class="pagination-select" id="itemsPerPage">
+              <option selected value="10">10</option>
+              <option value="15">15</option>
+              <option value="25">25</option>
+              <option value="50">50</option>
+              <option value="100">100</option>
+            </select>
           </div>
-        <!-- Pagination Controls -->
-        <section class="pagination-section">
+        </div>
+      </section>
+      <!-- Pagination Controls -->
+      <section class="pagination-section">
           <div class="pagination-container">
             <div class="pagination-controls">
               <div class="pagination-buttons">
@@ -477,8 +480,6 @@
               </div>
             </div>
           </div>
-        </section>
-      </section>
       </section>
       <!-- =============================================================================
          TOTALS SECTION
@@ -1433,10 +1434,16 @@
               <p class="settings-subtext">Import your data files.</p>
               <div class="import-block">
                 <div class="import-export-grid">
-                  <label class="btn" id="importCsvBtn">
-                    Import CSV <span class="import-icon">⬇️</span>
+                  <div class="import-dropdown-wrapper">
+                    <button class="btn" id="importCsvBtn">
+                      Import CSV <span class="import-icon">⬇️</span>
+                    </button>
+                    <div class="import-dropdown" id="importCsvOptions">
+                      <button class="btn" id="importCsvOverride">Override</button>
+                      <button class="btn" id="importCsvMerge">Merge</button>
+                    </div>
                     <input accept=".csv" hidden id="importCsvFile" type="file" />
-                  </label>
+                  </div>
                   <label class="btn" id="importJsonBtn">
                     Import JSON <span class="import-icon">⬇️</span>
                     <input accept=".json" hidden id="importJsonFile" type="file" />
@@ -1488,8 +1495,14 @@
               <p class="settings-subtext">Connect with external services like Numista.</p>
               <div class="third-party-block">
                 <div class="import-export-grid">
-                  <button class="btn" id="numistaImportBtn">Import from Numista</button>
-                  <input type="file" id="numistaImportFile" accept=".csv" hidden />
+                  <div class="import-dropdown-wrapper">
+                    <button class="btn" id="numistaImportBtn">Import from Numista</button>
+                    <div class="import-dropdown" id="numistaImportOptions">
+                      <button class="btn" id="numistaOverride">Override</button>
+                      <button class="btn" id="numistaMerge">Merge</button>
+                    </div>
+                    <input type="file" id="numistaImportFile" accept=".csv" hidden />
+                  </div>
                 </div>
               </div>
             </div>
@@ -1514,6 +1527,11 @@
                   🏴‍☠️ So, you've been in a boating accident? 🏴‍☠️
                 </button>
               </div>
+            </div>
+
+            <div class="settings-card">
+              <h3>Backup/Restore</h3>
+              <p class="settings-subtext">Coming Soon</p>
             </div>
           </div>
         </div>

--- a/js/constants.js
+++ b/js/constants.js
@@ -98,7 +98,7 @@ const API_PROVIDERS = {
  * State codes: a=alpha, b=beta, rc=release candidate
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
-const APP_VERSION = "3.03.08g";
+const APP_VERSION = "3.03.08h";
 
 /**
  * Returns formatted version string

--- a/js/events.js
+++ b/js/events.js
@@ -891,13 +891,46 @@ const setupEventListeners = () => {
     // IMPORT/EXPORT EVENT LISTENERS
     debugLog("Setting up import/export listeners...");
 
+    let csvImportOverride = false;
+    if (elements.importCsvBtn && elements.importCsvOptions) {
+      safeAttachListener(
+        elements.importCsvBtn,
+        "click",
+        () => elements.importCsvOptions.classList.toggle("show"),
+        "CSV import options toggle",
+      );
+    }
+    if (elements.importCsvOverride && elements.importCsvFile) {
+      safeAttachListener(
+        elements.importCsvOverride,
+        "click",
+        () => {
+          csvImportOverride = true;
+          elements.importCsvOptions.classList.remove("show");
+          elements.importCsvFile.click();
+        },
+        "CSV override option",
+      );
+    }
+    if (elements.importCsvMerge && elements.importCsvFile) {
+      safeAttachListener(
+        elements.importCsvMerge,
+        "click",
+        () => {
+          csvImportOverride = false;
+          elements.importCsvOptions.classList.remove("show");
+          elements.importCsvFile.click();
+        },
+        "CSV merge option",
+      );
+    }
     if (elements.importCsvFile) {
       safeAttachListener(
         elements.importCsvFile,
         "change",
         function (e) {
           if (e.target.files.length > 0) {
-            importCsv(e.target.files[0]);
+            importCsv(e.target.files[0], csvImportOverride);
           }
           this.value = "";
         },
@@ -933,25 +966,50 @@ const setupEventListeners = () => {
       );
     }
 
+    let numistaOverride = false;
+    if (elements.numistaImportBtn && elements.numistaImportOptions) {
+      safeAttachListener(
+        elements.numistaImportBtn,
+        "click",
+        () => elements.numistaImportOptions.classList.toggle("show"),
+        "Numista import options toggle",
+      );
+    }
+    if (elements.numistaOverride && elements.numistaImportFile) {
+      safeAttachListener(
+        elements.numistaOverride,
+        "click",
+        () => {
+          numistaOverride = true;
+          elements.numistaImportOptions.classList.remove("show");
+          elements.numistaImportFile.click();
+        },
+        "Numista override option",
+      );
+    }
+    if (elements.numistaMerge && elements.numistaImportFile) {
+      safeAttachListener(
+        elements.numistaMerge,
+        "click",
+        () => {
+          numistaOverride = false;
+          elements.numistaImportOptions.classList.remove("show");
+          elements.numistaImportFile.click();
+        },
+        "Numista merge option",
+      );
+    }
     if (elements.numistaImportFile) {
       safeAttachListener(
         elements.numistaImportFile,
         "change",
         function (e) {
           if (e.target.files.length > 0) {
-            importNumistaCsv(e.target.files[0]);
+            importNumistaCsv(e.target.files[0], numistaOverride);
           }
           this.value = "";
         },
         "Numista CSV import",
-      );
-    }
-    if (elements.numistaImportBtn && elements.numistaImportFile) {
-      safeAttachListener(
-        elements.numistaImportBtn,
-        "click",
-        () => elements.numistaImportFile.click(),
-        "Numista import trigger",
       );
     }
 

--- a/js/init.js
+++ b/js/init.js
@@ -85,13 +85,20 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Import/Export elements
     debugLog("Phase 3: Initializing import/export elements...");
+    elements.importCsvBtn = safeGetElement("importCsvBtn");
     elements.importCsvFile = safeGetElement("importCsvFile");
+    elements.importCsvOverride = safeGetElement("importCsvOverride");
+    elements.importCsvMerge = safeGetElement("importCsvMerge");
+    elements.importCsvOptions = safeGetElement("importCsvOptions");
     elements.importJsonFile = safeGetElement("importJsonFile");
     elements.importExcelFile = safeGetElement("importExcelFile");
     elements.importProgress = safeGetElement("importProgress");
     elements.importProgressText = safeGetElement("importProgressText");
     elements.numistaImportBtn = safeGetElement("numistaImportBtn");
     elements.numistaImportFile = safeGetElement("numistaImportFile");
+    elements.numistaOverride = safeGetElement("numistaOverride");
+    elements.numistaMerge = safeGetElement("numistaMerge");
+    elements.numistaImportOptions = safeGetElement("numistaImportOptions");
     elements.exportCsvBtn = safeGetElement("exportCsvBtn");
     elements.exportJsonBtn = safeGetElement("exportJsonBtn");
     elements.exportExcelBtn = safeGetElement("exportExcelBtn");

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -997,6 +997,7 @@ const endImportProgress = () => {
  * - Spot Price ($/oz) for historical premium calculations
  * 
  * @param {File} file - CSV file selected by user through file input
+ * @param {boolean} [override=false] - Replace existing inventory instead of merging
  * @returns {void} Updates inventory array if import successful
  * 
  * @example
@@ -1008,7 +1009,7 @@ const endImportProgress = () => {
  *   }
  * });
  */
-const importCsv = (file) => {
+const importCsv = (file, override = false) => {
   try {
     Papa.parse(file, {
       header: true,
@@ -1084,7 +1085,6 @@ const importCsv = (file) => {
 
         if (imported.length === 0) return alert('No items to import.');
 
-        const override = confirm(`Import ${imported.length} items?\nOK = Override, Cancel = Merge`);
         if (override) {
           inventory = imported;
         } else {
@@ -1125,8 +1125,9 @@ const importCsv = (file) => {
  * - Notes appended with import source reference
  *
  * @param {File} file - CSV file from Numista
+ * @param {boolean} [override=false] - Replace existing inventory instead of merging
  */
-const importNumistaCsv = (file) => {
+const importNumistaCsv = (file, override = false) => {
   try {
     const reader = new FileReader();
     reader.onload = function(e) {
@@ -1227,7 +1228,6 @@ const importNumistaCsv = (file) => {
 
         if (imported.length === 0) return alert('No items to import.');
 
-        const override = confirm(`Import ${imported.length} items?\nOK = Override, Cancel = Merge`);
         if (override) {
           inventory = imported;
         } else {

--- a/js/state.js
+++ b/js/state.js
@@ -63,13 +63,20 @@ const elements = {
   resetSpotBtnGold: null,
 
   // Import elements
+  importCsvBtn: null,
   importCsvFile: null,
+  importCsvOverride: null,
+  importCsvMerge: null,
+  importCsvOptions: null,
   importJsonFile: null,
   importExcelFile: null,
   importProgress: null,
   importProgressText: null,
   numistaImportBtn: null,
   numistaImportFile: null,
+  numistaOverride: null,
+  numistaMerge: null,
+  numistaImportOptions: null,
 
   // Export elements
   exportCsvBtn: null,


### PR DESCRIPTION
## Summary
- Group change log, disclaimer, and items selector into compact section beneath table
- Shrink pagination controls with uniform buttons for consistent layout
- Add Override/Merge dropdowns for CSV imports and placeholder Backup/Restore card

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689981ecbea4832eaa02b742c1f19018