### PR TITLE
Fix composition display in inventory table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# StackTrackr v3.03.08i
+# StackTrackr v3.03.08j
 
 
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -7,6 +7,7 @@ StackTrackr is a comprehensive client-side web application for tracking precious
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
+- **v3.03.08j - Composition display fix**: Composition column shows first word from imported data
 - **v3.03.08i - Numista import polish**: Uniform changelog bullets, default collectable flag, weight rounding, N# notes, and beta warning
 - **v3.03.08h - Table controls & import options**: Compact table controls, uniform pagination buttons, import Override/Merge menus, and Backup/Restore placeholder
 - **v3.03.08g - Change log & catalog improvements**: Condensed change log, undo from edit modal, and catalog mapping
@@ -312,7 +313,7 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: 3.03.08i
+**Current Version**: 3.03.08j
 **Last Updated**: August 10, 2025
 **Status**: Feature complete release candidate
 

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,7 +1,7 @@
 # Multi-Agent Development Workflow - StackTrackr v3.03.08e
 
 
-> **Latest release: v3.03.08i**
+> **Latest release: v3.03.08j**
 
 
 ## 🎯 Project Overview

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,13 +1,16 @@
 # StackTrackr — Changelog
 
 
-> **Latest release: v3.03.08i**
+> **Latest release: v3.03.08j**
 
 
 For upcoming work, see [roadmap](roadmap.md).
 
 ## 📋 Version History
 
+
+### Version 3.03.08j – Composition display fix (2025-08-10)
+- Composition column shows first word of imported composition instead of generic metal
 
 ### Version 3.03.08i – Numista import polish (2025-08-10)
 - Unified bullet styling for "What's New" lists

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.03.08i**
+> **Latest release: v3.03.08j**
 
 
 | File | Function | Description |
@@ -153,6 +153,7 @@
 | utils.js | convertToUsd | Converts amount from specified currency to USD using static rates |
 | utils.js | mapNumistaType | Maps Numista type strings to internal categories (coin, Aurum, Notes, bars/rounds, other) |
 | utils.js | parseNumistaMetal | Parses composition into Silver, Gold, Platinum, Palladium, Paper, or Alloy |
+| utils.js | getCompositionFirstWord | Extracts the first word from a composition string |
 | utils.js | saveData | Saves data to localStorage with JSON serialization |
 | utils.js | loadData | Loads data from localStorage with error handling |
 | utils.js | sortInventoryByDateNewestFirst | Sorts inventory by date (newest first) |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,4 +1,25 @@
 
+# Implementation Summary: Composition Display Fix
+
+> **Latest release: v3.03.08j**
+
+## Version Update: 3.03.08i → 3.03.08j
+
+## User Requirements Implemented
+
+- Composition column shows first word of imported composition instead of generic metal
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`index.html`**: Column now keyed as `composition`
+2. **`js/utils.js`**: Added `getCompositionFirstWord` and composition handling
+3. **`js/inventory.js`**: Stores composition separately and renders first word
+4. **`js/events.js`, `js/init.js`, `js/search.js`, `js/sorting.js`**: Updated for composition support
+5. **`js/constants.js`**: Bumped version to 3.03.08j
+6. **Documentation**: Updated changelog, function table, implementation summary, status, roadmap, structure, and README
+
+
 # Implementation Summary: Numista Import Polish
 
 > **Latest release: v3.03.08i**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,6 +12,7 @@ This roadmap outlines upcoming patch releases for the v3.03.x series.
 - **v3.03.08g** – Change log table refinement and catalog mapping *(completed)*
 - **v3.03.08h** – Table control compactness and import options *(completed)*
 - **v3.03.08i** – Numista import polish and weight rounding *(completed)*
+- **v3.03.08j** – Composition display fix *(completed)*
 - **v3.03.12a** – Advanced reporting and analytics features.
 - **v3.03.13a** – Mobile application companion.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,11 +1,11 @@
 # Project Status - StackTrackr
 
 
-> **Latest release: v3.03.08i**
+> **Latest release: v3.03.08j**
 
-## 🎯 Current State: **BETA v3.03.08i** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.03.08j** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.03.08i** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.03.08j** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -25,6 +25,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.03.08j - Composition display fix**: Composition column shows first word from imported data
 - **v3.03.08i - Numista import polish**: Unified changelog bullets, collectable default, weight rounding, N# notes, and beta warning
 - **v3.03.08h - Table controls & import options**: Grouped controls below the table, compact pagination, import Override/Merge menus, and Backup/Restore placeholder
 - **v3.03.08g - Change log & catalog improvements**: Condensed change log with row-click editing and catalog mapping
@@ -151,7 +152,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.03.08e (managed in `js/constants.js`)
+1. **Current Version**: 3.03.08j (managed in `js/constants.js`)
 2. **Last Change**: Files modal storage breakdown removed
 3. **Last Documentation Update**: August 10, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.03.08i**
+> **Latest release: v3.03.08j**
 
 
 The repository is organized as follows:

--- a/index.html
+++ b/index.html
@@ -412,7 +412,7 @@
             <tr>
               <th class="shrink" data-column="date">Date</th>
               <th class="shrink" data-column="type">Type</th>
-              <th class="shrink" data-column="metal">Composition</th>
+              <th class="shrink" data-column="composition">Composition</th>
               <th class="expand" data-column="name">Name</th>
               <th class="shrink" data-column="qty">Qty</th>
               <th class="shrink" data-column="weight">Weight<br />(oz)</th>

--- a/js/constants.js
+++ b/js/constants.js
@@ -99,7 +99,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.03.08i";
+const APP_VERSION = "3.03.08j";
 
 
 /**

--- a/js/events.js
+++ b/js/events.js
@@ -179,7 +179,7 @@ const updateColumnVisibility = () => {
         "spot",
         "weight",
         "qty",
-        "metal",
+        "composition",
       ],
     },
     {
@@ -192,7 +192,7 @@ const updateColumnVisibility = () => {
         "spot",
         "weight",
         "qty",
-        "metal",
+        "composition",
         "type",
       ],
     },
@@ -205,7 +205,7 @@ const updateColumnVisibility = () => {
   const allColumns = [
     "date",
     "type",
-    "metal",
+    "composition",
     "name",
     "qty",
     "weight",
@@ -377,7 +377,8 @@ const setupEventListeners = () => {
         function (e) {
           e.preventDefault();
 
-          const metal = elements.itemMetal.value;
+          const composition = getCompositionFirstWord(elements.itemMetal.value);
+          const metal = parseNumistaMetal(composition);
           const name = elements.itemName.value.trim();
           const qty = parseInt(elements.itemQty.value, 10);
           const type = elements.itemType.value;
@@ -425,6 +426,7 @@ const setupEventListeners = () => {
           const serial = getNextSerial();
           inventory.push({
             metal,
+            composition,
             name,
             qty,
             type,
@@ -442,7 +444,7 @@ const setupEventListeners = () => {
             numistaId: "",
           });
 
-          addCompositionOption(metal);
+          addCompositionOption(composition);
 
           catalogMap[serial] = "";
           saveInventory();
@@ -468,7 +470,8 @@ const setupEventListeners = () => {
 
           if (editingIndex === null) return;
 
-          const metal = elements.editMetal.value;
+          const composition = getCompositionFirstWord(elements.editMetal.value);
+          const metal = parseNumistaMetal(composition);
           const name = elements.editName.value.trim();
           const qty = parseInt(elements.editQty.value, 10);
           const type = elements.editType.value;
@@ -529,6 +532,7 @@ const setupEventListeners = () => {
           inventory[editingIndex] = {
             ...oldItem,
             metal,
+            composition,
             name,
             qty,
             type,
@@ -545,7 +549,7 @@ const setupEventListeners = () => {
             numistaId: elements.editCatalog.value.trim(),
           };
 
-          addCompositionOption(metal);
+          addCompositionOption(composition);
 
           catalogMap[serial] = inventory[editingIndex].numistaId;
           saveInventory();

--- a/js/init.js
+++ b/js/init.js
@@ -307,7 +307,7 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Load data
     loadInventory();
-    inventory.forEach((i) => addCompositionOption(i.metal));
+    inventory.forEach((i) => addCompositionOption(i.composition || i.metal));
     refreshCompositionOptions();
     loadSpotHistory();
 

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -40,6 +40,7 @@ const createBackupZip = async () => {
       exportDate: new Date().toISOString(),
       inventory: inventory.map(item => ({
         metal: item.metal,
+        composition: item.composition,
         name: item.name,
         qty: item.qty,
         type: item.type,
@@ -286,7 +287,7 @@ const generateBackupHtml = (sortedInventory, timeFormatted) => {
   <table>
     <thead>
       <tr>
-        <th>Metal</th><th>Name</th><th>Qty</th><th>Type</th><th>Weight(oz)</th>
+        <th>Composition</th><th>Name</th><th>Qty</th><th>Type</th><th>Weight(oz)</th>
         <th>Purchase Price</th><th>Purchase Location</th><th>Storage Location</th>
         <th>Notes</th><th>Date</th><th>Collectable</th>
       </tr>
@@ -294,7 +295,7 @@ const generateBackupHtml = (sortedInventory, timeFormatted) => {
     <tbody>
       ${sortedInventory.map(item => `
         <tr>
-          <td>${item.metal}</td>
+          <td>${getCompositionFirstWord(item.composition || item.metal)}</td>
           <td>${item.name}</td>
           <td>${item.qty}</td>
           <td>${item.type}</td>
@@ -458,7 +459,8 @@ const loadInventory = () => {
         spotPriceAtPurchase: spotPrice,
         premiumPerOz,
         totalPremium,
-        isCollectable: item.isCollectable !== undefined ? item.isCollectable : false
+        isCollectable: item.isCollectable !== undefined ? item.isCollectable : false,
+        composition: item.composition || item.metal || ""
       };
     }
     // Ensure all items have required properties
@@ -466,7 +468,8 @@ const loadInventory = () => {
       ...item,
       storageLocation: item.storageLocation || "Unknown",
       notes: item.notes || "",
-      isCollectable: item.isCollectable !== undefined ? item.isCollectable : false
+      isCollectable: item.isCollectable !== undefined ? item.isCollectable : false,
+      composition: item.composition || item.metal || ""
     };
   });
 
@@ -577,7 +580,7 @@ const renderTable = () => {
       <tr>
       <td class="shrink" data-column="date">${formatDisplayDate(item.date)}</td>
       <td class="shrink" data-column="type">${filterLink('type', item.type, getTypeColor(item.type))}</td>
-      <td class="shrink" data-column="metal">${filterLink('metal', item.metal || 'Silver', METAL_COLORS[item.metal] || 'var(--primary)')}</td>
+      <td class="shrink" data-column="composition">${filterLink('composition', getCompositionFirstWord(item.composition || item.metal || 'Silver'), METAL_COLORS[item.metal] || 'var(--primary)')}</td>
       <td class="clickable-name expand" data-column="name" onclick="editItem(${originalIdx})" title="Click to edit" tabindex="0" role="button" aria-label="Edit ${sanitizeHtml(item.name)}" onkeydown="if(event.key==='Enter'||event.key===' ')editItem(${originalIdx})">${sanitizeHtml(item.name)}</td>
       <td class="shrink" data-column="qty">${item.qty}</td>
       <td class="shrink" data-column="weight">${parseFloat(item.weight).toFixed(2)}</td>
@@ -877,7 +880,7 @@ const editItem = (idx, logIdx = null) => {
   const item = inventory[idx];
 
   // Populate edit form
-  elements.editMetal.value = item.metal;
+  elements.editMetal.value = item.composition || item.metal;
   elements.editName.value = item.name;
   elements.editQty.value = item.qty;
   elements.editType.value = item.type;
@@ -1023,7 +1026,9 @@ const importCsv = (file, override = false) => {
 
         for (const row of results.data) {
           processed++;
-          const metal = row['Metal'] || 'Silver';
+          const compositionRaw = row['Composition'] || row['Metal'] || 'Silver';
+          const composition = getCompositionFirstWord(compositionRaw);
+          const metal = parseNumistaMetal(composition);
           const name = row['Name'] || row['name'];
           const qty = row['Qty'] || row['qty'] || 1;
           const type = row['Type'] || row['type'] || 'Other';
@@ -1059,10 +1064,11 @@ const importCsv = (file, override = false) => {
             totalPremium = premiumPerOz * parseFloat(qty) * parseFloat(weight);
           }
 
-          addCompositionOption(metal);
+          addCompositionOption(composition);
 
           const item = sanitizeImportedItem({
             metal,
+            composition,
             name,
             qty,
             type,
@@ -1161,7 +1167,8 @@ const importNumistaCsv = (file, override = false) => {
           const year = (getValue(row, ['Year', 'Date']) || '').trim();
           const name = year.length >= 4 ? `${title} ${year}`.trim() : title;
           const issuedYear = year.length >= 4 ? year : '';
-          const composition = getValue(row, ['Composition', 'Metal']) || '';
+          const compositionRaw = getValue(row, ['Composition', 'Metal']) || '';
+          const composition = getCompositionFirstWord(compositionRaw);
 
           addCompositionOption(composition);
 
@@ -1210,6 +1217,7 @@ const importNumistaCsv = (file, override = false) => {
 
           const item = sanitizeImportedItem({
             metal,
+            composition,
             name,
             qty,
             type,

--- a/js/search.js
+++ b/js/search.js
@@ -12,7 +12,7 @@ const filterInventory = () => {
   Object.entries(columnFilters).forEach(([field, value]) => {
     const lower = value.toLowerCase();
     result = result.filter((item) => {
-      const fieldVal = (item[field] || '').toString().toLowerCase();
+      const fieldVal = (item[field] || (field === 'composition' ? item.metal : '')).toString().toLowerCase();
       return fieldVal === lower;
     });
   });
@@ -38,6 +38,7 @@ const filterInventory = () => {
     const formattedDate = formatDisplayDate(item.date).toLowerCase();
     return (
       item.metal.toLowerCase().includes(query) ||
+      (item.composition && item.composition.toLowerCase().includes(query)) ||
       item.name.toLowerCase().includes(query) ||
       item.type.toLowerCase().includes(query) ||
       item.purchaseLocation.toLowerCase().includes(query) ||

--- a/js/sorting.js
+++ b/js/sorting.js
@@ -17,7 +17,7 @@ const sortInventory = (data = inventory) => {
     switch(sortColumn) {
       case 0: valA = a.date; valB = b.date; break; // Date
       case 1: valA = a.type; valB = b.type; break; // Type
-      case 2: valA = a.metal; valB = b.metal; break; // Metal
+      case 2: valA = a.composition || a.metal; valB = b.composition || b.metal; break; // Composition
       case 3: valA = a.name; valB = b.name; break; // Name
       case 4: valA = a.qty; valB = b.qty; break; // Qty
       case 5: valA = a.weight; valB = b.weight; break; // Weight

--- a/js/utils.js
+++ b/js/utils.js
@@ -112,6 +112,16 @@ const addCompositionOption = (value) => {
 };
 
 /**
+ * Extracts the first complete word from a composition string
+ *
+ * @param {string} composition - Raw composition description
+ * @returns {string} First word of the composition
+ */
+const getCompositionFirstWord = (composition = "") => {
+  return composition.trim().split(/\s+/)[0].replace(/[(),]/g, "");
+};
+
+/**
  * Builds two-line HTML showing source and last sync info for a metal
  *
  * @param {string} metalName - Metal name ('Silver', 'Gold', 'Platinum', 'Palladium')
@@ -512,9 +522,12 @@ const validateInventoryItem = (item) => {
 const sanitizeImportedItem = (item) => {
   const sanitized = { ...item };
 
-  // Ensure metal/composition is a string
+  // Ensure metal and composition are strings
   if (typeof sanitized.metal !== 'string') {
     sanitized.metal = '';
+  }
+  if (typeof sanitized.composition !== 'string') {
+    sanitized.composition = sanitized.metal;
   }
 
   // Ensure numeric fields parse correctly


### PR DESCRIPTION
## Summary
- Show actual composition from imports in table instead of generic metal
- Track composition separately from metal classification in data model
- Bump version to v3.03.08j and update docs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899977ef598832eab6d15fd9dfb44ef