### PR TITLE
Standardize item types and fix inventory UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# StackTrackr v3.03.08j
+# StackTrackr v3.03.08k
 
 
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -7,6 +7,7 @@ StackTrackr is a comprehensive client-side web application for tracking precious
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
+- **v3.03.08k - Type dropdown and UI fixes**: Standardized type options, blank purchase locations, edit icon, and separate totals cards
 - **v3.03.08j - Composition display fix**: Composition column shows first word from imported data
 - **v3.03.08i - Numista import polish**: Uniform changelog bullets, default collectable flag, weight rounding, N# notes, and beta warning
 - **v3.03.08h - Table controls & import options**: Compact table controls, uniform pagination buttons, import Override/Merge menus, and Backup/Restore placeholder
@@ -313,7 +314,7 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: 3.03.08j
+**Current Version**: 3.03.08k
 **Last Updated**: August 10, 2025
 **Status**: Feature complete release candidate
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -1447,45 +1447,20 @@ tr:hover {
 }
 
 /* Clickable name cell styling */
-.clickable-name {
+.edit-icon {
+  background: none;
+  border: none;
   cursor: pointer;
-  color: var(--primary);
-  text-decoration: underline;
-  text-decoration-color: transparent;
-  transition: var(--transition);
-  position: relative;
-  font-weight: 500;
-}
-
-.clickable-name:hover {
-  color: var(--primary-hover);
-  text-decoration-color: var(--primary-hover);
-  background-color: var(--bg-secondary);
-}
-
-.clickable-name:focus {
-  outline: 2px solid var(--primary);
-  outline-offset: 2px;
-  color: var(--primary-hover);
-  text-decoration-color: var(--primary-hover);
-  background-color: var(--bg-secondary);
-}
-
-.clickable-name::after {
-  content: "✎";
-  position: absolute;
-  right: 2px;
-  top: 50%;
-  transform: translateY(-50%);
-  font-size: 0.7rem;
   color: var(--text-muted);
-  opacity: 0;
-  transition: opacity 0.2s;
+  font-size: 0.8rem;
+  margin-left: 4px;
+  padding: 0;
+  transition: color var(--transition);
 }
 
-.clickable-name:hover::after,
-.clickable-name:focus::after {
-  opacity: 0.7;
+.edit-icon:hover,
+.edit-icon:focus {
+  color: var(--primary);
 }
 /* Make buttons in table cells smaller */
 td .btn {

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,7 +1,7 @@
 # Multi-Agent Development Workflow - StackTrackr v3.03.08e
 
 
-> **Latest release: v3.03.08j**
+> **Latest release: v3.03.08k**
 
 
 ## 🎯 Project Overview

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,13 +1,18 @@
 # StackTrackr — Changelog
 
 
-> **Latest release: v3.03.08j**
+> **Latest release: v3.03.08k**
 
 
 For upcoming work, see [roadmap](roadmap.md).
 
 ## 📋 Version History
 
+
+### Version 3.03.08k – Type dropdown and UI fixes (2025-08-10)
+- Type dropdown standardized to Coin, Bar, Round, Note, Aurum, Other
+- Numista imports leave purchase location blank and avoid collectable tag for bars and rounds
+- Inventory name cells show a pencil icon for editing; totals cards restored to their own block
 
 ### Version 3.03.08j – Composition display fix (2025-08-10)
 - Composition column shows first word of imported composition instead of generic metal

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.03.08j**
+> **Latest release: v3.03.08k**
 
 
 | File | Function | Description |
@@ -151,7 +151,8 @@
 | utils.js | sanitizeHtml | Sanitizes text input for safe HTML display |
 | utils.js | gramsToOzt | Converts grams to troy ounces (ozt) |
 | utils.js | convertToUsd | Converts amount from specified currency to USD using static rates |
-| utils.js | mapNumistaType | Maps Numista type strings to internal categories (coin, Aurum, Notes, bars/rounds, other) |
+| utils.js | normalizeType | Ensures item type matches predefined options (Coin, Bar, Round, Note, Aurum, Other) |
+| utils.js | mapNumistaType | Maps Numista type strings to internal categories (Coin, Bar, Round, Note, Aurum, Other) |
 | utils.js | parseNumistaMetal | Parses composition into Silver, Gold, Platinum, Palladium, Paper, or Alloy |
 | utils.js | getCompositionFirstWord | Extracts the first word from a composition string |
 | utils.js | saveData | Saves data to localStorage with JSON serialization |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,3 +1,27 @@
+# Implementation Summary: Type Dropdown & UI Fixes
+
+> **Latest release: v3.03.08k**
+
+## Version Update: 3.03.08j → 3.03.08k
+
+## User Requirements Implemented
+
+- Type dropdown options standardized and validated
+- Numista imports skip collectable tag for bars/rounds and leave purchase location blank
+- Inventory name cells use pencil icon for editing with totals cards in separate block
+- Purchase location defaults to blank instead of "Unknown"
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`index.html`**: Reordered type dropdowns and separated totals section
+2. **`css/styles.css`**: Replaced clickable name styles with `.edit-icon`
+3. **`js/utils.js`**: Added `VALID_TYPES`, `normalizeType`, and updated Numista mapping
+4. **`js/inventory.js`**: Normalized types, blank purchase locations, name edit icon, Numista collectable logic
+5. **`js/events.js`**: Purchase location defaults to blank
+6. **`js/constants.js`**: Bumped version to 3.03.08k
+7. **Documentation**: Updated changelog, function table, implementation summary, status, roadmap, and structure
+
 
 # Implementation Summary: Composition Display Fix
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -13,6 +13,7 @@ This roadmap outlines upcoming patch releases for the v3.03.x series.
 - **v3.03.08h** – Table control compactness and import options *(completed)*
 - **v3.03.08i** – Numista import polish and weight rounding *(completed)*
 - **v3.03.08j** – Composition display fix *(completed)*
+- **v3.03.08k** – Type dropdown and UI fixes *(completed)*
 - **v3.03.12a** – Advanced reporting and analytics features.
 - **v3.03.13a** – Mobile application companion.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,11 +1,11 @@
 # Project Status - StackTrackr
 
 
-> **Latest release: v3.03.08j**
+> **Latest release: v3.03.08k**
 
-## 🎯 Current State: **BETA v3.03.08j** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.03.08k** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.03.08j** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.03.08k** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -25,6 +25,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.03.08k - Type dropdown and UI fixes**: Standardized type options, blank purchase locations, edit icon, and separate totals cards
 - **v3.03.08j - Composition display fix**: Composition column shows first word from imported data
 - **v3.03.08i - Numista import polish**: Unified changelog bullets, collectable default, weight rounding, N# notes, and beta warning
 - **v3.03.08h - Table controls & import options**: Grouped controls below the table, compact pagination, import Override/Merge menus, and Backup/Restore placeholder
@@ -142,8 +143,8 @@ All data is stored locally in the browser using localStorage with:
 ## 📚 Documentation Status (Updated: August 10, 2025)
 
 **All documentation files are current and synchronized:**
- - ✅ **status.md** - Updated for v3.03.08g release
- - ✅ **changelog.md** - Current through v3.03.08g
+ - ✅ **status.md** - Updated for v3.03.08k release
+ - ✅ **changelog.md** - Current through v3.03.08k
 - ✅ **MULTI_AGENT_WORKFLOW.md** - Comprehensive AI assistant development guide
 - ✅ **structure.md** - Reflects streamlined project organization
 - ✅ **versioning.md** - Accurate version management documentation
@@ -152,7 +153,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.03.08j (managed in `js/constants.js`)
+1. **Current Version**: 3.03.08k (managed in `js/constants.js`)
 2. **Last Change**: Files modal storage breakdown removed
 3. **Last Documentation Update**: August 10, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.03.08j**
+> **Latest release: v3.03.08k**
 
 
 The repository is organized as follows:

--- a/index.html
+++ b/index.html
@@ -481,8 +481,9 @@
             </div>
           </div>
       </section>
-      <!-- =============================================================================
-         TOTALS SECTION
+    </section>
+    <!-- =============================================================================
+       TOTALS SECTION
 
          Comprehensive financial summary cards for each metal type showing:
          - Total items and weight in inventory
@@ -766,9 +767,9 @@
               <div>
                 <label for="itemType">Type</label>
                 <select id="itemType">
-                  <option value="Round">Round</option>
-                  <option value="Bar">Bar</option>
                   <option value="Coin">Coin</option>
+                  <option value="Bar">Bar</option>
+                  <option value="Round">Round</option>
                   <option value="Note">Note</option>
                   <option value="Aurum">Aurum</option>
                   <option value="Other">Other</option>
@@ -888,9 +889,9 @@
             <div>
               <label for="editType">Type</label>
               <select id="editType">
-                <option value="Round">Round</option>
-                <option value="Bar">Bar</option>
                 <option value="Coin">Coin</option>
+                <option value="Bar">Bar</option>
+                <option value="Round">Round</option>
                 <option value="Note">Note</option>
                 <option value="Aurum">Aurum</option>
                 <option value="Other">Other</option>

--- a/js/constants.js
+++ b/js/constants.js
@@ -99,7 +99,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.03.08j";
+const APP_VERSION = "3.03.08k";
 
 
 /**

--- a/js/events.js
+++ b/js/events.js
@@ -386,7 +386,7 @@ const setupEventListeners = () => {
           weight = isNaN(weight) ? 0 : parseFloat(weight.toFixed(2));
           const price = parseFloat(elements.itemPrice.value);
           const purchaseLocation =
-            elements.purchaseLocation.value.trim() || "Unknown";
+            elements.purchaseLocation.value.trim() || "";
           const storageLocation =
             elements.storageLocation.value.trim() || "";
           const notes = elements.itemNotes.value.trim() || "";
@@ -479,7 +479,7 @@ const setupEventListeners = () => {
           weight = isNaN(weight) ? 0 : parseFloat(weight.toFixed(2));
           const price = parseFloat(elements.editPrice.value);
           const purchaseLocation =
-            elements.editPurchaseLocation.value.trim() || "Unknown";
+            elements.editPurchaseLocation.value.trim() || "";
           const storageLocation =
             elements.editStorageLocation.value.trim() || "";
           const notes = elements.editNotes.value.trim() || "";

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -453,7 +453,8 @@ const loadInventory = () => {
 
       return {
         ...item,
-        purchaseLocation: item.purchaseLocation || "Unknown",
+        type: normalizeType(item.type),
+        purchaseLocation: item.purchaseLocation || "",
         storageLocation: item.storageLocation || "Unknown",
         notes: item.notes || "",
         spotPriceAtPurchase: spotPrice,
@@ -466,6 +467,8 @@ const loadInventory = () => {
     // Ensure all items have required properties
     return {
       ...item,
+      type: normalizeType(item.type),
+      purchaseLocation: item.purchaseLocation || "",
       storageLocation: item.storageLocation || "Unknown",
       notes: item.notes || "",
       isCollectable: item.isCollectable !== undefined ? item.isCollectable : false,
@@ -581,13 +584,13 @@ const renderTable = () => {
       <td class="shrink" data-column="date">${formatDisplayDate(item.date)}</td>
       <td class="shrink" data-column="type">${filterLink('type', item.type, getTypeColor(item.type))}</td>
       <td class="shrink" data-column="composition">${filterLink('composition', getCompositionFirstWord(item.composition || item.metal || 'Silver'), METAL_COLORS[item.metal] || 'var(--primary)')}</td>
-      <td class="clickable-name expand" data-column="name" onclick="editItem(${originalIdx})" title="Click to edit" tabindex="0" role="button" aria-label="Edit ${sanitizeHtml(item.name)}" onkeydown="if(event.key==='Enter'||event.key===' ')editItem(${originalIdx})">${sanitizeHtml(item.name)}</td>
+      <td class="expand" data-column="name">${sanitizeHtml(item.name)} <button type="button" class="edit-icon" onclick="editItem(${originalIdx})" aria-label="Edit ${sanitizeHtml(item.name)}" title="Edit ${sanitizeHtml(item.name)}">✎</button></td>
       <td class="shrink" data-column="qty">${item.qty}</td>
       <td class="shrink" data-column="weight">${parseFloat(item.weight).toFixed(2)}</td>
       <td class="shrink" data-column="purchasePrice">${formatDollar(item.price)}</td>
       <td class="shrink" data-column="spot">${item.isCollectable ? 'N/A' : (item.spotPriceAtPurchase > 0 ? formatDollar(item.spotPriceAtPurchase) : 'N/A')}</td>
       <td class="shrink" data-column="premium" style="color: ${item.isCollectable ? 'var(--text-muted)' : (item.totalPremium > 0 ? 'var(--warning)' : 'inherit')}">${item.isCollectable ? 'N/A' : formatDollar(item.totalPremium)}</td>
-      <td class="shrink" data-column="purchaseLocation">${filterLink('purchaseLocation', item.purchaseLocation, getPurchaseLocationColor(item.purchaseLocation))}</td>
+      <td class="shrink" data-column="purchaseLocation">${item.purchaseLocation ? filterLink('purchaseLocation', item.purchaseLocation, getPurchaseLocationColor(item.purchaseLocation)) : ''}</td>
       <td class="shrink" data-column="storageLocation">${item.storageLocation ? filterLink('storageLocation', item.storageLocation, getStorageLocationColor(item.storageLocation)) : ''}</td>
       <td class="shrink" data-column="collectable"><button type="button" class="btn action-btn collectable-btn ${item.isCollectable ? 'success' : ''}" onclick="toggleCollectable(${originalIdx})" aria-label="Toggle collectable status for ${sanitizeHtml(item.name)}" title="Toggle collectable status">${item.isCollectable ? 'Yes' : 'No'}</button></td>
       <td class="shrink" data-column="notes"><button type="button" class="btn action-btn notes-btn ${item.notes && item.notes.trim() ? 'success' : ''}" onclick="showNotes(${originalIdx})" aria-label="View notes" title="View notes">${item.notes && item.notes.trim() ? 'Yes' : 'No'}</button></td>
@@ -1031,14 +1034,14 @@ const importCsv = (file, override = false) => {
           const metal = parseNumistaMetal(composition);
           const name = row['Name'] || row['name'];
           const qty = row['Qty'] || row['qty'] || 1;
-          const type = row['Type'] || row['type'] || 'Other';
+          const type = normalizeType(row['Type'] || row['type']);
           const weight = row['Weight(oz)'] || row['weight'];
           const priceStr = row['Purchase Price'] || row['price'];
           let price = typeof priceStr === 'string'
             ? parseFloat(priceStr.replace(/[^\d.-]+/g, ''))
             : parseFloat(priceStr);
           if (price < 0) price = 0;
-          const purchaseLocation = row['Purchase Location'] || 'Unknown';
+          const purchaseLocation = row['Purchase Location'] || '';
           const storageLocation = row['Storage Location'] || '';
           const notes = row['Notes'] || '';
           const date = parseDate(row['Date']);
@@ -1128,7 +1131,7 @@ const importCsv = (file, override = false) => {
  * - Weight columns → max value converted from grams to ozt
  * - Composition → metal detected via parseNumistaMetal(), defaults to Alloy
  * - Buying price (currency) → price in USD via convertToUsd()
- * - Storage location / Acquisition place → defaults to "unknown" if blank
+ * - Storage location / Acquisition place → left blank if missing
  * - Acquisition date → parsed YYYY-MM-DD or today if blank
  * - Notes appended with import source reference
  *
@@ -1175,7 +1178,7 @@ const importNumistaCsv = (file, override = false) => {
           let metal = parseNumistaMetal(composition);
           const qty = parseInt(getValue(row, ['Quantity', 'Qty', 'Quantity owned']) || 1, 10);
 
-          let type = mapNumistaType(getValue(row, ['Type']) || '');
+          let type = normalizeType(mapNumistaType(getValue(row, ['Type']) || ''));
           if (metal === 'Paper' || composition.toLowerCase().startsWith('paper')) {
             type = 'Note';
             metal = 'Alloy';
@@ -1199,7 +1202,7 @@ const importNumistaCsv = (file, override = false) => {
           }
 
           const purchaseLocRaw = getValue(row, ['Acquisition place', 'Acquired from', 'Purchase place']);
-          const purchaseLocation = purchaseLocRaw && purchaseLocRaw.trim() ? purchaseLocRaw.trim() : 'unknown';
+          const purchaseLocation = purchaseLocRaw && purchaseLocRaw.trim() ? purchaseLocRaw.trim() : '';
           const storageLocRaw = getValue(row, ['Storage location', 'Stored at', 'Storage place']);
           const storageLocation = storageLocRaw && storageLocRaw.trim() ? storageLocRaw.trim() : '';
 
@@ -1210,7 +1213,7 @@ const importNumistaCsv = (file, override = false) => {
           const baseNote = (getValue(row, ['Note', 'Notes']) || '').trim();
           const notes = `${baseNote ? baseNote + ' ' : ''}(Imported from Numista.com N#${numistaId})`;
 
-          const isCollectable = true;
+          const isCollectable = !(type === 'Bar' || type === 'Round');
           const spotPriceAtPurchase = 0;
           const premiumPerOz = 0;
           const totalPremium = 0;
@@ -1361,7 +1364,7 @@ const importJson = (file) => {
           weight: parseFloat(item.weight),
           price,
           date: parseDate(item.date || todayStr()),
-          purchaseLocation: item.purchaseLocation || "Unknown",
+          purchaseLocation: item.purchaseLocation || "",
           storageLocation: item.storageLocation || "Unknown",
           notes: item.notes || "",
           spotPriceAtPurchase: item.spotPriceAtPurchase || spotPrices[item.metal.toLowerCase()],
@@ -1494,14 +1497,14 @@ const importExcel = (file) => {
         const metal = row['Metal'] || 'Silver';
         const name = row['Name'] || row['name'];
         const qty = parseInt(row['Qty'] || row['qty'] || 1, 10);
-        const type = row['Type'] || row['type'] || 'Other';
+        const type = normalizeType(row['Type'] || row['type']);
         const weight = parseFloat(row['Weight(oz)'] || row['weight']);
         const priceStr = row['Purchase Price'] || row['price'];
         let price = parseFloat(
           typeof priceStr === "string" ? priceStr.replace(/[^0-9.-]+/g, "") : priceStr
         );
         if (price < 0) price = 0;
-        const purchaseLocation = row['Purchase Location'] || "Unknown";
+        const purchaseLocation = row['Purchase Location'] || "";
         const storageLocation = row['Storage Location'] || "Unknown";
         const notes = row['Notes'] || "";
         const date = parseDate(row['Date']); // Using the new date parser

--- a/js/utils.js
+++ b/js/utils.js
@@ -381,6 +381,24 @@ const convertToUsd = (amount, currency = "USD") => {
 };
 
 /**
+ * Allowed inventory item types
+ * @constant {string[]}
+ */
+const VALID_TYPES = ["Coin", "Bar", "Round", "Note", "Aurum", "Other"];
+
+/**
+ * Normalizes item type to one of the predefined options
+ *
+ * @param {string} [type=""] - Raw type string
+ * @returns {string} Normalized type value
+ */
+const normalizeType = (type = "") => {
+  const t = type.toString().trim().toLowerCase();
+  const match = VALID_TYPES.find(v => v.toLowerCase() === t);
+  return match || "Other";
+};
+
+/**
  * Maps Numista type strings to internal StackTrackr categories
  *
  * @param {string} type - Numista type string
@@ -389,10 +407,11 @@ const convertToUsd = (amount, currency = "USD") => {
 const mapNumistaType = (type = "") => {
   const t = type.toLowerCase();
   if (t.includes("aurum")) return "Aurum";
-  if (t.includes("note")) return "Notes";
-  if (t.includes("bar") || t.includes("round")) return "bars/rounds";
-  if (t.includes("coin")) return "coin";
-  return "other";
+  if (t.includes("note")) return "Note";
+  if (t.includes("bar") || t.includes("ingot")) return "Bar";
+  if (t.includes("round") || t.includes("token") || t.includes("medal")) return "Round";
+  if (t.includes("coin")) return "Coin";
+  return "Other";
 };
 
 /**
@@ -544,6 +563,7 @@ const sanitizeImportedItem = (item) => {
   for (const field of strFields) {
     if (typeof sanitized[field] !== 'string') sanitized[field] = '';
   }
+  sanitized.type = normalizeType(sanitized.type);
 
   // Reset premium calculations if price or weight are missing
   if (!sanitized.price || !sanitized.weight) {


### PR DESCRIPTION
## Summary
- normalize all item types and reorder type dropdowns to Coin, Bar, Round, Note, Aurum, Other
- add pencil edit icon for name cells and keep totals cards in a separate section
- treat blank purchase locations as empty strings and skip collectable flag for imported bars and rounds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68999d7d6bec832ebfc34ee382495617