### PR TITLE
feat: add inventory type filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# StackTrackr v3.03.08l
+# StackTrackr v3.03.08n
 
 
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -7,6 +7,8 @@ StackTrackr is a comprehensive client-side web application for tracking precious
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
+- **v3.03.08n - Inventory type filter**: Added type dropdown and dynamic metal options
+- **v3.03.08m - Inventory filter dropdown**: Added metal filter to inventory title bar for quick filtering
 - **v3.03.08l - Search fix & composition parsing**: Search box filters table as you type and Numista compositions truncate to two words
 - **v3.03.08k - Type dropdown and UI fixes**: Standardized type options, blank purchase locations, edit icon, and separate totals cards
 - **v3.03.08j - Composition display fix**: Composition column shows first word from imported data
@@ -315,8 +317,8 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: 3.03.08l
-**Last Updated**: August 10, 2025
+**Current Version**: 3.03.08n
+**Last Updated**: August 11, 2025
 **Status**: Feature complete release candidate
 
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -2159,6 +2159,11 @@ td input:checked + .slider:before {
   flex: 1;
 }
 
+.filter-select {
+  width: 8rem;
+  height: 1.375rem;
+}
+
 #clearSearchBtn {
   width: auto;
   padding: 0.75rem 1.5rem;

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackTrackr v3.03.08e
+# Multi-Agent Development Workflow - StackTrackr v3.03.08n
 
 
-> **Latest release: v3.03.08l**
+> **Latest release: v3.03.08n**
 
 
 ## 🎯 Project Overview
 
-You are contributing to the **StackTrackr v3.03.08e**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to the **StackTrackr v3.03.08n**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.03.08e (beta)
+**Current Status**: v3.03.08n (beta)
 **Your Role**: Complete focused v3.03.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,13 +1,20 @@
 # StackTrackr — Changelog
 
 
-> **Latest release: v3.03.08l**
+ > **Latest release: v3.03.08n**
 
 
 For upcoming work, see [roadmap](roadmap.md).
 
 ## 📋 Version History
 
+
+### Version 3.03.08n – Inventory type filter (2025-08-10)
+- Added type filter dropdown before metal filter
+- Metal filter options now derive from truncated composition values
+
+### Version 3.03.08m – Inventory filter dropdown (2025-08-10)
+- Added metal filter to inventory title bar for quick result filtering
 
 ### Version 3.03.08l – Search fix & composition parsing (2025-08-10)
 - Fixed search box to filter inventory as you type

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.03.08l**
+ > **Latest release: v3.03.08n**
 
 
 | File | Function | Description |
@@ -79,6 +79,7 @@
 | events.js | setupEventListeners | Sets up all primary event listeners for the application |
 | events.js | updateThemeDisplay |  |
 | events.js | setupPagination | Sets up pagination event listeners |
+| events.js | populateFilterOptions | Populates type and metal filter dropdowns |
 | events.js | setupSearch | Sets up search event listeners |
 | events.js | setupThemeToggle | Sets up theme toggle event listeners |
 | events.js | setupApiEvents | Sets up API-related event listeners |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,3 +1,47 @@
+# Implementation Summary: Inventory Type Filter
+
+> **Latest release: v3.03.08n**
+
+## Version Update: 3.03.08m → 3.03.08n
+
+## User Requirements Implemented
+
+- Added type filter dropdown to inventory title bar ahead of metal filter
+- Metal filter options now derive from truncated composition values
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`index.html`**: Added type filter and removed hardcoded metal options
+2. **`js/state.js`**: Cached type filter element
+3. **`js/init.js`**: Initialized type filter element
+4. **`js/events.js`**: Populates filter options, added type filter listener, and reset logic
+5. **`js/search.js`**: Synced dropdowns with column filters
+6. **`js/constants.js`**: Bumped version to 3.03.08n
+7. **Documentation**: Updated changelog, function table, implementation summary, roadmap, status, structure, and README
+
+# Implementation Summary: Inventory Filter Dropdown
+
+> **Latest release: v3.03.08m**
+
+## Version Update: 3.03.08l → 3.03.08m
+
+## User Requirements Implemented
+
+- Added metal filter dropdown to inventory title bar
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`index.html`**: Added metal filter dropdown
+2. **`css/styles.css`**: Styled metal filter select
+3. **`js/state.js`**: Cached metal filter element
+4. **`js/init.js`**: Initialized metal filter
+5. **`js/events.js`**: Added metal filter listener and reset
+6. **`js/search.js`**: Synced dropdown with column filters
+7. **`js/constants.js`**: Bumped version to 3.03.08m
+8. **Documentation**: Updated changelog, function table, implementation summary, roadmap, status, structure, and README
+
 # Implementation Summary: Search Fix & Composition Parsing
 
 > **Latest release: v3.03.08l**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,7 +14,9 @@ This roadmap outlines upcoming patch releases for the v3.03.x series.
 - **v3.03.08i** – Numista import polish and weight rounding *(completed)*
 - **v3.03.08j** – Composition display fix *(completed)*
 - **v3.03.08k** – Type dropdown and UI fixes *(completed)*
-- **v3.03.08l** – Search box fix and composition parsing *(completed)*
-- **v3.03.12a** – Advanced reporting and analytics features.
-- **v3.03.13a** – Mobile application companion.
+  - **v3.03.08l** – Search box fix and composition parsing *(completed)*
+  - **v3.03.08m** – Inventory filter dropdown *(completed)*
+  - **v3.03.08n** – Inventory type filter and dynamic metals *(completed)*
+  - **v3.03.12a** – Advanced reporting and analytics features.
+  - **v3.03.13a** – Mobile application companion.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,11 +1,11 @@
 # Project Status - StackTrackr
 
 
-> **Latest release: v3.03.08l**
+> **Latest release: v3.03.08n**
 
-## 🎯 Current State: **BETA v3.03.08l** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.03.08n** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.03.08l** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.03.08n** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.03.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -25,6 +25,8 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.03.08n - Inventory type filter**: Added type dropdown and dynamic metal options
+- **v3.03.08m - Inventory filter dropdown**: Added metal filter to inventory title bar for quick filtering
 - **v3.03.08l - Search fix & composition parsing**: Search input filters table in real time and Numista compositions truncate to two words
 - **v3.03.08k - Type dropdown and UI fixes**: Standardized type options, blank purchase locations, edit icon, and separate totals cards
 - **v3.03.08j - Composition display fix**: Composition column shows first word from imported data
@@ -144,8 +146,8 @@ All data is stored locally in the browser using localStorage with:
 ## 📚 Documentation Status (Updated: August 10, 2025)
 
 **All documentation files are current and synchronized:**
- - ✅ **status.md** - Updated for v3.03.08l release
- - ✅ **changelog.md** - Current through v3.03.08l
+  - ✅ **status.md** - Updated for v3.03.08n release
+  - ✅ **changelog.md** - Current through v3.03.08n
 - ✅ **MULTI_AGENT_WORKFLOW.md** - Comprehensive AI assistant development guide
 - ✅ **structure.md** - Reflects streamlined project organization
 - ✅ **versioning.md** - Accurate version management documentation
@@ -154,8 +156,8 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.03.08l (managed in `js/constants.js`)
-2. **Last Change**: Search filters inventory in real time; Numista composition parsing improved
+1. **Current Version**: 3.03.08n (managed in `js/constants.js`)
+2. **Last Change**: Added type filter and dynamic metal options for inventory
 3. **Last Documentation Update**: August 10, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns
 5. **Documentation**: Comprehensive JSDoc comments throughout codebase

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.03.08l**
+> **Latest release: v3.03.08n**
 
 
 The repository is organized as follows:

--- a/index.html
+++ b/index.html
@@ -388,6 +388,12 @@
               placeholder="Search inventory by metal, name, type, purchase location, storage location, notes, date..."
               type="text"
             />
+            <select id="typeFilter" class="filter-select" title="Filter by type" aria-label="Filter by type">
+              <option value="">All Types</option>
+            </select>
+            <select id="metalFilter" class="filter-select" title="Filter by metal" aria-label="Filter by metal">
+              <option value="">All Metals</option>
+            </select>
             <button class="btn" id="clearSearchBtn">Clear</button>
             <button class="btn success" id="newItemBtn">New Item</button>
           </div>

--- a/js/constants.js
+++ b/js/constants.js
@@ -99,7 +99,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.03.08l";
+const APP_VERSION = "3.03.08n";
 
 
 /**

--- a/js/events.js
+++ b/js/events.js
@@ -1321,10 +1321,45 @@ const setupPagination = () => {
 };
 
 /**
+ * Populates type and metal filter dropdowns based on current inventory
+ */
+const populateFilterOptions = () => {
+  if (elements.metalFilter) {
+    const selected = elements.metalFilter.value;
+    const metals = [
+      ...new Set(
+        inventory.map((i) =>
+          getCompositionFirstWords(i.composition || i.metal || ""),
+        ),
+      ),
+    ]
+      .filter(Boolean)
+      .sort();
+    elements.metalFilter.innerHTML =
+      '<option value="">All Metals</option>' +
+      metals.map((m) => `<option value="${m}">${m}</option>`).join("");
+    elements.metalFilter.value = selected;
+  }
+
+  if (elements.typeFilter) {
+    const selected = elements.typeFilter.value;
+    const types = [...new Set(inventory.map((i) => i.type))]
+      .filter(Boolean)
+      .sort();
+    elements.typeFilter.innerHTML =
+      '<option value="">All Types</option>' +
+      types.map((t) => `<option value="${t}">${t}</option>`).join("");
+    elements.typeFilter.value = selected;
+  }
+};
+
+/**
  * Sets up search event listeners
  */
 const setupSearch = () => {
   debugLog("Setting up search listeners...");
+
+  populateFilterOptions();
 
   try {
     if (elements.searchInput) {
@@ -1340,6 +1375,46 @@ const setupSearch = () => {
       );
     }
 
+    if (elements.typeFilter) {
+      safeAttachListener(
+        elements.typeFilter,
+        "change",
+        function () {
+          const value = this.value;
+          if (value) {
+            columnFilters.type = value;
+          } else {
+            delete columnFilters.type;
+          }
+          searchQuery = "";
+          if (elements.searchInput) elements.searchInput.value = "";
+          currentPage = 1;
+          renderTable();
+        },
+        "Type filter select",
+      );
+    }
+
+    if (elements.metalFilter) {
+      safeAttachListener(
+        elements.metalFilter,
+        "change",
+        function () {
+          const value = this.value;
+          if (value) {
+            columnFilters.composition = value;
+          } else {
+            delete columnFilters.composition;
+          }
+          searchQuery = "";
+          if (elements.searchInput) elements.searchInput.value = "";
+          currentPage = 1;
+          renderTable();
+        },
+        "Metal filter select",
+      );
+    }
+
     if (elements.clearSearchBtn) {
       safeAttachListener(
         elements.clearSearchBtn,
@@ -1347,6 +1422,12 @@ const setupSearch = () => {
         function () {
           if (elements.searchInput) {
             elements.searchInput.value = "";
+          }
+          if (elements.typeFilter) {
+            elements.typeFilter.value = "";
+          }
+          if (elements.metalFilter) {
+            elements.metalFilter.value = "";
           }
           searchQuery = "";
           columnFilters = {};

--- a/js/init.js
+++ b/js/init.js
@@ -179,6 +179,8 @@ document.addEventListener("DOMContentLoaded", () => {
     // Search elements
     debugLog("Phase 6: Initializing search elements...");
     elements.searchInput = safeGetElement("searchInput");
+    elements.typeFilter = safeGetElement("typeFilter");
+    elements.metalFilter = safeGetElement("metalFilter");
     elements.clearSearchBtn = safeGetElement("clearSearchBtn");
     elements.newItemBtn = safeGetElement("newItemBtn");
     elements.searchResultsInfo = safeGetElement("searchResultsInfo");

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -549,6 +549,7 @@ const getStorageLocationColor = loc => getColor(storageLocationColors, loc);
 
 const renderTable = () => {
   return monitorPerformance(() => {
+    populateFilterOptions();
     const filteredInventory = filterInventory();
 
     // Automatically adjust items-per-page dropdown when filtered results

--- a/js/search.js
+++ b/js/search.js
@@ -65,6 +65,11 @@ const applyColumnFilter = (field, value) => {
   } else {
     columnFilters[field] = value;
   }
+  if (field === 'composition' && elements.metalFilter) {
+    elements.metalFilter.value = columnFilters[field] || '';
+  } else if (field === 'type' && elements.typeFilter) {
+    elements.typeFilter.value = columnFilters[field] || '';
+  }
   searchQuery = '';
   if (elements.searchInput) elements.searchInput.value = '';
   currentPage = 1;

--- a/js/state.js
+++ b/js/state.js
@@ -154,6 +154,8 @@ const elements = {
 
   // Search elements
   searchInput: null,
+  typeFilter: null,
+  metalFilter: null,
   clearSearchBtn: null,
   newItemBtn: null,
   searchResultsInfo: null,

--- a/structure.md
+++ b/structure.md
@@ -1,6 +1,6 @@
 # StackTrackr - Project Structure
 
-## Current Structure (Version 3.03.08e)
+## Current Structure (Version 3.03.08n)
 
 ```text
 ├── css/


### PR DESCRIPTION
## Summary
- populate metal filter from truncated composition values
- add type filter dropdown alongside metal filter
- bump version to v3.03.08n and update docs

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899a556179c832ebd41eb923cecb1ab