### PR TITLE
Reset search clears filters and sanitize Numista imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# StackTrackr v3.04.00
+# StackTrackr v3.04.01
 
 
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -7,6 +7,7 @@ StackTrackr is a comprehensive client-side web application for tracking precious
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
+- **v3.04.01 - Filter reset & Numista sanitization**: Clear search resets filters, sanitized Numista imports, batch API pulls
 - **v3.04.00 - Inventory filter click & API cleanup**: Click any table value to filter and removed global API cache duration dropdown
 - **v3.03.08n - Inventory type filter**: Added type dropdown and dynamic metal options
 - **v3.03.08m - Inventory filter dropdown**: Added metal filter to inventory title bar for quick filtering
@@ -44,6 +45,11 @@ The public hosted version of the app is available at [stackrtrackr.com](https://
 - **v3.1.9 - UI Consistency**: Clear Cache button styling improvements across themes
 - **v3.1.8 - Backup System**: Full ZIP backup functionality with restoration guides
 - **v3.1.6 - Theme Toggle**: Fixed theme management with system preference detection
+
+## 🆕 What's New in v3.04.01
+- Clear search button resets all filters, including those set in the modal
+- Numista imports sanitize text fields to ensure filter links remain functional
+- API providers craft a single batch request using only selected metals
 
 ## 🆕 What's New in v3.04.00
 - Clicking any non-action table cell adds a filter; repeat clicks toggle filters and support up to three stacked conditions

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackTrackr v3.04.00
+# Multi-Agent Development Workflow - StackTrackr v3.04.01
 
 
-> **Latest release: v3.04.00**
+> **Latest release: v3.04.01**
 
 
 ## 🎯 Project Overview
 
-You are contributing to the **StackTrackr v3.04.00**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to the **StackTrackr v3.04.01**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.04.00 (beta)
+**Current Status**: v3.04.01 (beta)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,13 +1,18 @@
 # StackTrackr — Changelog
 
 
- > **Latest release: v3.04.00**
+> **Latest release: v3.04.01**
 
 
 For upcoming work, see [roadmap](roadmap.md).
 
 ## 📋 Version History
 
+
+### Version 3.04.01 – Filter reset & Numista sanitization (2025-08-11)
+- Clear search button now resets all active filters including modal selections
+- Numista imports strip unsafe characters from fields to preserve table filtering
+- API providers craft batch requests for selected metals in a single pull
 
 ### Version 3.04.00 – Filter click & API cleanup (2025-08-11)
 - Table cells (except collectable, notes, delete) now toggle exact-match filters with multi-level stacking

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
- > **Latest release: v3.04.00**
+ > **Latest release: v3.04.01**
 
 
 | File | Function | Description |
@@ -162,7 +162,7 @@
 | utils.js | loadData | Loads data from localStorage with error handling |
 | utils.js | sortInventoryByDateNewestFirst | Sorts inventory by date (newest first) |
 | utils.js | validateInventoryItem | Validates inventory item data |
-| utils.js | sanitizeImportedItem | Coerces invalid imported fields to safe defaults |
+| utils.js | sanitizeImportedItem | Coerces invalid imported fields to safe defaults and strips unsafe characters |
 | utils.js | handleError | Handles errors with user-friendly messaging |
 | utils.js | getUserFriendlyMessage | Converts technical error messages to user-friendly ones |
 | utils.js | downloadFile | Downloads a file with the specified content and filename |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,3 +1,24 @@
+# Implementation Summary: Filter Reset & Numista Sanitization
+
+> **Latest release: v3.04.01**
+
+## Version Update: 3.04.00 → 3.04.01
+
+## User Requirements Implemented
+
+- Clear search button resets all filters including modal selections
+- Numista imports sanitize text fields to preserve filtering
+- API providers issue single batch request for selected metals
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`js/events.js`**: Clear search delegates to global filter reset
+2. **`js/utils.js`**: `sanitizeImportedItem` strips unsafe characters from string fields
+3. **`js/api.js`**: Batch requests attempted for all providers using selected metals
+4. **`js/constants.js`**: Bumped version to 3.04.01
+5. **Documentation**: Updated changelog, status, roadmap, structure, and function table
+
 # Implementation Summary: Filter Click Enhancements
 
 > **Latest release: v3.04.00**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,6 +2,7 @@
 
 This roadmap outlines upcoming patch releases for the v3.04.x series.
 
+- **v3.04.01** – Search reset, Numista sanitization, and batch API pulls *(completed)*
 - **v3.04.00** – Inventory filter enhancements and API cleanup *(completed)*
 - **v3.03.07b** – Documentation normalization and reference cleanup *(completed)*
 - **v3.03.08a** – Version update changelog modal *(completed)*

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,11 +1,11 @@
 # Project Status - StackTrackr
 
 
-> **Latest release: v3.04.00**
+> **Latest release: v3.04.01**
 
-## 🎯 Current State: **BETA v3.04.00** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.01** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.04.00** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.04.01** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -25,6 +25,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.04.01 - Filter reset & Numista sanitization**: Clear search resets filters, sanitized Numista imports, batch API pulls
 - **v3.04.00 - Inventory filter click & API cleanup**: Clickable table value filters and removed global API cache duration dropdown
 - **v3.03.08n - Inventory type filter**: Added type dropdown and dynamic metal options
 - **v3.03.08m - Inventory filter dropdown**: Added metal filter to inventory title bar for quick filtering
@@ -147,8 +148,8 @@ All data is stored locally in the browser using localStorage with:
 ## 📚 Documentation Status (Updated: August 11, 2025)
 
 **All documentation files are current and synchronized:**
-  - ✅ **status.md** - Updated for v3.04.00 release
-  - ✅ **changelog.md** - Current through v3.04.00
+  - ✅ **status.md** - Updated for v3.04.01 release
+  - ✅ **changelog.md** - Current through v3.04.01
 - ✅ **MULTI_AGENT_WORKFLOW.md** - Comprehensive AI assistant development guide
 - ✅ **structure.md** - Reflects streamlined project organization
 - ✅ **versioning.md** - Accurate version management documentation
@@ -157,8 +158,8 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.03.08n (managed in `js/constants.js`)
-2. **Last Change**: Added type filter and dynamic metal options for inventory
+1. **Current Version**: 3.04.01 (managed in `js/constants.js`)
+2. **Last Change**: Search reset, Numista sanitization, and batch API pulls
 3. **Last Documentation Update**: August 10, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns
 5. **Documentation**: Comprehensive JSDoc comments throughout codebase

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.04.00**
+> **Latest release: v3.04.01**
 
 
 The repository is organized as follows:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.04.00**
+> **Latest release: v3.04.01**
 
 ## Overview 
 
@@ -9,7 +9,7 @@ The StackTrackr now uses a dynamic version management system that automatically 
 ## How It Works
 
 ### Single Source of Truth
-- Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.00'`
+- Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.01'`
   - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation
@@ -19,7 +19,7 @@ The StackTrackr now uses a dynamic version management system that automatically 
 
 ### Utility Functions
 - `js/constants.js` provides:
-  - `getVersionString(prefix)`: Returns formatted version (e.g., "v3.04.00")
+  - `getVersionString(prefix)`: Returns formatted version (e.g., "v3.04.01")
   - `injectVersionString(elementId, prefix)`: Inserts formatted version into a target element
 - `js/utils.js` provides:
   - `getAppTitle(baseTitle)`: Returns full app title with version
@@ -31,13 +31,13 @@ To release a new version:
 1. **Update ONLY the constants file:**
    ```javascript
    // In js/constants.js
-   const APP_VERSION = '3.04.00';  // Change this line only
+     const APP_VERSION = '3.04.01';  // Change this line only
    ```
 
 2. **All these will automatically update:**
-   - Page title: "StackTrackr v3.04.00"
-   - Page heading: "StackTrackr v3.04.00"
-   - Browser tab title: "StackTrackr v3.04.00"
+  - Page title: "StackTrackr v3.04.01"
+  - Page heading: "StackTrackr v3.04.01"
+  - Browser tab title: "StackTrackr v3.04.01"
    - App header: "StackTrackr v3.03.07b"
 
 3. **Update changelog:** Add entry to `/docs/changelog.md` for documentation

--- a/js/api.js
+++ b/js/api.js
@@ -934,15 +934,29 @@ const fetchSpotPricesFromApi = async (provider, apiKey) => {
   };
 
   // Get selected metals
-  const selectedMetals = Object.keys(selected).filter(metal => selected[metal] !== false);
-  
-  // Try batch request first if supported and multiple metals selected
-  if (providerConfig.batchSupported && selectedMetals.length > 1) {
+  const selectedMetals = Object.keys(selected).filter(
+    (metal) => selected[metal] !== false,
+  );
+
+  if (selectedMetals.length === 0) {
+    throw new Error("No metals selected for sync");
+  }
+
+  // Try batch request first if supported
+  if (providerConfig.batchSupported) {
     try {
       const historyDays = config.historyDays?.[provider] || 0;
-      return await fetchBatchSpotPrices(provider, apiKey, selectedMetals, historyDays);
+      return await fetchBatchSpotPrices(
+        provider,
+        apiKey,
+        selectedMetals,
+        historyDays,
+      );
     } catch (batchError) {
-      console.warn(`Batch request failed for ${provider}, falling back to individual requests:`, batchError.message);
+      console.warn(
+        `Batch request failed for ${provider}, falling back to individual requests:`,
+        batchError.message,
+      );
       // Fall through to individual requests
     }
   }

--- a/js/constants.js
+++ b/js/constants.js
@@ -149,7 +149,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.00";
+const APP_VERSION = "3.04.01";
 
 
 /**

--- a/js/events.js
+++ b/js/events.js
@@ -1412,8 +1412,16 @@ const setupSearch = () => {
         elements.clearSearchBtn,
         "click",
         function () {
-          if (elements.searchInput) {
-            elements.searchInput.value = "";
+          if (typeof clearAllFilters === "function") {
+            clearAllFilters();
+          } else {
+            if (elements.searchInput) {
+              elements.searchInput.value = "";
+            }
+            searchQuery = "";
+            columnFilters = {};
+            currentPage = 1;
+            renderTable();
           }
           if (elements.typeFilter) {
             elements.typeFilter.value = "";
@@ -1421,10 +1429,6 @@ const setupSearch = () => {
           if (elements.metalFilter) {
             elements.metalFilter.value = "";
           }
-          searchQuery = "";
-          columnFilters = {};
-          currentPage = 1;
-          renderTable();
         },
         "Clear search button",
       );

--- a/js/utils.js
+++ b/js/utils.js
@@ -571,10 +571,15 @@ const sanitizeImportedItem = (item) => {
     }
   }
 
-  // Normalize string fields
+  // Normalize and sanitize string fields
   const strFields = ['name', 'type', 'purchaseLocation', 'storageLocation', 'notes'];
+  const cleanString = (str = '') =>
+    str
+      .toString()
+      .replace(/[\u0000-\u001F\u007F'\"]/g, '')
+      .trim();
   for (const field of strFields) {
-    if (typeof sanitized[field] !== 'string') sanitized[field] = '';
+    sanitized[field] = cleanString(sanitized[field]);
   }
   sanitized.type = normalizeType(sanitized.type);
 


### PR DESCRIPTION
## Summary
- Ensure the search bar's clear button resets all active filters, including those set in the filters modal
- Sanitize Numista-imported text fields to strip unsafe characters that could break filter links
- Batch each API provider request into a single pull using the user's selected metals and bump version to v3.04.01

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899c1030de4832e84df7bdeb9a89d64