### PR TITLE
fix: trim Numista CSV headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# StackTrackr v3.04.01
+# StackTrackr v3.04.02
 
 
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -7,6 +7,7 @@ StackTrackr is a comprehensive client-side web application for tracking precious
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
+- **v3.04.02 - Numista header trimming**: Imports accept Numista CSVs with trailing spaces in column headers
 - **v3.04.01 - Filter reset & Numista sanitization**: Clear search resets filters, sanitized Numista imports, batch API pulls
 - **v3.04.00 - Inventory filter click & API cleanup**: Click any table value to filter and removed global API cache duration dropdown
 - **v3.03.08n - Inventory type filter**: Added type dropdown and dynamic metal options

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackTrackr v3.04.01
+# Multi-Agent Development Workflow - StackTrackr v3.04.02
 
 
-> **Latest release: v3.04.01**
+> **Latest release: v3.04.02**
 
 
 ## 🎯 Project Overview
 
-You are contributing to the **StackTrackr v3.04.01**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to the **StackTrackr v3.04.02**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.04.01 (beta)
+**Current Status**: v3.04.02 (beta)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,13 +1,16 @@
 # StackTrackr — Changelog
 
 
-> **Latest release: v3.04.01**
+> **Latest release: v3.04.02**
 
 
 For upcoming work, see [roadmap](roadmap.md).
 
 ## 📋 Version History
 
+
+### Version 3.04.02 – Numista header trimming (2025-08-11)
+- Accepts Numista CSV exports with trailing spaces in headers
 
 ### Version 3.04.01 – Filter reset & Numista sanitization (2025-08-11)
 - Clear search button now resets all active filters including modal selections

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
- > **Latest release: v3.04.01**
+> **Latest release: v3.04.02**
 
 
 | File | Function | Description |
@@ -109,7 +109,7 @@
 | inventory.js | updateImportProgress |  |
 | inventory.js | endImportProgress |  |
 | inventory.js | importCsv | Imports inventory data from CSV file with comprehensive validation; supports override or merge modes |
-| inventory.js | importNumistaCsv | Imports Numista CSV data with override/merge options, defaulting items to collectable |
+| inventory.js | importNumistaCsv | Imports Numista CSV data with header trimming and merge/override options |
 | inventory.js | exportCsv | Exports current inventory to CSV format |
 | inventory.js | importJson | Imports inventory data from JSON file |
 | inventory.js | exportJson | Exports current inventory to JSON format |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,3 +1,20 @@
+# Implementation Summary: Numista Header Trimming
+
+> **Latest release: v3.04.02**
+
+## Version Update: 3.04.01 → 3.04.02
+
+## User Requirements Implemented
+
+- Accept Numista CSV files with trailing spaces in column headers
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`js/inventory.js`**: Trim CSV header names during Numista import to prevent field mismatches
+2. **`js/constants.js`**: Bumped version to 3.04.02
+3. **Documentation**: Updated README, changelog, status, roadmap, structure, and function table
+
 # Implementation Summary: Filter Reset & Numista Sanitization
 
 > **Latest release: v3.04.01**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,6 +2,7 @@
 
 This roadmap outlines upcoming patch releases for the v3.04.x series.
 
+- **v3.04.02** – Numista header trimming *(completed)*
 - **v3.04.01** – Search reset, Numista sanitization, and batch API pulls *(completed)*
 - **v3.04.00** – Inventory filter enhancements and API cleanup *(completed)*
 - **v3.03.07b** – Documentation normalization and reference cleanup *(completed)*

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,11 +1,11 @@
 # Project Status - StackTrackr
 
 
-> **Latest release: v3.04.01**
+> **Latest release: v3.04.02**
 
-## 🎯 Current State: **BETA v3.04.01** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.02** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.04.01** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.04.02** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -25,6 +25,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.04.02 - Numista header trimming**: Imports accept Numista CSVs with trailing spaces in column headers
 - **v3.04.01 - Filter reset & Numista sanitization**: Clear search resets filters, sanitized Numista imports, batch API pulls
 - **v3.04.00 - Inventory filter click & API cleanup**: Clickable table value filters and removed global API cache duration dropdown
 - **v3.03.08n - Inventory type filter**: Added type dropdown and dynamic metal options
@@ -148,8 +149,8 @@ All data is stored locally in the browser using localStorage with:
 ## 📚 Documentation Status (Updated: August 11, 2025)
 
 **All documentation files are current and synchronized:**
-  - ✅ **status.md** - Updated for v3.04.01 release
-  - ✅ **changelog.md** - Current through v3.04.01
+  - ✅ **status.md** - Updated for v3.04.02 release
+  - ✅ **changelog.md** - Current through v3.04.02
 - ✅ **MULTI_AGENT_WORKFLOW.md** - Comprehensive AI assistant development guide
 - ✅ **structure.md** - Reflects streamlined project organization
 - ✅ **versioning.md** - Accurate version management documentation
@@ -158,9 +159,9 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.04.01 (managed in `js/constants.js`)
-2. **Last Change**: Search reset, Numista sanitization, and batch API pulls
-3. **Last Documentation Update**: August 10, 2025 - All docs synchronized
+1. **Current Version**: 3.04.02 (managed in `js/constants.js`)
+2. **Last Change**: Numista header trimming
+3. **Last Documentation Update**: August 11, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns
 5. **Documentation**: Comprehensive JSDoc comments throughout codebase
 6. **Data Structure**: Includes all fields (metal, name, qty, type, weight, price, date, purchaseLocation, storageLocation, **notes**, spotPriceAtPurchase, premiumPerOz, totalPremium, isCollectable)

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.04.01**
+> **Latest release: v3.04.02**
 
 
 The repository is organized as follows:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.04.01**
+> **Latest release: v3.04.02**
 
 ## Overview 
 
@@ -9,7 +9,7 @@ The StackTrackr now uses a dynamic version management system that automatically 
 ## How It Works
 
 ### Single Source of Truth
-- Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.01'`
+- Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.02'`
   - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation
@@ -19,7 +19,7 @@ The StackTrackr now uses a dynamic version management system that automatically 
 
 ### Utility Functions
 - `js/constants.js` provides:
-  - `getVersionString(prefix)`: Returns formatted version (e.g., "v3.04.01")
+  - `getVersionString(prefix)`: Returns formatted version (e.g., "v3.04.02")
   - `injectVersionString(elementId, prefix)`: Inserts formatted version into a target element
 - `js/utils.js` provides:
   - `getAppTitle(baseTitle)`: Returns full app title with version
@@ -31,13 +31,13 @@ To release a new version:
 1. **Update ONLY the constants file:**
    ```javascript
    // In js/constants.js
-     const APP_VERSION = '3.04.01';  // Change this line only
+    const APP_VERSION = '3.04.02';  // Change this line only
    ```
 
 2. **All these will automatically update:**
-  - Page title: "StackTrackr v3.04.01"
-  - Page heading: "StackTrackr v3.04.01"
-  - Browser tab title: "StackTrackr v3.04.01"
+  - Page title: "StackTrackr v3.04.02"
+  - Page heading: "StackTrackr v3.04.02"
+  - Browser tab title: "StackTrackr v3.04.02"
    - App header: "StackTrackr v3.03.07b"
 
 3. **Update changelog:** Add entry to `/docs/changelog.md` for documentation

--- a/js/constants.js
+++ b/js/constants.js
@@ -149,7 +149,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.01";
+const APP_VERSION = "3.04.02";
 
 
 /**

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1151,7 +1151,11 @@ const importNumistaCsv = (file, override = false) => {
         const csvText = e.target.result;
         localStorage.setItem(NUMISTA_RAW_KEY, csvText);
         const storedCsv = localStorage.getItem(NUMISTA_RAW_KEY) || "";
-        const results = Papa.parse(storedCsv, { header: true, skipEmptyLines: true });
+        const results = Papa.parse(storedCsv, {
+          header: true,
+          skipEmptyLines: true,
+          transformHeader: (h) => h.trim(), // Handle Numista headers with trailing spaces
+        });
         const rawTable = results.data;
         const imported = [];
         const totalRows = rawTable.length;


### PR DESCRIPTION
## Summary
- handle trailing spaces in Numista CSV headers during import
- bump version to 3.04.02 and sync documentation

## Testing
- `node <<'NODE'
const fs=require('fs');
const csv=fs.readFileSync('docs/numista.csv','utf8').trim();
const lines=csv.split(/\r?\n/);
const headerWithSpaces=lines[0].split(',').map(h=>h+' ').join(',');
const csvMessy=headerWithSpaces+'\n'+lines.slice(1).join('\n');
function parseCsv(content, transformHeader){
 const lines=content.split(/\r?\n/); let headers=lines[0].split(',');
 if(transformHeader) headers=headers.map(h=>h.trim());
 const rows=lines.slice(1).map(line=>{ const values=line.split(','); const obj={}; headers.forEach((h,i)=>obj[h]=values[i]); return obj; });
 return rows;
}
function getValue(row,keys){ for(const key of keys){ const foundKey=Object.keys(row).find(k=>k.toLowerCase()===key.toLowerCase()); if(foundKey) return row[foundKey]; } return ''; }
const rowsNoTrim=parseCsv(csvMessy,false);
const rowsTrim=parseCsv(csvMessy,true);
console.log('Keys without trim:', Object.keys(rowsNoTrim[0]));
console.log('getValue without trim:', getValue(rowsNoTrim[0], ['Title']));
console.log('Keys with transformHeader:', Object.keys(rowsTrim[0]));
console.log('getValue with trim:', getValue(rowsTrim[0], ['Title']));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6899c3eaf07c832eb369ee7b452a33fe