### PR TITLE
Sanitize imported names for stable search

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,12 +1,14 @@
 # StackTrackr — Changelog
 
-> **Latest release: v3.04.05**
+> **Latest release: v3.04.06**
 
 
 For upcoming work, see [roadmap](roadmap.md).
 
 ## 📋 Version History
 
+### Version 3.04.06 – Name sanitization (2025-08-11)
+- Strip HTML tags and excess whitespace from imported text fields to stabilize table search
 
 ### Version 3.04.05 – Search sanitization (2025-08-11)
 - Escaped table cell values and search input to prevent search corruption

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.05**
+> **Latest release: v3.04.06**
 
 
 | File | Function | Description |
@@ -163,7 +163,7 @@
 | utils.js | loadData | Loads data from localStorage with error handling |
 | utils.js | sortInventoryByDateNewestFirst | Sorts inventory by date (newest first) |
 | utils.js | validateInventoryItem | Validates inventory item data |
-| utils.js | sanitizeImportedItem | Coerces invalid imported fields to safe defaults and strips unsafe characters |
+| utils.js | sanitizeImportedItem | Coerces invalid imported fields to safe defaults and strips HTML, diacritics, and unsafe characters |
 | utils.js | handleError | Handles errors with user-friendly messaging |
 | utils.js | getUserFriendlyMessage | Converts technical error messages to user-friendly ones |
 | utils.js | downloadFile | Downloads a file with the specified content and filename |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,3 +1,21 @@
+# Implementation Summary: Name Sanitization
+
+> **Latest release: v3.04.06**
+
+## Version Update: 3.04.05 → 3.04.06
+
+## User Requirements Implemented
+
+- Strip HTML tags and excess whitespace from imported text fields to stabilize table search
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`js/utils.js`**: Expanded `sanitizeImportedItem` to remove HTML tags, diacritics, and collapse whitespace
+2. **`js/inventory.js`**: Sanitizes loaded inventory records with `sanitizeImportedItem`
+3. **`js/constants.js`**: Bumped version to 3.04.06
+4. **Documentation**: Updated changelog, status, roadmap, structure, function table, and version references
+
 # Implementation Summary: Search Sanitization
 
 > **Latest release: v3.04.05**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,6 +2,7 @@
 
 This roadmap outlines upcoming patch releases for the v3.04.x series.
 
+- **v3.04.06** – Name sanitization *(completed)*
 - **v3.04.05** – Search sanitization *(completed)*
 - **v3.04.04** – Multi-term search *(completed)*
 - **v3.04.03** – Search input restore *(completed)*

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,11 +1,11 @@
 # Project Status - StackTrackr
 
 
-> **Latest release: v3.04.05**
+> **Latest release: v3.04.06**
 
-## 🎯 Current State: **BETA v3.04.05** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.06** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.04.05** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.04.06** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -25,6 +25,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.04.06 - Name sanitization**: Cleaned imported text fields for reliable table searching
 - **v3.04.05 - Search sanitization**: Escaped table values and sanitized search input to prevent corruption
 - **v3.04.04 - Multi-term search**: Search box accepts comma-separated terms to filter multiple values at once
 - **v3.04.03 - Search input restore**: Search box reliably filters inventory table as you type

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.04.05**
+> **Latest release: v3.04.06**
 
 
 The repository is organized as follows:

--- a/js/constants.js
+++ b/js/constants.js
@@ -149,7 +149,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.05";
+const APP_VERSION = "3.04.06";
 
 
 /**

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -451,6 +451,7 @@ const loadInventory = () => {
   const data = loadData(LS_KEY, []);
   // Migrate legacy data to include new fields
   inventory = data.map(item => {
+    let normalized;
     // Handle legacy data that might not have all fields
     if (item.premiumPerOz === undefined) {
       // For legacy items, calculate premium if possible
@@ -460,7 +461,7 @@ const loadInventory = () => {
       const premiumPerOz = spotPrice > 0 ? (item.price / item.weight) - spotPrice : 0;
       const totalPremium = premiumPerOz * item.qty * item.weight;
 
-      return {
+      normalized = {
         ...item,
         type: normalizeType(item.type),
         purchaseLocation: item.purchaseLocation || "",
@@ -472,17 +473,19 @@ const loadInventory = () => {
         isCollectable: item.isCollectable !== undefined ? item.isCollectable : false,
         composition: item.composition || item.metal || ""
       };
+    } else {
+      // Ensure all items have required properties
+      normalized = {
+        ...item,
+        type: normalizeType(item.type),
+        purchaseLocation: item.purchaseLocation || "",
+        storageLocation: item.storageLocation || "Unknown",
+        notes: item.notes || "",
+        isCollectable: item.isCollectable !== undefined ? item.isCollectable : false,
+        composition: item.composition || item.metal || ""
+      };
     }
-    // Ensure all items have required properties
-    return {
-      ...item,
-      type: normalizeType(item.type),
-      purchaseLocation: item.purchaseLocation || "",
-      storageLocation: item.storageLocation || "Unknown",
-      notes: item.notes || "",
-      isCollectable: item.isCollectable !== undefined ? item.isCollectable : false,
-      composition: item.composition || item.metal || ""
-    };
+    return sanitizeImportedItem(normalized);
   });
 
   let serialCounter = parseInt(localStorage.getItem(SERIAL_KEY) || '0', 10);

--- a/js/utils.js
+++ b/js/utils.js
@@ -576,7 +576,11 @@ const sanitizeImportedItem = (item) => {
   const cleanString = (str = '') =>
     str
       .toString()
+      .replace(/<[^>]*>/g, '')
+      .normalize('NFD')
+      .replace(/\p{Diacritic}/gu, '')
       .replace(/[\u0000-\u001F\u007F'\"]/g, '')
+      .replace(/\s+/g, ' ')
       .trim();
   for (const field of strFields) {
     sanitized[field] = cleanString(sanitized[field]);


### PR DESCRIPTION
## Summary
- strip HTML tags, diacritics and extra whitespace from imported text fields
- sanitize existing inventory records on load for consistent searching
- document name sanitization and bump version to 3.04.06

## Testing
- `node -c js/utils.js`
- `node -c js/inventory.js`
- `node -c js/constants.js`


------
https://chatgpt.com/codex/tasks/task_e_689a1527dee0832e93677b4cdf7bc836