### PR TITLE
Replace inventory actions with icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The public hosted version of the app is available at [stackrtrackr.com](https://
 - Collectable checkbox replaced with status button and action buttons aligned in inventory table
 - Totals cards renamed with refined labels and font sizes
 - About modal title contrast improved in light mode
-- Notes button displays "Yes" in green when an item contains notes
+- Notes button uses a notebook icon and highlights green when an item contains notes
 
 ## 🆕 What's New in v3.2.05rc
 - Disclaimer splash hides permanently after you click "I Understand"

--- a/css/styles.css
+++ b/css/styles.css
@@ -1603,21 +1603,6 @@ tr:hover {
   text-decoration: underline;
 }
 
-.edit-icon {
-  background: none;
-  border: none;
-  cursor: pointer;
-  color: var(--text-muted);
-  font-size: 0.8rem;
-  padding: 2px;
-  transition: color var(--transition);
-  flex-shrink: 0;
-}
-
-.edit-icon:hover,
-.edit-icon:focus {
-  color: var(--primary);
-}
 /* Make buttons in table cells smaller */
 td .btn {
   padding: 0.25rem 0.5rem;

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -182,7 +182,7 @@ For upcoming work, see [roadmap](roadmap.md).
 - Collectable checkbox replaced with status button and aligned action buttons
 - Totals cards renamed with refined labels and font sizing
 - Improved About modal title contrast in light mode
-- Notes button displays a green "Yes" when items have saved notes
+- Notes button uses a notebook icon and highlights green when items have saved notes
 
 ### Version 3.2.05rc – Splash Opt-Out (2025-08-09)
 - Disclaimer splash now hides permanently after the acknowledgment button is clicked, removing the previous checkbox

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -210,7 +210,7 @@
 
 ### Files Modified:
 1. **`index.html`**: Reordered type dropdowns and separated totals section
-2. **`css/styles.css`**: Replaced clickable name styles with `.edit-icon`
+2. **`css/styles.css`**: Removed obsolete `.edit-icon` style after moving edit action to dedicated column
 3. **`js/utils.js`**: Added `VALID_TYPES`, `normalizeType`, and updated Numista mapping
 4. **`js/inventory.js`**: Normalized types, blank purchase locations, name edit icon, Numista collectable logic
 5. **`js/events.js`**: Purchase location defaults to blank

--- a/index.html
+++ b/index.html
@@ -426,8 +426,9 @@
               <th class="shrink" data-column="purchaseLocation">Purchase<br />Location</th>
               <th class="shrink" data-column="storageLocation">Storage<br />Location</th>
               <th class="shrink" data-column="collectable">Collectable</th>
-              <th class="shrink" data-column="notes">Notes</th>
-              <th class="shrink" data-column="delete">Delete</th>
+              <th class="shrink" data-column="edit" aria-label="Edit" title="Edit">✎</th>
+              <th class="shrink" data-column="notes" aria-label="Notes" title="Notes">📓</th>
+              <th class="shrink" data-column="delete" aria-label="Delete" title="Delete">🗑️</th>
             </tr>
           </thead>
           <tbody></tbody>

--- a/js/events.js
+++ b/js/events.js
@@ -68,8 +68,8 @@ const setupColumnResizing = () => {
   // Add resize handles to table headers
   const headers = table.querySelectorAll("th");
   headers.forEach((header, index) => {
-    // Skip the last column (delete button)
-    if (index === headers.length - 1) return;
+    // Skip action columns (edit/notes/delete)
+    if (index >= headers.length - 3) return;
 
     const resizeHandle = document.createElement("div");
     resizeHandle.className = "resize-handle";
@@ -340,8 +340,8 @@ const setupEventListeners = () => {
     if (inventoryTable) {
       const headers = inventoryTable.querySelectorAll("th");
       headers.forEach((header, index) => {
-        // Skip Notes/Delete columns (last two)
-        if (index >= headers.length - 2) {
+        // Skip action columns (edit/notes/delete)
+        if (index >= headers.length - 3) {
           return;
         }
 

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -640,7 +640,7 @@ const renderTable = () => {
       <td class="shrink" data-column="date">${filterLink('date', item.date, 'var(--text-primary)', formatDisplayDate(item.date))}</td>
       <td class="shrink" data-column="type">${filterLink('type', item.type, getTypeColor(item.type))}</td>
       <td class="shrink" data-column="composition">${filterLink('composition', getCompositionFirstWords(item.composition || item.metal || 'Silver'), METAL_COLORS[item.metal] || 'var(--primary)')}</td>
-      <td class="expand" data-column="name" style="text-align: left;"><button type="button" class="edit-icon" onclick="editItem(${originalIdx})" aria-label="Edit ${sanitizeHtml(item.name)}" title="Edit ${sanitizeHtml(item.name)}" style="float: left; margin-right: 8px;">✎</button><span class="filter-text" onclick="applyColumnFilter('name', '${sanitizeHtml(item.name).replace(/'/g, "\'")}')"; style="cursor: pointer; color: var(--text-primary);" title="Filter by this name">${sanitizeHtml(item.name)}</span></td>
+      <td class="expand" data-column="name" style="text-align: left;"><span class="filter-text" onclick="applyColumnFilter('name', '${sanitizeHtml(item.name).replace(/'/g, "\'")}')"; style="cursor: pointer; color: var(--text-primary);" title="Filter by this name">${sanitizeHtml(item.name)}</span></td>
       <td class="shrink" data-column="numista">${item.numistaId ? `<a href="https://en.numista.com/catalogue/pieces${item.numistaId}.html" target="_blank" rel="noopener" title="View on Numista">${sanitizeHtml(item.numistaId)}</a>` : ''}</td>
       <td class="shrink" data-column="qty">${filterLink('qty', item.qty, 'var(--text-primary)')}</td>
       <td class="shrink" data-column="weight">${filterLink('weight', item.weight, 'var(--text-primary)', parseFloat(item.weight).toFixed(2))}</td>
@@ -650,8 +650,9 @@ const renderTable = () => {
       <td class="shrink" data-column="purchaseLocation">${item.purchaseLocation ? filterLink('purchaseLocation', item.purchaseLocation, getPurchaseLocationColor(item.purchaseLocation)) : ''}</td>
       <td class="shrink" data-column="storageLocation">${item.storageLocation ? filterLink('storageLocation', item.storageLocation, getStorageLocationColor(item.storageLocation)) : ''}</td>
       <td class="shrink" data-column="collectable"><button type="button" class="btn action-btn collectable-btn ${item.isCollectable ? 'success' : ''}" onclick="toggleCollectable(${originalIdx})" aria-label="Toggle collectable status for ${sanitizeHtml(item.name)}" title="Toggle collectable status">${item.isCollectable ? 'Yes' : 'No'}</button></td>
-      <td class="shrink" data-column="notes"><button type="button" class="btn action-btn notes-btn ${item.notes && item.notes.trim() ? 'success' : ''}" onclick="showNotes(${originalIdx})" aria-label="View notes" title="View notes">${item.notes && item.notes.trim() ? 'Yes' : 'No'}</button></td>
-      <td class="shrink" data-column="delete"><button class="btn action-btn danger" onclick="deleteItem(${originalIdx})" aria-label="Delete item" title="Delete item">Delete</button></td>
+      <td class="shrink" data-column="edit"><button type="button" class="btn action-btn edit-btn" onclick="editItem(${originalIdx})" aria-label="Edit ${sanitizeHtml(item.name)}" title="Edit ${sanitizeHtml(item.name)}">✎</button></td>
+      <td class="shrink" data-column="notes"><button type="button" class="btn action-btn notes-btn ${item.notes && item.notes.trim() ? 'success' : ''}" onclick="showNotes(${originalIdx})" aria-label="View notes" title="View notes">📓</button></td>
+      <td class="shrink" data-column="delete"><button class="btn action-btn danger" onclick="deleteItem(${originalIdx})" aria-label="Delete item" title="Delete item">🗑️</button></td>
       </tr>
       `);
     }


### PR DESCRIPTION
## Summary
- Replace Notes column header and button text with a notebook icon and keep success highlighting
- Swap Delete column header and buttons for recycle bin icons
- Add dedicated Edit column with pencil icon and update sorting/resizing logic

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a1a10103c832e9fb24994be9be922