### PR TITLE
Center inventory headers and streamline action icons

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1517,7 +1517,7 @@ th {
   color: var(--text-primary);
   font-weight: 600;
   padding: 0.375rem 0.25rem; /* Reduced padding for narrower rows */
-  text-align: left;
+  text-align: center;
   cursor: pointer;
   position: relative;
   border-bottom: 2px solid var(--border);
@@ -1617,6 +1617,22 @@ td .action-btn {
   margin: 1px auto;
   display: flex;
   justify-content: center;
+}
+
+td .action-icon {
+  width: 4.5rem;
+  margin: 1px auto;
+  display: flex;
+  justify-content: center;
+  cursor: pointer;
+}
+
+td .action-icon.danger {
+  color: var(--danger);
+}
+
+td .action-icon.success {
+  color: var(--success);
 }
 
 td .filter-text {
@@ -2831,6 +2847,9 @@ input:disabled + .slider {
     min-height: 1.5rem;
   }
   td .action-btn {
+    width: 4rem;
+  }
+  td .action-icon {
     width: 4rem;
   }
 

--- a/js/events.js
+++ b/js/events.js
@@ -384,11 +384,12 @@ const setupEventListeners = () => {
           const type = elements.itemType.value;
           let weight = parseFloat(elements.itemWeight.value);
           weight = isNaN(weight) ? 0 : parseFloat(weight.toFixed(2));
-          const price = parseFloat(elements.itemPrice.value);
+          let price = parseFloat(elements.itemPrice.value);
+          price = isNaN(price) || price < 0 ? 0 : price;
           const purchaseLocation =
             elements.purchaseLocation.value.trim() || "";
           const storageLocation =
-            elements.storageLocation.value.trim() || "";
+            elements.storageLocation.value.trim() || "Unknown";
           const notes = elements.itemNotes.value.trim() || "";
           const date = elements.itemDate.value || todayStr();
           const spotPriceInput = elements.itemSpotPrice.value.trim();
@@ -399,9 +400,7 @@ const setupEventListeners = () => {
             qty < 1 ||
             !Number.isInteger(qty) ||
             isNaN(weight) ||
-            weight <= 0 ||
-            isNaN(price) ||
-            price < 0
+            weight <= 0
           ) {
             return alert("Please enter valid values for all fields.");
           }
@@ -478,11 +477,12 @@ const setupEventListeners = () => {
           const type = elements.editType.value;
           let weight = parseFloat(elements.editWeight.value);
           weight = isNaN(weight) ? 0 : parseFloat(weight.toFixed(2));
-          const price = parseFloat(elements.editPrice.value);
+          let price = parseFloat(elements.editPrice.value);
+          price = isNaN(price) || price < 0 ? 0 : price;
           const purchaseLocation =
             elements.editPurchaseLocation.value.trim() || "";
           const storageLocation =
-            elements.editStorageLocation.value.trim() || "";
+            elements.editStorageLocation.value.trim() || "Unknown";
           const notes = elements.editNotes.value.trim() || "";
           const date = elements.editDate.value;
 
@@ -508,8 +508,6 @@ const setupEventListeners = () => {
             !Number.isInteger(qty) ||
             isNaN(weight) ||
             weight <= 0 ||
-            isNaN(price) ||
-            price < 0 ||
             (!isCollectable &&
               (isNaN(spotPriceAtPurchase) || spotPriceAtPurchase <= 0))
           ) {

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -644,15 +644,15 @@ const renderTable = () => {
       <td class="shrink" data-column="numista">${item.numistaId ? `<a href="https://en.numista.com/catalogue/pieces${item.numistaId}.html" target="_blank" rel="noopener" title="View on Numista">${sanitizeHtml(item.numistaId)}</a>` : ''}</td>
       <td class="shrink" data-column="qty">${filterLink('qty', item.qty, 'var(--text-primary)')}</td>
       <td class="shrink" data-column="weight">${filterLink('weight', item.weight, 'var(--text-primary)', parseFloat(item.weight).toFixed(2))}</td>
-      <td class="shrink" data-column="purchasePrice">${filterLink('price', item.price, 'var(--text-primary)', formatDollar(item.price))}</td>
+      <td class="shrink" data-column="purchasePrice">${item.price > 0 ? filterLink('price', item.price, 'var(--text-primary)', formatDollar(item.price)) : ''}</td>
       <td class="shrink" data-column="spot">${filterLink('spotPriceAtPurchase', spotValue, 'var(--text-primary)', spotDisplay)}</td>
       <td class="shrink" data-column="premium" style="color: ${item.isCollectable ? 'var(--text-muted)' : (item.totalPremium > 0 ? 'var(--warning)' : 'inherit')}">${filterLink('totalPremium', premiumValue, 'var(--text-primary)', premiumDisplay)}</td>
       <td class="shrink" data-column="purchaseLocation">${item.purchaseLocation ? filterLink('purchaseLocation', item.purchaseLocation, getPurchaseLocationColor(item.purchaseLocation)) : ''}</td>
-      <td class="shrink" data-column="storageLocation">${item.storageLocation ? filterLink('storageLocation', item.storageLocation, getStorageLocationColor(item.storageLocation)) : ''}</td>
+      <td class="shrink" data-column="storageLocation">${item.storageLocation && item.storageLocation !== 'Unknown' ? filterLink('storageLocation', item.storageLocation, getStorageLocationColor(item.storageLocation)) : ''}</td>
       <td class="shrink" data-column="collectable"><button type="button" class="btn action-btn collectable-btn ${item.isCollectable ? 'success' : ''}" onclick="toggleCollectable(${originalIdx})" aria-label="Toggle collectable status for ${sanitizeHtml(item.name)}" title="Toggle collectable status">${item.isCollectable ? 'Yes' : 'No'}</button></td>
-      <td class="shrink" data-column="edit"><button type="button" class="btn action-btn edit-btn" onclick="editItem(${originalIdx})" aria-label="Edit ${sanitizeHtml(item.name)}" title="Edit ${sanitizeHtml(item.name)}">✎</button></td>
-      <td class="shrink" data-column="notes"><button type="button" class="btn action-btn notes-btn ${item.notes && item.notes.trim() ? 'success' : ''}" onclick="showNotes(${originalIdx})" aria-label="View notes" title="View notes">📓</button></td>
-      <td class="shrink" data-column="delete"><button class="btn action-btn danger" onclick="deleteItem(${originalIdx})" aria-label="Delete item" title="Delete item">🗑️</button></td>
+      <td class="shrink" data-column="edit"><span class="action-icon" role="button" tabindex="0" onclick="editItem(${originalIdx})" aria-label="Edit ${sanitizeHtml(item.name)}" title="Edit ${sanitizeHtml(item.name)}">✎</span></td>
+      <td class="shrink" data-column="notes"><span class="action-icon ${item.notes && item.notes.trim() ? 'success' : ''}" role="button" tabindex="0" onclick="showNotes(${originalIdx})" aria-label="View notes" title="View notes">📓</span></td>
+      <td class="shrink" data-column="delete"><span class="action-icon danger" role="button" tabindex="0" onclick="deleteItem(${originalIdx})" aria-label="Delete item" title="Delete item">🗑️</span></td>
       </tr>
       `);
     }
@@ -924,9 +924,9 @@ const editItem = (idx, logIdx = null) => {
   elements.editQty.value = item.qty;
   elements.editType.value = item.type;
   elements.editWeight.value = parseFloat(item.weight).toFixed(2);
-  elements.editPrice.value = item.price;
+  elements.editPrice.value = item.price > 0 ? item.price : '';
   elements.editPurchaseLocation.value = item.purchaseLocation;
-  elements.editStorageLocation.value = item.storageLocation || '';
+  elements.editStorageLocation.value = item.storageLocation && item.storageLocation !== 'Unknown' ? item.storageLocation : '';
   
   // Add fallback for notes field
   const notesField = elements.editNotes || document.getElementById('editNotes');


### PR DESCRIPTION
## Summary
- Center all inventory table headers and add reusable `action-icon` styles
- Replace edit, notes, and delete buttons with centered icon actions and hide unknown values
- Default missing or negative purchase prices to 0 and store blank storage locations as "Unknown"

## Testing
- `node --check js/inventory.js`
- `node --check js/events.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a1bfcbb80832ebf369a4f0aad1802