### PR TITLE
feat: show active filter chips and hide numista column

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1551,6 +1551,11 @@ td {
   display: none;
 }
 
+#inventoryTable th[data-column="numista"],
+#inventoryTable td[data-column="numista"] {
+  display: none;
+}
+
 tr:nth-child(even) {
   background: var(--bg-secondary);
 }
@@ -2340,14 +2345,45 @@ td input:checked + .slider:before {
   background: var(--secondary-hover);
 }
 
+.filter-info {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: var(--spacing-sm);
+  flex-wrap: wrap;
+  gap: var(--spacing-sm);
+}
+
+.active-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--spacing-xs);
+}
+
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--spacing-xs);
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius);
+  font-size: 0.75rem;
+  cursor: pointer;
+}
+
+.filter-chip:hover {
+  opacity: 0.85;
+}
+
 .search-results-info {
   font-size: 0.875rem;
   color: var(--text-muted);
   text-align: right;
+  margin-left: auto;
 }
 
 .search-results-info:not(:empty) {
-  margin-top: var(--spacing-sm);
+  margin-top: 0;
 }
 
 /* =============================================================================

--- a/index.html
+++ b/index.html
@@ -394,7 +394,10 @@
             <button class="btn" id="clearSearchBtn">Clear</button>
             <button class="btn success" id="newItemBtn">New Item</button>
           </div>
-          <div class="search-results-info" id="searchResultsInfo"></div>
+          <div class="filter-info">
+            <div class="active-filters" id="activeFilters"></div>
+            <div class="search-results-info" id="searchResultsInfo"></div>
+          </div>
         </section>
         <!-- =============================================================================
            INVENTORY TABLE SECTION

--- a/js/filters.js
+++ b/js/filters.js
@@ -148,6 +148,7 @@ const applyFilters = () => {
 
   // Update filters button to show active state
   updateFiltersButtonState();
+  renderActiveFilters();
 };
 
 /**
@@ -165,6 +166,7 @@ const clearAllFilters = () => {
   renderTable();
   populateFilterDropdowns();
   updateFiltersButtonState();
+  renderActiveFilters();
 };
 
 /**
@@ -183,6 +185,65 @@ const updateFiltersButtonState = () => {
     filtersBtn.textContent = 'Filters';
     filtersBtn.classList.remove('active');
   }
+};
+
+/**
+ * Renders active filter chips beneath the search bar
+ */
+const renderActiveFilters = () => {
+  const container = document.getElementById('activeFilters');
+  if (!container) return;
+
+  container.innerHTML = '';
+
+  const filters = [];
+  Object.entries(activeFilters).forEach(([field, value]) => {
+    filters.push({ field, value });
+  });
+  Object.entries(columnFilters).forEach(([field, value]) => {
+    if (!activeFilters[field]) filters.push({ field, value });
+  });
+  if (searchQuery) {
+    filters.push({ field: 'search', value: searchQuery });
+  }
+
+  const colors = ['var(--primary)', 'var(--secondary)', 'var(--success)', 'var(--warning)', 'var(--danger)', 'var(--info)'];
+  const labels = {
+    composition: 'Metal',
+    type: 'Type',
+    purchaseLocation: 'Purchase Location',
+    storageLocation: 'Storage Location',
+    collectable: 'Collectable',
+    dateFrom: 'From',
+    dateTo: 'To',
+    search: 'Search'
+  };
+
+  filters.forEach((f, i) => {
+    const chip = document.createElement('span');
+    chip.className = 'filter-chip';
+    chip.style.backgroundColor = colors[i % colors.length];
+    const label = f.field === 'search'
+      ? `${f.value}`
+      : `${labels[f.field] || f.field}: ${f.value}`;
+    chip.innerHTML = `${label} &times;`;
+    chip.title = 'Click to remove filter';
+    chip.onclick = () => {
+      if (f.field === 'search') {
+        searchQuery = '';
+        const input = document.getElementById('searchInput');
+        if (input) input.value = '';
+      } else {
+        delete activeFilters[f.field];
+        delete columnFilters[f.field];
+      }
+      currentPage = 1;
+      renderTable();
+      updateFiltersButtonState();
+      renderActiveFilters();
+    };
+    container.appendChild(chip);
+  });
 };
 
 /**
@@ -311,6 +372,7 @@ const applyQuickFilter = (field, value) => {
   currentPage = 1;
   renderTable();
   updateFiltersButtonState();
+  renderActiveFilters();
 };
 
 /**
@@ -331,5 +393,6 @@ window.applyQuickFilter = applyQuickFilter;
 window.applyColumnFilter = applyColumnFilter;
 window.filterInventoryAdvanced = filterInventoryAdvanced;
 window.updateFiltersButtonState = updateFiltersButtonState;
+window.renderActiveFilters = renderActiveFilters;
 
 // =============================================================================

--- a/js/search.js
+++ b/js/search.js
@@ -70,7 +70,13 @@ document.addEventListener('DOMContentLoaded', () => {
       searchQuery = e.target.value.replace(/[<>]/g, '').trim();
       currentPage = 1;
       renderTable();
+      if (typeof renderActiveFilters === 'function') {
+        renderActiveFilters();
+      }
     }, 300));
+  }
+  if (typeof renderActiveFilters === 'function') {
+    renderActiveFilters();
   }
 });
 


### PR DESCRIPTION
## Summary
- display applied filters as removable color-coded chips beneath the search bar
- refresh chips when filters, search, or quick filters change
- hide Numista (N#) column from inventory table

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a23ac8274832e83b374fe507cc0d7