### PR TITLE
Handle missing numeric fields in search filters

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -290,7 +290,13 @@ const filterInventoryAdvanced = () => {
           if (value === 'N/A') {
             return itemVal === undefined || itemVal === null || itemVal === '' || itemVal === 0;
           }
-          return itemVal != null && itemVal.toString() === value.toString();
+          if (itemVal == null) return false;
+          const itemNum = Number(itemVal);
+          const valueNum = Number(value);
+          if (Number.isFinite(itemNum) && Number.isFinite(valueNum)) {
+            return itemNum === valueNum;
+          }
+          return String(itemVal) === String(value ?? '');
         });
         break;
     }
@@ -301,7 +307,8 @@ const filterInventoryAdvanced = () => {
     if (!activeFilters[field]) { // Don't double-filter
       const lower = value.toLowerCase();
       result = result.filter(item => {
-        const fieldVal = (item[field] || (field === 'composition' ? item.metal : '')).toString().toLowerCase();
+        const rawVal = item[field] ?? (field === 'composition' ? item.metal : '');
+        const fieldVal = String(rawVal ?? '').toLowerCase();
         return fieldVal === lower;
       });
     }
@@ -336,9 +343,9 @@ const filterInventoryAdvanced = () => {
       (item.notes && item.notes.toLowerCase().includes(q)) ||
       item.date.includes(q) ||
       formattedDate.includes(q) ||
-      item.qty.toString().includes(q) ||
-      item.weight.toString().includes(q) ||
-      item.price.toString().includes(q) ||
+      String(Number.isFinite(Number(item.qty)) ? Number(item.qty) : '').includes(q) ||
+      String(Number.isFinite(Number(item.weight)) ? Number(item.weight) : '').includes(q) ||
+      String(Number.isFinite(Number(item.price)) ? Number(item.price) : '').includes(q) ||
       (item.isCollectable ? 'yes' : 'no').includes(q)
     ));
   });

--- a/js/search.js
+++ b/js/search.js
@@ -18,7 +18,8 @@ const filterInventory = () => {
   Object.entries(columnFilters).forEach(([field, value]) => {
     const lower = value.toLowerCase();
     result = result.filter((item) => {
-      const fieldVal = (item[field] || (field === 'composition' ? item.metal : '')).toString().toLowerCase();
+      const rawVal = item[field] ?? (field === 'composition' ? item.metal : '');
+      const fieldVal = String(rawVal ?? '').toLowerCase();
       return fieldVal === lower;
     });
   });
@@ -52,9 +53,9 @@ const filterInventory = () => {
       (item.notes && item.notes.toLowerCase().includes(q)) ||
       item.date.includes(q) ||
       formattedDate.includes(q) ||
-      item.qty.toString().includes(q) ||
-      item.weight.toString().includes(q) ||
-      item.price.toString().includes(q) ||
+      String(Number.isFinite(Number(item.qty)) ? Number(item.qty) : '').includes(q) ||
+      String(Number.isFinite(Number(item.weight)) ? Number(item.weight) : '').includes(q) ||
+      String(Number.isFinite(Number(item.price)) ? Number(item.price) : '').includes(q) ||
       (item.isCollectable ? 'yes' : 'no').includes(q)
     ));
   });

--- a/tests/search-numista.test.js
+++ b/tests/search-numista.test.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+// Stub minimal browser environment
+global.inventory = [];
+global.columnFilters = {};
+global.searchQuery = '';
+global.formatDisplayDate = d => d;
+global.debounce = fn => fn;
+global.renderTable = () => {};
+global.renderActiveFilters = () => {};
+global.currentPage = 1;
+global.document = { addEventListener: () => {} };
+global.window = global;
+
+// Load search functionality
+vm.runInThisContext(fs.readFileSync('js/search.js', 'utf8'));
+
+// Test handling of missing and invalid numeric fields
+inventory = [
+  { metal: 'Gold', name: 'Valid', type: 'Coin', purchaseLocation: 'Shop', qty: 1, weight: 1, price: 100, date: '2020-01-01', isCollectable: false },
+  { metal: 'Silver', name: 'Missing', type: 'Coin', purchaseLocation: 'Shop', date: '2020-07-02', isCollectable: false },
+  { metal: 'Silver', name: 'Invalid', type: 'Coin', purchaseLocation: 'Shop', qty: 'abc', weight: NaN, price: undefined, date: '2020-07-03', isCollectable: false }
+];
+
+searchQuery = '100';
+assert.strictEqual(filterInventory().length, 1, 'search for numeric value should work with missing/invalid numbers');
+
+// Load Numista CSV and verify search
+const csvLines = fs.readFileSync('docs/numista.csv', 'utf8').trim().split(/\r?\n/).slice(1);
+inventory = csvLines.map(line => {
+  const parts = line.split(',');
+  return {
+    metal: (parts[3] || '').split(' ')[0],
+    name: parts[1] || '',
+    type: parts[4] || '',
+    weight: parseFloat(parts[5]),
+    qty: parseFloat(parts[6]),
+    price: parseFloat(parts[7]),
+    date: parts[8] || '',
+    purchaseLocation: parts[9] || '',
+    storageLocation: parts[10] || '',
+    isCollectable: false,
+  };
+});
+
+searchQuery = 'Silver';
+assert(filterInventory().length > 0, 'search should find items after importing numista.csv');
+
+console.log('All search tests passed');
+


### PR DESCRIPTION
## Summary
- replace unsafe numeric `toString()` calls in search and filter logic with resilient `String(Number(...))` conversions
- ensure filters compare numeric values robustly
- add regression test covering missing/invalid numeric fields and Numista import

## Testing
- `node tests/search-numista.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a261eb060832ebf7cde865b7845d6