### PR TITLE
feat: highlight "N/A" values

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1645,6 +1645,11 @@ td .filter-text {
   font-weight: 600;
 }
 
+.na-value {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
 td .inline-edit-icon,
 td .save-inline,
 td .cancel-inline {

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -593,7 +593,10 @@ const filterLink = (field, value, color, displayValue = value, title) => {
   const safe = sanitizeHtml(displayStr);
   const titleStr = title ? String(title) : `Filter by ${displayStr}`;
   const safeTitle = sanitizeHtml(titleStr);
-  return `<span class="filter-text" style="color: ${color};" onclick="${escaped}" tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' ')${escaped}" title="${safeTitle}">${safe}</span>`;
+  const isNA = displayStr === 'N/A';
+  const classNames = `filter-text${isNA ? ' na-value' : ''}`;
+  const styleAttr = isNA ? '' : ` style="color: ${color};"`;
+  return `<span class="${classNames}"${styleAttr} onclick="${escaped}" tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' ')${escaped}" title="${safeTitle}">${safe}</span>`;
 };
 
 const getTypeColor = type => getColor(typeColors, type);


### PR DESCRIPTION
## Summary
- style N/A text with new gray italic `.na-value` class
- tag inventory table filter links with `.na-value` when displaying N/A

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node tests/search-numista.test.js`
- `node tests/totals-numista.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a3884cd50832ea18eaf12179ebffe