### PR TITLE
feat: add default currency and formatter

### DIFF
--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -152,7 +152,7 @@
 | utils.js | currentMonthKey | Returns current month key in YYYY-MM format |
 | utils.js | parseDate | Parses various date formats into standard YYYY-MM-DD format |
 | utils.js | formatDisplayDate | Formats a date string into two-digit year ISO format (YY-MM-DD) |
-| utils.js | formatDollar | Formats a number as a dollar amount with two decimal places |
+| utils.js | formatCurrency | Formats a number as a currency string using the default currency |
 | utils.js | formatLossProfit | Formats a profit/loss value with color coding |
 | utils.js | sanitizeHtml | Sanitizes text input for safe HTML display |
 | utils.js | gramsToOzt | Converts grams to troy ounces (ozt) |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -353,7 +353,7 @@
 ## Technical Changes Made
 
 ### Files Modified:
-1. **`js/utils.js`**: Added `sanitizeImportedItem` helper and improved `formatDollar`
+1. **`js/utils.js`**: Added `sanitizeImportedItem` helper and improved currency formatting
 2. **`js/inventory.js`**: CSV and Numista importers sanitize fields and support merge/override
 3. **`js/constants.js`**: Bumped version to 3.03.08f
 4. **Documentation**: Updated changelog, function table, implementation summary, status, roadmap, structure, and README

--- a/js/api.js
+++ b/js/api.js
@@ -337,7 +337,7 @@ const updateProviderHistoryTables = () => {
         (e) => e.provider === providerName && e.metal === metal,
       );
       const last = entries.length
-        ? formatDollar(entries[entries.length - 1].spot)
+        ? formatCurrency(entries[entries.length - 1].spot)
         : "-";
       const key = metal.toLowerCase();
       const checked = selections[key] !== false ? "checked" : "";
@@ -459,7 +459,7 @@ const renderApiHistoryTable = () => {
   let html =
     "<tr><th data-column=\"timestamp\">Time</th><th data-column=\"metal\">Metal</th><th data-column=\"spot\">Price</th><th data-column=\"provider\">API</th></tr>";
   data.forEach((e) => {
-    html += `<tr><td>${e.timestamp}</td><td>${e.metal}</td><td>${formatDollar(
+    html += `<tr><td>${e.timestamp}</td><td>${e.metal}</td><td>${formatCurrency(
       e.spot,
     )}</td><td>${e.provider || ""}</td></tr>`;
   });
@@ -693,7 +693,7 @@ const refreshFromCache = () => {
       spotPrices[metal] = price;
 
       // Update display
-      elements.spotPriceDisplay[metal].textContent = formatDollar(price);
+      elements.spotPriceDisplay[metal].textContent = formatCurrency(price);
 
       // Record in history as 'cached' to distinguish from fresh API calls
       recordSpot(
@@ -1126,7 +1126,7 @@ const syncSpotPricesFromApi = async (
         spotPrices[metal] = price;
 
         // Update display
-        elements.spotPriceDisplay[metal].textContent = formatDollar(price);
+        elements.spotPriceDisplay[metal].textContent = formatCurrency(price);
 
         // Record in history
         recordSpot(
@@ -1287,7 +1287,7 @@ const handleProviderSync = async (provider) => {
       if (metalConfig && price > 0) {
         localStorage.setItem(metalConfig.spotKey, price.toString());
         spotPrices[metal] = price;
-        elements.spotPriceDisplay[metal].textContent = formatDollar(price);
+        elements.spotPriceDisplay[metal].textContent = formatCurrency(price);
         recordSpot(
           price,
           "api",
@@ -1569,7 +1569,7 @@ const resetSpotPrice = (metal) => {
 
   // Update display
   elements.spotPriceDisplay[metalConfig.key].textContent =
-    formatDollar(resetPrice);
+    formatCurrency(resetPrice);
 
   // Record in history
   recordSpot(resetPrice, source, metalConfig.name, providerName);
@@ -1649,10 +1649,10 @@ const downloadCompleteBackup = async () => {
         item.qty,
         item.type,
         parseFloat(item.weight).toFixed(4),
-        formatDollar(item.price),
-        item.isCollectable ? "N/A" : formatDollar(item.spotPriceAtPurchase),
-        item.isCollectable ? "N/A" : formatDollar(item.premiumPerOz),
-        item.isCollectable ? "N/A" : formatDollar(item.totalPremium),
+        formatCurrency(item.price),
+        item.isCollectable ? "N/A" : formatCurrency(item.spotPriceAtPurchase),
+        item.isCollectable ? "N/A" : formatCurrency(item.premiumPerOz),
+        item.isCollectable ? "N/A" : formatCurrency(item.totalPremium),
         item.purchaseLocation,
         item.storageLocation || "Unknown",
         item.notes || "",

--- a/js/charts.js
+++ b/js/charts.js
@@ -103,7 +103,7 @@ const createPieChart = (canvas, data, title) => {
                   const percentage = ((value / total) * 100).toFixed(1);
 
                   return {
-                    text: `${label} (${formatDollar(value)} - ${percentage}%)`,
+                    text: `${label} (${formatCurrency(value)} - ${percentage}%)`,
                     fillStyle: data.datasets[0].backgroundColor[i],
                     strokeStyle: data.datasets[0].borderColor[i],
                     lineWidth: data.datasets[0].borderWidth,
@@ -135,7 +135,7 @@ const createPieChart = (canvas, data, title) => {
               const weight = breakdownItem ? breakdownItem.weight.toFixed(2) : '0.00';
 
               return [
-                `${label}: ${formatDollar(value)} (${percentage}%)`,
+                `${label}: ${formatCurrency(value)} (${percentage}%)`,
                 `Items: ${count}`,
                 `Weight: ${weight} oz`
               ];

--- a/js/constants.js
+++ b/js/constants.js
@@ -151,6 +151,11 @@ const API_PROVIDERS = {
 
 const APP_VERSION = "3.04.08";
 
+/**
+ * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting
+ */
+const DEFAULT_CURRENCY = "USD";
+
 
 /**
  * Returns formatted version string
@@ -354,6 +359,7 @@ if (typeof window !== "undefined") {
   window.API_PROVIDERS = API_PROVIDERS;
   window.METALS = METALS;
   window.DEBUG = DEBUG;
+  window.DEFAULT_CURRENCY = DEFAULT_CURRENCY;
   window.BRANDING_DOMAIN_OPTIONS = BRANDING_DOMAIN_OPTIONS;
   window.BRANDING_DOMAIN_OVERRIDE = BRANDING_DOMAIN_OVERRIDE;
 }

--- a/js/detailsModal.js
+++ b/js/detailsModal.js
@@ -93,7 +93,7 @@ const createBreakdownElements = (breakdown) => {
 
     const value = document.createElement('div');
     value.className = 'breakdown-value';
-    value.textContent = formatDollar(data.value);
+    value.textContent = formatCurrency(data.value);
 
     values.appendChild(count);
     values.appendChild(weight);

--- a/js/events.js
+++ b/js/events.js
@@ -815,7 +815,7 @@ const setupEventListeners = () => {
               spotPrices[metalKey] = defaultPrice;
               if (elements.spotPriceDisplay[metalKey]) {
                 elements.spotPriceDisplay[metalKey].textContent =
-                  formatDollar(defaultPrice);
+                  formatCurrency(defaultPrice);
               }
               updateSummary();
             }

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -99,10 +99,10 @@ const createBackupZip = async () => {
         item.qty,
         item.type,
         parseFloat(item.weight).toFixed(4),
-        formatDollar(item.price),
-        exportSpotPrice > 0 ? formatDollar(exportSpotPrice) : 'N/A',
-        item.isCollectable ? 'N/A' : formatDollar(item.premiumPerOz),
-        item.isCollectable ? 'N/A' : formatDollar(item.totalPremium),
+        formatCurrency(item.price),
+        exportSpotPrice > 0 ? formatCurrency(exportSpotPrice) : 'N/A',
+        item.isCollectable ? 'N/A' : formatCurrency(item.premiumPerOz),
+        item.isCollectable ? 'N/A' : formatCurrency(item.totalPremium),
         item.purchaseLocation,
         item.storageLocation || '',
         item.notes || '',
@@ -314,7 +314,7 @@ const generateBackupHtml = (sortedInventory, timeFormatted) => {
           <td>${item.qty}</td>
           <td>${item.type}</td>
           <td>${parseFloat(item.weight).toFixed(2)}</td>
-          <td>${formatDollar(item.price)}</td>
+          <td>${formatCurrency(item.price)}</td>
           <td>${item.purchaseLocation}</td>
           <td>${item.storageLocation || ''}</td>
           <td>${item.notes || ''}</td>
@@ -754,9 +754,9 @@ const renderTable = () => {
     for (let i = startIndex; i < endIndex; i++) {
       const item = sortedInventory[i];
       const originalIdx = inventory.indexOf(item);
-      const spotDisplay = item.isCollectable ? 'N/A' : (item.spotPriceAtPurchase > 0 ? formatDollar(item.spotPriceAtPurchase) : 'N/A');
+      const spotDisplay = item.isCollectable ? 'N/A' : (item.spotPriceAtPurchase > 0 ? formatCurrency(item.spotPriceAtPurchase) : 'N/A');
       const spotValue = item.isCollectable ? 'N/A' : (item.spotPriceAtPurchase > 0 ? item.spotPriceAtPurchase : 'N/A');
-      const premiumDisplay = item.isCollectable ? 'N/A' : formatDollar(item.totalPremium);
+      const premiumDisplay = item.isCollectable ? 'N/A' : formatCurrency(item.totalPremium);
       const premiumValue = item.isCollectable ? 'N/A' : item.totalPremium;
 
       rows.push(`
@@ -779,7 +779,7 @@ const renderTable = () => {
       </td>
       <td class="shrink" data-column="purchasePrice" title="USD">
         <span class="inline-edit-icon" role="button" tabindex="0" onclick="startCellEdit(${originalIdx}, 'price', this)" aria-label="Edit purchase price" title="Edit purchase price">✎</span>
-        ${item.price > 0 ? filterLink('price', item.price, 'var(--text-primary)', formatDollar(item.price)) : ''}
+        ${item.price > 0 ? filterLink('price', item.price, 'var(--text-primary)', formatCurrency(item.price)) : ''}
       </td>
       <td class="shrink" data-column="spot" title="USD">
         <span class="inline-edit-icon" role="button" tabindex="0" onclick="startCellEdit(${originalIdx}, 'spotPriceAtPurchase', this)" aria-label="Edit spot price" title="Edit spot price">✎</span>
@@ -939,15 +939,15 @@ const updateSummary = () => {
 
     elements.totals[metalKey].items.textContent = totals.totalItems;
     elements.totals[metalKey].weight.textContent = totals.totalWeight.toFixed(2);
-    elements.totals[metalKey].value.innerHTML = formatDollar(totals.currentSpotValue || 0);
-    elements.totals[metalKey].purchased.innerHTML = formatDollar(totals.totalPurchased || 0);
-    elements.totals[metalKey].premium.innerHTML = formatDollar(totals.totalPremium || 0);
+    elements.totals[metalKey].value.innerHTML = formatCurrency(totals.currentSpotValue || 0);
+    elements.totals[metalKey].purchased.innerHTML = formatCurrency(totals.totalPurchased || 0);
+    elements.totals[metalKey].premium.innerHTML = formatCurrency(totals.totalPremium || 0);
     elements.totals[metalKey].lossProfit.innerHTML = formatLossProfit(totals.lossProfit || 0);
-    elements.totals[metalKey].avgPrice.innerHTML = formatDollar(totals.avgPrice || 0);
-    elements.totals[metalKey].avgPremium.innerHTML = formatDollar(totals.avgPremium || 0);
+    elements.totals[metalKey].avgPrice.innerHTML = formatCurrency(totals.avgPrice || 0);
+    elements.totals[metalKey].avgPremium.innerHTML = formatCurrency(totals.avgPremium || 0);
     // Add the new collectable/non-collectable averages
-    elements.totals[metalKey].avgCollectablePrice.innerHTML = formatDollar(totals.avgCollectablePrice || 0);
-    elements.totals[metalKey].avgNonCollectablePrice.innerHTML = formatDollar(totals.avgNonCollectablePrice || 0);
+    elements.totals[metalKey].avgCollectablePrice.innerHTML = formatCurrency(totals.avgCollectablePrice || 0);
+    elements.totals[metalKey].avgNonCollectablePrice.innerHTML = formatCurrency(totals.avgNonCollectablePrice || 0);
   });
 
   // Calculate combined totals for all metals
@@ -987,14 +987,14 @@ const updateSummary = () => {
   if (elements.totals.all.items.textContent !== undefined) {
     elements.totals.all.items.textContent = allTotals.totalItems;
     elements.totals.all.weight.textContent = allTotals.totalWeight.toFixed(2);
-    elements.totals.all.value.innerHTML = formatDollar(allTotals.currentSpotValue || 0);
-    elements.totals.all.purchased.innerHTML = formatDollar(allTotals.totalPurchased || 0);
-    elements.totals.all.premium.innerHTML = formatDollar(allTotals.totalPremium || 0);
+    elements.totals.all.value.innerHTML = formatCurrency(allTotals.currentSpotValue || 0);
+    elements.totals.all.purchased.innerHTML = formatCurrency(allTotals.totalPurchased || 0);
+    elements.totals.all.premium.innerHTML = formatCurrency(allTotals.totalPremium || 0);
     elements.totals.all.lossProfit.innerHTML = formatLossProfit(allTotals.lossProfit || 0);
-    elements.totals.all.avgPrice.innerHTML = formatDollar(allTotals.totalPurchased / allTotals.totalWeight || 0);
-    elements.totals.all.avgPremium.innerHTML = formatDollar(allTotals.totalPremium / allTotals.totalWeight || 0);
-    elements.totals.all.avgCollectablePrice.innerHTML = formatDollar(avgCollectablePriceAll || 0);
-    elements.totals.all.avgNonCollectablePrice.innerHTML = formatDollar(avgNonCollectablePriceAll || 0);
+    elements.totals.all.avgPrice.innerHTML = formatCurrency(allTotals.totalPurchased / allTotals.totalWeight || 0);
+    elements.totals.all.avgPremium.innerHTML = formatCurrency(allTotals.totalPremium / allTotals.totalWeight || 0);
+    elements.totals.all.avgCollectablePrice.innerHTML = formatCurrency(avgCollectablePriceAll || 0);
+    elements.totals.all.avgNonCollectablePrice.innerHTML = formatCurrency(avgNonCollectablePriceAll || 0);
   }
 };
 
@@ -1458,10 +1458,10 @@ const exportCsv = () => {
       i.qty,
       i.type,
       parseFloat(i.weight).toFixed(4),
-      formatDollar(i.price),
-      exportSpotPrice > 0 ? formatDollar(exportSpotPrice) : 'N/A',
-      i.isCollectable ? 'N/A' : formatDollar(i.premiumPerOz),
-      i.isCollectable ? 'N/A' : formatDollar(i.totalPremium),
+      formatCurrency(i.price),
+      exportSpotPrice > 0 ? formatCurrency(exportSpotPrice) : 'N/A',
+      i.isCollectable ? 'N/A' : formatCurrency(i.premiumPerOz),
+      i.isCollectable ? 'N/A' : formatCurrency(i.totalPremium),
       i.purchaseLocation,
       i.storageLocation || '',
       i.notes || '',
@@ -1846,10 +1846,10 @@ const exportPdf = () => {
     item.qty,
     item.type,
     parseFloat(item.weight).toFixed(2),
-    formatDollar(item.price),
-    item.isCollectable ? 'N/A' : formatDollar(item.spotPriceAtPurchase),
-    item.isCollectable ? 'N/A' : formatDollar(item.premiumPerOz),
-    item.isCollectable ? 'N/A' : formatDollar(item.totalPremium),
+    formatCurrency(item.price),
+    item.isCollectable ? 'N/A' : formatCurrency(item.spotPriceAtPurchase),
+    item.isCollectable ? 'N/A' : formatCurrency(item.premiumPerOz),
+    item.isCollectable ? 'N/A' : formatCurrency(item.totalPremium),
     item.purchaseLocation,
     item.storageLocation || '',
     item.notes || '',

--- a/js/spot.js
+++ b/js/spot.js
@@ -49,7 +49,7 @@ const fetchSpotPrice = () => {
         elements.spotPriceDisplay[metalConfig.key] &&
         elements.spotPriceDisplay[metalConfig.key].textContent !== undefined
       ) {
-        elements.spotPriceDisplay[metalConfig.key].textContent = formatDollar(
+        elements.spotPriceDisplay[metalConfig.key].textContent = formatCurrency(
           spotPrices[metalConfig.key],
         );
       }
@@ -61,7 +61,7 @@ const fetchSpotPrice = () => {
         elements.spotPriceDisplay[metalConfig.key] &&
         elements.spotPriceDisplay[metalConfig.key].textContent !== undefined
       ) {
-        elements.spotPriceDisplay[metalConfig.key].textContent = formatDollar(
+        elements.spotPriceDisplay[metalConfig.key].textContent = formatCurrency(
           spotPrices[metalConfig.key],
         );
       }
@@ -105,7 +105,7 @@ const updateManualSpot = (metalKey) => {
     elements.spotPriceDisplay[metalKey] &&
     elements.spotPriceDisplay[metalKey].textContent !== undefined
   ) {
-    elements.spotPriceDisplay[metalKey].textContent = formatDollar(
+    elements.spotPriceDisplay[metalKey].textContent = formatCurrency(
       spotPrices[metalKey],
     );
   }
@@ -162,7 +162,7 @@ const resetSpot = (metalKey) => {
     elements.spotPriceDisplay[metalKey] &&
     elements.spotPriceDisplay[metalKey].textContent !== undefined
   ) {
-    elements.spotPriceDisplay[metalKey].textContent = formatDollar(
+    elements.spotPriceDisplay[metalKey].textContent = formatCurrency(
       spotPrices[metalKey],
     );
   }

--- a/js/utils.js
+++ b/js/utils.js
@@ -350,15 +350,24 @@ const formatDisplayDate = (dateStr) => {
 };
 
 /**
- * Formats a number as a dollar amount with two decimal places
+ * Formats a number as a currency string using the default currency
  *
- * @param {number|string} n - Number to format
- * @returns {string} Formatted dollar string (e.g., "$1,234.56")
+ * @param {number|string} value - Number to format
+ * @param {string} [currency=DEFAULT_CURRENCY] - ISO currency code
+ * @returns {string} Formatted currency string (e.g., "$1,234.56")
  */
-const formatDollar = (n) => {
-  const num = parseFloat(n);
+const formatCurrency = (value, currency = DEFAULT_CURRENCY) => {
+  const num = parseFloat(value);
   if (isNaN(num)) return "";
-  return `$${num.toFixed(2)}`;
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: "currency",
+      currency,
+    }).format(num);
+  } catch (e) {
+    // Fallback for environments without Intl support
+    return `${currency} ${num.toFixed(2)}`;
+  }
 };
 
 /**
@@ -368,7 +377,7 @@ const formatDollar = (n) => {
  * @returns {string} HTML string with appropriate color styling
  */
 const formatLossProfit = (value) => {
-  const formatted = formatDollar(value);
+  const formatted = formatCurrency(value);
   if (value > 0) {
     return `<span style="color: var(--success);">${formatted}</span>`;
   } else if (value < 0) {


### PR DESCRIPTION
## Summary
- define `DEFAULT_CURRENCY` constant and expose globally
- add `formatCurrency` leveraging `Intl.NumberFormat`
- replace `formatDollar` usage across modules with `formatCurrency`

## Testing
- `node tests/search-numista.test.js`
- `node tests/totals-numista.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a3cd7d790832eb77ede4bf8555a88