### PR TITLE
Remove legacy quick filter helpers

### DIFF
--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -83,7 +83,6 @@
 | events.js | setupEventListeners | Sets up all primary event listeners for the application |
 | events.js | updateThemeDisplay |  |
 | events.js | setupPagination | Sets up pagination event listeners |
-| events.js | populateFilterOptions | Populates type and metal filter dropdowns while preserving selections |
 | events.js | setupSearch | Sets up search event listeners |
 | events.js | setupThemeToggle | Sets up theme toggle event listeners |
 | events.js | setupApiEvents | Sets up API-related event listeners |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -31,10 +31,9 @@
 ### Files Modified:
 1. **`index.html`**: Added `multiple` filter selects and Exclude checkboxes
 2. **`css/styles.css`**: Styled exclude toggle controls
-3. **`js/events.js`**: `populateFilterOptions` preserves multi-select selections
-4. **`js/filters.js`**: Multi-select and exclusion support across dropdowns, application, chips, and filter logic
-5. **`js/constants.js`**: Bumped version to 3.04.09
-6. **Documentation**: Updated changelog, function table, roadmap, status, and structure
+3. **`js/filters.js`**: Multi-select and exclusion support across dropdowns, application, chips, and filter logic
+4. **`js/constants.js`**: Bumped version to 3.04.09
+5. **Documentation**: Updated changelog, function table, roadmap, status, and structure
 
 # Implementation Summary: Debounced Search
 

--- a/js/events.js
+++ b/js/events.js
@@ -1311,57 +1311,10 @@ const setupPagination = () => {
 };
 
 /**
- * Populates type and metal filter dropdowns based on current inventory
- */
-const populateFilterOptions = () => {
-  if (elements.metalFilter) {
-    const selected = Array.from(elements.metalFilter.selectedOptions).map(
-      (o) => o.value,
-    );
-    const metals = [
-      ...new Set(
-        inventory.map((i) =>
-          getCompositionFirstWords(i.composition || i.metal || ""),
-        ),
-      ),
-    ]
-      .filter(Boolean)
-      .sort();
-    elements.metalFilter.innerHTML =
-      '<option value="">All Metals</option>' +
-      metals
-        .map(
-          (m) =>
-            `<option value="${m}" ${selected.includes(m) ? "selected" : ""}>${m}</option>`,
-        )
-        .join("");
-  }
-
-  if (elements.typeFilter) {
-    const selected = Array.from(elements.typeFilter.selectedOptions).map(
-      (o) => o.value,
-    );
-    const types = [...new Set(inventory.map((i) => i.type))]
-      .filter(Boolean)
-      .sort();
-    elements.typeFilter.innerHTML =
-      '<option value="">All Types</option>' +
-      types
-        .map(
-          (t) =>
-            `<option value="${t}" ${selected.includes(t) ? "selected" : ""}>${t}</option>`,
-        )
-        .join("");
-  }
-};
-
-/**
  * Sets up search event listeners
  */
 const setupSearch = () => {
   debugLog("Setting up search listeners...");
-
-  populateFilterOptions();
 
   try {
     if (elements.searchInput) {

--- a/js/init.js
+++ b/js/init.js
@@ -179,8 +179,6 @@ document.addEventListener("DOMContentLoaded", () => {
     // Search elements
     debugLog("Phase 6: Initializing search elements...");
     elements.searchInput = safeGetElement("searchInput");
-    elements.typeFilter = safeGetElement("typeFilter");
-    elements.metalFilter = safeGetElement("metalFilter");
     elements.clearSearchBtn = safeGetElement("clearSearchBtn");
     elements.newItemBtn = safeGetElement("newItemBtn");
     elements.searchResultsInfo = safeGetElement("searchResultsInfo");

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -724,7 +724,6 @@ window.startCellEdit = startCellEdit;
 
 const renderTable = () => {
   return monitorPerformance(() => {
-    populateFilterOptions();
     const filteredInventory = filterInventory();
 
     // Automatically adjust items-per-page dropdown when filtered results


### PR DESCRIPTION
## Summary
- drop obsolete `populateFilterOptions` and related calls
- stop initializing removed quick filter elements
- document removal of deprecated quick filter helper

## Testing
- `node tests/search-numista.test.js`
- `node tests/totals-numista.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a50d2c200832e8ecc87482fd752c5