### PR TITLE
Add history time support in batch spot price fetches

### DIFF
--- a/index.html
+++ b/index.html
@@ -1603,7 +1603,7 @@
                   <div class="provider-setting-row">
                     <label for="historyTimes_METALS_DEV">Times per Day:</label>
                     <input type="text" id="historyTimes_METALS_DEV" class="provider-history-input"
-                           placeholder="HH:MM,HH:MM">
+                           placeholder="08:00,20:00">
                   </div>
 
                   <!-- Metal Selection -->
@@ -1725,7 +1725,7 @@
                   <div class="provider-setting-row">
                     <label for="historyTimes_METALS_API">Times per Day:</label>
                     <input type="text" id="historyTimes_METALS_API" class="provider-history-input"
-                           placeholder="HH:MM,HH:MM">
+                           placeholder="08:00,20:00">
                   </div>
 
                   <!-- Metal Selection -->
@@ -1853,7 +1853,7 @@
                   <div class="provider-setting-row">
                     <label for="historyTimes_METAL_PRICE_API">Times per Day:</label>
                     <input type="text" id="historyTimes_METAL_PRICE_API" class="provider-history-input"
-                           placeholder="HH:MM,HH:MM">
+                           placeholder="08:00,20:00">
                   </div>
 
                   <!-- Metal Selection -->
@@ -1992,7 +1992,7 @@
                   <div class="provider-setting-row">
                     <label for="historyTimes_CUSTOM">Times per Day:</label>
                     <input type="text" id="historyTimes_CUSTOM" class="provider-history-input"
-                           placeholder="HH:MM,HH:MM">
+                           placeholder="08:00,20:00">
                   </div>
 
                   <!-- Metal Selection -->

--- a/js/api.js
+++ b/js/api.js
@@ -301,7 +301,7 @@ const updateProviderSettings = (provider) => {
     const times = timesInput.value
       .split(',')
       .map(t => t.trim())
-      .filter(t => t);
+      .filter(t => /^\d{2}:\d{2}$/.test(t));
     config.historyTimes[provider] = times;
   }
 
@@ -858,17 +858,12 @@ const fetchBatchSpotPrices = async (provider, apiKey, selectedMetals, historyDay
 
   try {
     let url = providerConfig.baseUrl + providerConfig.batchEndpoint;
-    
-    // Replace placeholders based on provider
+
+    // Replace placeholders based on provider specifics
     if (provider === 'METALS_DEV') {
       const metals = selectedMetals.join(',');
       url = url.replace('{API_KEY}', apiKey)
-              .replace('{METALS}', metals)
-              .replace('{DAYS}', historyDays);
-      if (Array.isArray(historyTimes) && historyTimes.length) {
-        const timesParam = historyTimes.map(t => encodeURIComponent(t)).join(',');
-        url += `&times=${timesParam}`;
-      }
+              .replace('{METALS}', metals);
     } else if (provider === 'METALS_API') {
       const symbolMap = { silver: 'XAG', gold: 'XAU', platinum: 'XPT', palladium: 'XPD' };
       const symbols = selectedMetals.map(metal => symbolMap[metal]).join(',');
@@ -879,6 +874,19 @@ const fetchBatchSpotPrices = async (provider, apiKey, selectedMetals, historyDay
       const currencies = selectedMetals.map(metal => symbolMap[metal]).join(',');
       url = url.replace('{API_KEY}', apiKey)
               .replace('{CURRENCIES}', currencies);
+    }
+
+    // Apply historical parameters if supported
+    if (url.includes('{DAYS}')) {
+      url = url.replace('{DAYS}', historyDays);
+      if (Array.isArray(historyTimes) && historyTimes.length) {
+        const timesParam = historyTimes.map(t => encodeURIComponent(t)).join(',');
+        if (url.includes('{TIMES}')) {
+          url = url.replace('{TIMES}', timesParam);
+        } else {
+          url += `&times=${timesParam}`;
+        }
+      }
     }
 
     const headers = {


### PR DESCRIPTION
## Summary
- allow entering comma-separated daily history times for providers
- include historyDays and historyTimes when building batch spot price URLs

## Testing
- `node tests/search-numista.test.js`
- `node tests/totals-numista.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a5293b614832e9f56ed0a5a543ac4