### PR TITLE
Reorganize provider info into settings

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -649,6 +649,7 @@ input[type="submit"] {
   gap: 0.25rem;
   align-items: center;
   text-align: center;
+  margin-top: var(--spacing);
 }
 
 .provider-history {

--- a/index.html
+++ b/index.html
@@ -1633,32 +1633,32 @@
                     </div>
                   </div>
                   
-                  <!-- Batch Optimization Display -->
-                  <div class="batch-optimization">
-                    <div class="batch-info" id="batchInfo_METALS_DEV">
-                      📊 Batch Request: 4 metals + 30 days = 1 API call<br>
-                      <span class="batch-savings">(saves 123 calls vs individual requests)</span>
-                    </div>
+                <!-- Batch Optimization Display -->
+                <div class="batch-optimization">
+                  <div class="batch-info" id="batchInfo_METALS_DEV">
+                    📊 Batch Request: 4 metals + 30 days = 1 API call<br>
+                    <span class="batch-savings">(saves 123 calls vs individual requests)</span>
                   </div>
                 </div>
-                
-                <div class="provider-footer">
-                  <div class="provider-info">
-                    <div class="api-key-note">
-                      Your API key is stored locally and never shared.
-                    </div>
-                    <div class="provider-status">
-                      <span class="status-dot"></span>
-                      <span class="status-text">Disconnected</span>
-                    </div>
-                    <div class="provider-history"></div>
+                <div class="provider-info">
+                  <div class="api-key-note">
+                    Your API key is stored locally and never shared.
                   </div>
-                  <div class="provider-actions">
-                    <button
-                      type="button"
-                      class="btn provider-default-btn"
-                      data-provider="METALS_DEV"
-                    >
+                  <div class="provider-status">
+                    <span class="status-dot"></span>
+                    <span class="status-text">Disconnected</span>
+                  </div>
+                  <div class="provider-history"></div>
+                </div>
+              </div>
+
+              <div class="provider-footer">
+                <div class="provider-actions">
+                  <button
+                    type="button"
+                    class="btn provider-default-btn"
+                    data-provider="METALS_DEV"
+                  >
                     </button>
                     <div class="provider-actions-right">
                       <button
@@ -1755,32 +1755,32 @@
                     </div>
                   </div>
                   
-                  <!-- Batch Optimization Display -->
-                  <div class="batch-optimization">
-                    <div class="batch-info" id="batchInfo_METALS_API">
-                      📊 Batch Request: 4 metals + 30 days = 1 API call<br>
-                      <span class="batch-savings">(saves 123 calls vs individual requests)</span>
-                    </div>
+                <!-- Batch Optimization Display -->
+                <div class="batch-optimization">
+                  <div class="batch-info" id="batchInfo_METALS_API">
+                    📊 Batch Request: 4 metals + 30 days = 1 API call<br>
+                    <span class="batch-savings">(saves 123 calls vs individual requests)</span>
                   </div>
                 </div>
-                
-                <div class="provider-footer">
-                  <div class="provider-info">
-                    <div class="api-key-note">
-                      Your API key is stored locally and never shared.
-                    </div>
-                    <div class="provider-status">
-                      <span class="status-dot"></span>
-                      <span class="status-text">Disconnected</span>
-                    </div>
-                    <div class="provider-history"></div>
+                <div class="provider-info">
+                  <div class="api-key-note">
+                    Your API key is stored locally and never shared.
                   </div>
-                  <div class="provider-actions">
-                    <button
-                      type="button"
-                      class="btn provider-default-btn"
-                      data-provider="METALS_API"
-                    >
+                  <div class="provider-status">
+                    <span class="status-dot"></span>
+                    <span class="status-text">Disconnected</span>
+                  </div>
+                  <div class="provider-history"></div>
+                </div>
+              </div>
+
+              <div class="provider-footer">
+                <div class="provider-actions">
+                  <button
+                    type="button"
+                    class="btn provider-default-btn"
+                    data-provider="METALS_API"
+                  >
                     </button>
                     <div class="provider-actions-right">
                       <button
@@ -1883,31 +1883,31 @@
                     </div>
                   </div>
                   
-                  <!-- Batch Optimization Display -->
-                  <div class="batch-optimization">
-                    <div class="batch-info" id="batchInfo_METAL_PRICE_API">
-                      📊 Batch Request: 4 metals + 30 days = 1 API call<br>
-                      <span class="batch-savings">(saves 123 calls vs individual requests)</span>
-                    </div>
+                <!-- Batch Optimization Display -->
+                <div class="batch-optimization">
+                  <div class="batch-info" id="batchInfo_METAL_PRICE_API">
+                    📊 Batch Request: 4 metals + 30 days = 1 API call<br>
+                    <span class="batch-savings">(saves 123 calls vs individual requests)</span>
                   </div>
                 </div>
-                <div class="provider-footer">
-                  <div class="provider-info">
-                    <div class="api-key-note">
-                      Your API key is stored locally and never shared.
-                    </div>
-                    <div class="provider-status">
-                      <span class="status-dot"></span>
-                      <span class="status-text">Disconnected</span>
-                    </div>
-                    <div class="provider-history"></div>
+                <div class="provider-info">
+                  <div class="api-key-note">
+                    Your API key is stored locally and never shared.
                   </div>
-                  <div class="provider-actions">
-                    <button
-                      type="button"
-                      class="btn provider-default-btn"
-                      data-provider="METAL_PRICE_API"
-                    >
+                  <div class="provider-status">
+                    <span class="status-dot"></span>
+                    <span class="status-text">Disconnected</span>
+                  </div>
+                  <div class="provider-history"></div>
+                </div>
+              </div>
+              <div class="provider-footer">
+                <div class="provider-actions">
+                  <button
+                    type="button"
+                    class="btn provider-default-btn"
+                    data-provider="METAL_PRICE_API"
+                  >
                     </button>
                     <div class="provider-actions-right">
                       <button
@@ -2022,31 +2022,31 @@
                     </div>
                   </div>
                   
-                  <!-- Batch Optimization Display -->
-                  <div class="batch-optimization">
-                    <div class="batch-info" id="batchInfo_CUSTOM">
-                      📊 Individual Requests: 4 metals = 4 API calls<br>
-                      <span class="batch-savings">(batch requests not supported)</span>
-                    </div>
+                <!-- Batch Optimization Display -->
+                <div class="batch-optimization">
+                  <div class="batch-info" id="batchInfo_CUSTOM">
+                    📊 Individual Requests: 4 metals = 4 API calls<br>
+                    <span class="batch-savings">(batch requests not supported)</span>
                   </div>
                 </div>
-                <div class="provider-footer">
-                  <div class="provider-info">
-                    <div class="api-key-note">
-                      Your API key is stored locally and never shared.
-                    </div>
-                    <div class="provider-status">
-                      <span class="status-dot"></span>
-                      <span class="status-text">Disconnected</span>
-                    </div>
-                    <div class="provider-history"></div>
+                <div class="provider-info">
+                  <div class="api-key-note">
+                    Your API key is stored locally and never shared.
                   </div>
-                  <div class="provider-actions">
-                    <button
-                      type="button"
-                      class="btn provider-default-btn"
-                      data-provider="CUSTOM"
-                    >
+                  <div class="provider-status">
+                    <span class="status-dot"></span>
+                    <span class="status-text">Disconnected</span>
+                  </div>
+                  <div class="provider-history"></div>
+                </div>
+              </div>
+              <div class="provider-footer">
+                <div class="provider-actions">
+                  <button
+                    type="button"
+                    class="btn provider-default-btn"
+                    data-provider="CUSTOM"
+                  >
                     </button>
                     <div class="provider-actions-right">
                       <button

--- a/js/api.js
+++ b/js/api.js
@@ -351,9 +351,9 @@ const setupProviderSettingsListeners = (provider) => {
 const updateProviderHistoryTables = () => {
   const config = loadApiConfig();
   Object.keys(API_PROVIDERS).forEach((prov) => {
-    const container = document.querySelector(
-      `.api-provider[data-provider="${prov}"] .provider-history`,
-    );
+      const container = document.querySelector(
+        `.api-provider[data-provider="${prov}"] .provider-settings .provider-history`,
+      );
     if (!container) return;
     const usage = config.usage?.[prov] || {
       quota: DEFAULT_API_QUOTA,


### PR DESCRIPTION
## Summary
- Move provider info blocks into each provider's settings section after batch details
- Adjust API history selector for new provider info placement
- Add spacing for relocated provider info elements

## Testing
- `node tests/search-numista.test.js`
- `node tests/totals-numista.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a617af0d4832eb0e8dca27847b93b