### PR TITLE
Support Numista CSV estimate price import

### DIFF
--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1349,6 +1349,14 @@ const importNumistaCsv = (file, override = false) => {
             purchasePrice = convertToUsd(amount, currency);
           }
 
+          if (!priceKey && purchasePrice === 0) {
+            const estimateRaw = getValue(row, ['Estimate (USD)']);
+            if (estimateRaw) {
+              const estimateAmount = parseFloat(String(estimateRaw).replace(/[^0-9.\-]/g, ''));
+              if (!isNaN(estimateAmount)) purchasePrice = convertToUsd(estimateAmount, 'USD');
+            }
+          }
+
           const purchaseLocRaw = getValue(row, ['Acquisition place', 'Acquired from', 'Purchase place']);
           const purchaseLocation = purchaseLocRaw && purchaseLocRaw.trim() ? purchaseLocRaw.trim() : '';
           const storageLocRaw = getValue(row, ['Storage location', 'Stored at', 'Storage place']);

--- a/tests/estimate-numista.test.js
+++ b/tests/estimate-numista.test.js
@@ -1,0 +1,88 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+// Minimal browser-like environment
+global.window = global;
+global.window.location = { search: '' };
+global.localStorage = {
+  _data: {},
+  setItem(key, value) { this._data[key] = String(value); },
+  getItem(key) { return this._data[key] || null; },
+};
+global.elements = { importProgress: null, importProgressText: null };
+global.compositionOptions = new Set();
+global.catalogManager = { syncInventory: inv => inv };
+global.alert = () => {};
+
+// Stubs for dependencies used in importNumistaCsv
+global.startImportProgress = () => {};
+global.updateImportProgress = () => {};
+global.endImportProgress = () => {};
+global.saveInventory = () => {};
+global.renderTable = () => {};
+global.updateStorageStats = () => {};
+global.handleError = () => {};
+global.getNextSerial = () => 1;
+
+// FileReader stub to feed CSV content
+global.FileReader = class {
+  readAsText(file) {
+    if (this.onload) {
+      this.onload({ target: { result: file.content } });
+    }
+  }
+};
+
+// Lightweight CSV parser stub mimicking Papa.parse
+global.Papa = {
+  parse: (csv, options = {}) => {
+    const lines = csv.trim().split(/\r?\n/);
+    let headers = lines[0].split(',');
+    if (typeof options.transformHeader === 'function') {
+      headers = headers.map(h => options.transformHeader(h));
+    }
+    const data = lines.slice(1).filter(Boolean).map(line => {
+      const parts = line.split(',');
+      const obj = {};
+      headers.forEach((h, i) => { obj[h] = parts[i] || ''; });
+      return obj;
+    });
+    return { data };
+  }
+};
+
+vm.runInThisContext(fs.readFileSync('js/constants.js', 'utf8'));
+vm.runInThisContext(fs.readFileSync('js/utils.js', 'utf8'));
+
+// Extract and evaluate only the importNumistaCsv function
+const inventorySrc = fs.readFileSync('js/inventory.js', 'utf8');
+const start = inventorySrc.indexOf('const importNumistaCsv');
+const braceStart = inventorySrc.indexOf('{', start);
+let idx = braceStart + 1;
+let depth = 1;
+while (depth > 0 && idx < inventorySrc.length) {
+  const ch = inventorySrc[idx++];
+  if (ch === '{') depth++;
+  else if (ch === '}') depth--;
+}
+let fnCode = inventorySrc.slice(start, idx);
+fnCode = fnCode.replace(/\s*if \(typeof updateStorageStats[^}]*\}\n/, '\n');
+vm.runInThisContext(fnCode + ';');
+
+// CSV row with only an Estimate column for pricing
+const csv = 'Numista #,Title,Year,Composition,Type,Weight,Estimate (USD)\n123,Test Coin,2024,Silver 0.999,Coin,31.103,15.5';
+const file = { content: csv };
+
+global.inventory = [];
+importNumistaCsv(file);
+
+assert.strictEqual(inventory.length, 1, 'item should be imported');
+assert.strictEqual(
+  inventory[0].purchasePrice,
+  convertToUsd(15.5, 'USD'),
+  'estimate value should be used as purchase price'
+);
+
+console.log('Estimate import test passed');
+


### PR DESCRIPTION
## Summary
- Fallback to `Estimate (USD)` when Numista CSV lacks a buying price and convert that estimate to USD
- Add unit test verifying estimate values populate purchase price during Numista imports

## Testing
- `node tests/search-numista.test.js`
- `node tests/totals-numista.test.js`
- `node tests/estimate-numista.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a63a7dde8832ea8211f6ad3a6c2fa