### PR TITLE
Handle multi-line Numista import notes

### DIFF
--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1367,7 +1367,15 @@ const importNumistaCsv = (file, override = false) => {
           const date = parseDate(dateStr);
 
           const baseNote = (getValue(row, ['Note', 'Notes']) || '').trim();
-          const notes = `${baseNote ? baseNote + ' ' : ''}(Imported from Numista.com N#${numistaId})`;
+          const privateComment = (getValue(row, ['Private comment']) || '').trim();
+          const publicComment = (getValue(row, ['Public comment']) || '').trim();
+          const otherComment = (getValue(row, ['Comment']) || '').trim();
+          const noteParts = [];
+          if (baseNote) noteParts.push(baseNote);
+          if (privateComment) noteParts.push(`Private Comment: ${privateComment}`);
+          if (publicComment) noteParts.push(`Public Comment: ${publicComment}`);
+          if (otherComment) noteParts.push(`Comment: ${otherComment}`);
+          const notes = noteParts.join('\n');
 
           const isCollectable = !(type === 'Bar' || type === 'Round');
           const spotPriceAtPurchase = 0;

--- a/js/utils.js
+++ b/js/utils.js
@@ -439,7 +439,7 @@ const stripNonAlphanumeric = (str = "") =>
 const sanitizeObjectFields = (obj) => {
   const cleaned = { ...obj };
   for (const key of Object.keys(cleaned)) {
-    if (typeof cleaned[key] === "string") {
+    if (typeof cleaned[key] === "string" && key !== 'notes') {
       cleaned[key] = stripNonAlphanumeric(cleaned[key]);
     }
   }
@@ -617,7 +617,7 @@ const sanitizeImportedItem = (item) => {
   }
 
   // Normalize and sanitize string fields
-  const strFields = ['name', 'type', 'purchaseLocation', 'storageLocation', 'notes'];
+  const basicFields = ['name', 'type', 'purchaseLocation', 'storageLocation'];
   const cleanString = (str = '') =>
     str
       .toString()
@@ -627,9 +627,21 @@ const sanitizeImportedItem = (item) => {
       .replace(/[\u0000-\u001F\u007F'\"]/g, '')
       .replace(/\s+/g, ' ')
       .trim();
-  for (const field of strFields) {
+  const cleanMultilineString = (str = '') =>
+    str
+      .toString()
+      .replace(/<[^>]*>/g, '')
+      .normalize('NFD')
+      .replace(/\p{Diacritic}/gu, '')
+      .replace(/[\u0000-\u0008\u000B-\u001F\u007F'\"]/g, '')
+      .replace(/\r\n?/g, '\n')
+      .replace(/[ \t]+/g, ' ')
+      .replace(/ *\n */g, '\n')
+      .trim();
+  for (const field of basicFields) {
     sanitized[field] = cleanString(sanitized[field]);
   }
+  sanitized.notes = cleanMultilineString(sanitized.notes);
   sanitized.type = normalizeType(sanitized.type);
 
   // Reset premium calculations if price or weight are missing

--- a/tests/estimate-numista.test.js
+++ b/tests/estimate-numista.test.js
@@ -86,3 +86,16 @@ assert.strictEqual(
 
 console.log('Estimate import test passed');
 
+// Test preservation of comment fields in notes
+const csv2 = 'Numista #,Title,Year,Composition,Type,Weight,Note,Private comment,Public comment,Comment\n' +
+  '123,Test Coin,2024,Silver 0.999,Coin,31.103,Base note,Private text,Public text,Other text';
+const file2 = { content: csv2 };
+global.inventory = [];
+importNumistaCsv(file2);
+assert.strictEqual(
+  inventory[0].notes,
+  'Base note\nPrivate Comment: Private text\nPublic Comment: Public text\nComment: Other text',
+  'all comment fields should appear in notes'
+);
+console.log('Numista comment import test passed');
+


### PR DESCRIPTION
## Summary
- Capture Numista comment fields and build multi-line notes without import suffix
- Preserve newline and punctuation in notes by updating sanitization
- Test comment field preservation in Numista CSV import

## Testing
- `node tests/estimate-numista.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a65eca670832e8c1fc772c2ee4d7c