### PR TITLE
feat: export Numista comments

### DIFF
--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1445,6 +1445,96 @@ const importNumistaCsv = (file, override = false) => {
 };
 
 /**
+ * Exports inventory using Numista-compatible column layout
+ */
+const exportNumistaCsv = () => {
+  const timestamp = new Date().toISOString().slice(0,10).replace(/-/g,'');
+  const headers = [
+    "N# number",
+    "Title",
+    "Year",
+    "Metal",
+    "Quantity",
+    "Type",
+    "Weight (g)",
+    "Buying price (USD)",
+    "Acquisition place",
+    "Storage location",
+    "Acquisition date",
+    "Note",
+    "Private comment",
+    "Public comment",
+    "Comment",
+  ];
+
+  const sortedInventory = sortInventoryByDateNewestFirst();
+  const rows = [];
+
+  for (const item of sortedInventory) {
+    const year = item.issuedYear || '';
+    let title = item.name || '';
+    if (year) {
+      const yearRegex = new RegExp(`\\s*${year}\\b`);
+      title = title.replace(yearRegex, '').trim();
+    }
+
+    const weightGrams = parseFloat(item.weight)
+      ? parseFloat(item.weight) * 31.1034768
+      : 0;
+    const purchasePrice = item.purchasePrice ?? item.price;
+
+    let baseNote = '';
+    let privateComment = '';
+    let publicComment = '';
+    let otherComment = '';
+    if (item.notes) {
+      const lines = String(item.notes).split(/\n/);
+      for (const line of lines) {
+        if (/^\s*Private Comment:/i.test(line)) {
+          privateComment = line.replace(/^\s*Private Comment:\s*/i, '').trim();
+        } else if (/^\s*Public Comment:/i.test(line)) {
+          publicComment = line.replace(/^\s*Public Comment:\s*/i, '').trim();
+        } else if (/^\s*Comment:/i.test(line)) {
+          otherComment = line.replace(/^\s*Comment:\s*/i, '').trim();
+        } else {
+          baseNote = baseNote ? `${baseNote}\n${line}` : line;
+        }
+      }
+    }
+
+    rows.push([
+      item.numistaId || '',
+      title,
+      year,
+      item.metal || '',
+      item.qty || '',
+      item.type || '',
+      weightGrams ? weightGrams.toFixed(2) : '',
+      purchasePrice != null ? Number(purchasePrice).toFixed(2) : '',
+      item.purchaseLocation || '',
+      item.storageLocation || '',
+      item.date || '',
+      baseNote,
+      privateComment,
+      publicComment,
+      otherComment,
+    ]);
+  }
+
+  const csv = Papa.unparse([headers, ...rows]);
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `numista_export_${timestamp}.csv`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+};
+
+/**
  * Exports current inventory to CSV format
  */
 const exportCsv = () => {

--- a/tests/export-numista-comments.test.js
+++ b/tests/export-numista-comments.test.js
@@ -1,0 +1,115 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+// Minimal browser-like environment
+global.window = global;
+global.window.location = { search: '' };
+global.localStorage = {
+  _data: {},
+  setItem(key, value) { this._data[key] = String(value); },
+  getItem(key) { return this._data[key] || null; },
+};
+
+global.elements = { importProgress: null, importProgressText: null };
+global.compositionOptions = new Set();
+global.catalogManager = { syncInventory: inv => inv };
+global.alert = () => {};
+
+// Stubs for dependencies used in import/export
+global.startImportProgress = () => {};
+global.updateImportProgress = () => {};
+global.endImportProgress = () => {};
+global.saveInventory = () => {};
+global.renderTable = () => {};
+global.updateStorageStats = () => {};
+global.handleError = () => {};
+global.getNextSerial = () => 1;
+
+let capturedCsv = '';
+
+global.Papa = {
+  parse: (csv, options = {}) => {
+    const lines = csv.trim().split(/\r?\n/);
+    let headers = lines[0].split(',');
+    if (typeof options.transformHeader === 'function') {
+      headers = headers.map(h => options.transformHeader(h));
+    }
+    const data = lines.slice(1).filter(Boolean).map(line => {
+      const parts = line.split(',');
+      const obj = {};
+      headers.forEach((h, i) => { obj[h] = parts[i] || ''; });
+      return obj;
+    });
+    return { data };
+  },
+  unparse: (rows) => rows.map(r => r.map(v => {
+    const s = String(v ?? '');
+    return /[",\n]/.test(s) ? '"' + s.replace(/"/g,'""') + '"' : s;
+  }).join(',')).join('\n')
+};
+
+global.FileReader = class {
+  readAsText(file) {
+    if (this.onload) {
+      this.onload({ target: { result: file.content } });
+    }
+  }
+};
+
+global.Blob = class { constructor(parts){ this.parts = parts; } };
+global.URL = {
+  createObjectURL(blob){ capturedCsv = blob.parts.join(''); return 'blob:url'; },
+  revokeObjectURL(){}
+};
+global.document = {
+  body: { appendChild(){}, removeChild(){} },
+  createElement(){ return { href:'', download:'', click(){}, remove(){}, style:{} }; }
+};
+
+vm.runInThisContext(fs.readFileSync('js/constants.js', 'utf8'));
+vm.runInThisContext(fs.readFileSync('js/utils.js', 'utf8'));
+
+const inventorySrc = fs.readFileSync('js/inventory.js', 'utf8');
+function extractFn(name){
+  const start = inventorySrc.indexOf(`const ${name}`);
+  const braceStart = inventorySrc.indexOf('{', start);
+  let idx = braceStart + 1;
+  let depth = 1;
+  while (depth > 0 && idx < inventorySrc.length) {
+    const ch = inventorySrc[idx++];
+    if (ch === '{') depth++;
+    else if (ch === '}') depth--;
+  }
+  let code = inventorySrc.slice(start, idx);
+  code = code.replace(/\s*if \(typeof updateStorageStats[^}]*\}\n/, '\n');
+  return code;
+}
+vm.runInThisContext(extractFn('importNumistaCsv') + ';');
+vm.runInThisContext(extractFn('exportNumistaCsv') + ';');
+
+const csv = 'Numista #,Title,Year,Composition,Type,Weight,Note,Private comment,Public comment,Comment\n' +
+  '123,Test Coin,2024,Silver 0.999,Coin,31.103,Base note,Private text,Public text,Other text';
+const file = { content: csv };
+
+global.inventory = [];
+importNumistaCsv(file);
+
+capturedCsv = '';
+exportNumistaCsv();
+
+const lines = capturedCsv.trim().split(/\r?\n/);
+const headers = lines[0].split(',');
+const row = lines[1].split(',');
+
+assert.deepStrictEqual(
+  headers.slice(11),
+  ['Note','Private comment','Public comment','Comment'],
+  'header columns should include note and comment fields'
+);
+assert.strictEqual(row[11], 'Base note');
+assert.strictEqual(row[12], 'Private text');
+assert.strictEqual(row[13], 'Public text');
+assert.strictEqual(row[14], 'Other text');
+
+console.log('Numista comment export test passed');


### PR DESCRIPTION
## Summary
- add Numista CSV export that separates private, public, and generic comments
- test export to ensure comment fields survive round trip

## Testing
- `node tests/estimate-numista.test.js`
- `node tests/search-numista.test.js`
- `node tests/totals-numista.test.js`
- `node tests/export-numista-comments.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a6709d18c832ea1a94e731b59454f