### PR TITLE
Add weight formatting utilities and gram editing support

### DIFF
--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -157,6 +157,8 @@
 | utils.js | formatLossProfit | Formats a profit/loss value with color coding |
 | utils.js | sanitizeHtml | Sanitizes text input for safe HTML display |
 | utils.js | gramsToOzt | Converts grams to troy ounces (ozt) |
+| utils.js | oztToGrams | Converts troy ounces to grams |
+| utils.js | formatWeight | Formats a weight in ozt to grams or ounces |
 | utils.js | convertToUsd | Converts amount from specified currency to USD using static rates |
 | utils.js | stripNonAlphanumeric | Removes all characters except letters, numbers, and spaces |
 | utils.js | sanitizeObjectFields | Strips non-alphanumeric characters from all string properties in an object |

--- a/js/events.js
+++ b/js/events.js
@@ -476,6 +476,9 @@ const setupEventListeners = () => {
           const qty = parseInt(elements.editQty.value, 10);
           const type = elements.editType.value;
           let weight = parseFloat(elements.editWeight.value);
+          if (elements.editWeight.dataset.unit === 'g') {
+            weight = gramsToOzt(weight);
+          }
           weight = isNaN(weight) ? 0 : parseFloat(weight.toFixed(2));
           let price = parseFloat(elements.editPrice.value);
           price = isNaN(price) || price < 0 ? 0 : price;

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -679,7 +679,15 @@ const startCellEdit = (idx, field, icon) => {
   } else {
     input.type = 'text';
   }
-  input.value = current;
+  if (field === 'weight' && item.weight < 1) {
+    input.value = oztToGrams(current).toFixed(2);
+    input.dataset.unit = 'g';
+  } else if (['weight', 'price', 'spotPriceAtPurchase'].includes(field)) {
+    input.value = parseFloat(current).toFixed(2);
+    if (field === 'weight') input.dataset.unit = 'oz';
+  } else {
+    input.value = current;
+  }
   input.className = 'inline-input';
   td.innerHTML = '';
   td.appendChild(input);
@@ -707,7 +715,11 @@ const startCellEdit = (idx, field, icon) => {
       : ['weight', 'price', 'spotPriceAtPurchase'].includes(field)
         ? parseFloat(value)
         : value.trim();
-    item[field] = parsed;
+    let finalValue = parsed;
+    if (field === 'weight' && input.dataset.unit === 'g') {
+      finalValue = gramsToOzt(parsed);
+    }
+    item[field] = finalValue;
     if (['qty', 'weight', 'price', 'spotPriceAtPurchase'].includes(field)) {
       recalcItem(item);
     }
@@ -776,7 +788,7 @@ const renderTable = () => {
         ${filterLink('qty', item.qty, 'var(--text-primary)')}
       </td>
       <td class="shrink" data-column="weight">
-        ${filterLink('weight', item.weight, 'var(--text-primary)', parseFloat(item.weight).toFixed(2) + ' (oz)', 'Troy ounces (ozt)')}
+        ${filterLink('weight', item.weight, 'var(--text-primary)', formatWeight(item.weight), item.weight < 1 ? 'Grams (g)' : 'Troy ounces (ozt)')}
       </td>
       <td class="shrink" data-column="purchasePrice" title="USD">
         ${item.price > 0 ? filterLink('price', item.price, 'var(--text-primary)', formatCurrency(item.price)) : ''}
@@ -1057,7 +1069,13 @@ const editItem = (idx, logIdx = null) => {
   elements.editName.value = item.name;
   elements.editQty.value = item.qty;
   elements.editType.value = item.type;
-  elements.editWeight.value = parseFloat(item.weight).toFixed(2);
+  if (item.weight < 1) {
+    elements.editWeight.value = oztToGrams(item.weight).toFixed(2);
+    elements.editWeight.dataset.unit = 'g';
+  } else {
+    elements.editWeight.value = parseFloat(item.weight).toFixed(2);
+    elements.editWeight.dataset.unit = 'oz';
+  }
   elements.editPrice.value = item.price > 0 ? item.price : '';
   elements.editPurchaseLocation.value = item.purchaseLocation;
   elements.editStorageLocation.value = item.storageLocation && item.storageLocation !== 'Unknown' ? item.storageLocation : '';

--- a/js/utils.js
+++ b/js/utils.js
@@ -409,6 +409,28 @@ const sanitizeHtml = (text) => {
 const gramsToOzt = (grams) => grams / 31.1034768;
 
 /**
+ * Converts troy ounces to grams
+ *
+ * @param {number} ozt - Weight in troy ounces
+ * @returns {number} Weight in grams
+ */
+const oztToGrams = (ozt) => ozt * 31.1034768;
+
+/**
+ * Formats a weight in troy ounces to either grams or ounces
+ *
+ * @param {number} ozt - Weight in troy ounces
+ * @returns {string} Formatted weight string with unit
+ */
+const formatWeight = (ozt) => {
+  const weight = parseFloat(ozt);
+  if (weight < 1) {
+    return `${oztToGrams(weight).toFixed(2)} g`;
+  }
+  return `${weight.toFixed(2)} oz`;
+};
+
+/**
  * Converts amount from specified currency to USD using static rates
  *
  * @param {number} amount - Monetary amount


### PR DESCRIPTION
## Summary
- add `oztToGrams` and `formatWeight` helpers for weight conversions
- display inventory weights in grams when under 1 ozt and add tooltips
- convert gram inputs back to troy ounces when saving edits

## Testing
- `node tests/estimate-numista.test.js`
- `node tests/export-numista-comments.test.js`
- `node tests/search-numista.test.js`
- `node tests/totals-numista.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a6db370d0832e91d19a489968bc08