### PR TITLE
Display 'Alloy' for non-precious compositions

### DIFF
--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -166,6 +166,7 @@
 | utils.js | mapNumistaType | Maps Numista type strings to internal categories (Coin, Bar, Round, Note, Aurum, Other) |
 | utils.js | parseNumistaMetal | Parses composition into Silver, Gold, Platinum, Palladium, Paper, or Alloy |
 | utils.js | getCompositionFirstWords | Extracts first two words from a composition string, ignoring parentheses and numbers |
+| utils.js | getDisplayComposition | Returns "Alloy" when composition doesn't start with a primary metal |
 | utils.js | saveData | Saves data to localStorage with JSON serialization |
 | utils.js | loadData | Loads data from localStorage with error handling |
 | utils.js | sortInventoryByDateNewestFirst | Sorts inventory by date (newest first) |

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -779,7 +779,7 @@ const renderTable = () => {
       <tr>
       <td class="shrink" data-column="date">${filterLink('date', item.date, 'var(--text-primary)', formatDisplayDate(item.date))}</td>
       <td class="shrink" data-column="type">${filterLink('type', item.type, getTypeColor(item.type))}</td>
-      <td class="shrink" data-column="composition">${filterLink('composition', getCompositionFirstWords(item.composition || item.metal || 'Silver'), METAL_COLORS[item.metal] || 'var(--primary)')}</td>
+      <td class="shrink" data-column="composition" data-composition="${escapeAttribute(item.composition || item.metal || '')}">${filterLink('composition', item.composition || item.metal || 'Silver', METAL_COLORS[item.metal] || 'var(--primary)', getDisplayComposition(item.composition || item.metal || 'Silver'))}</td>
       <td class="expand" data-column="name" style="text-align: left;">
         <span class="inline-edit-icon" role="button" tabindex="0" onclick="startCellEdit(${originalIdx}, 'name', this)" aria-label="Edit name" title="Edit name">✎</span>
         ${filterLink('name', item.name, 'var(--text-primary)')}

--- a/js/utils.js
+++ b/js/utils.js
@@ -158,6 +158,22 @@ const getCompositionFirstWords = (composition = "") => {
 };
 
 /**
+ * Determines display-friendly composition text.
+ *
+ * Returns "Alloy" when the first word isn't one of the primary metals
+ * (Gold, Silver, Platinum, Palladium).
+ *
+ * @param {string} composition - Raw composition description
+ * @returns {string} Display text for the composition
+ */
+const getDisplayComposition = (composition = "") => {
+  const firstWords = getCompositionFirstWords(composition);
+  const first = firstWords.split(/\s+/)[0] || "";
+  const metals = ["gold", "silver", "platinum", "palladium"];
+  return metals.includes(first.toLowerCase()) ? firstWords : "Alloy";
+};
+
+/**
  * Builds two-line HTML showing source and last sync info for a metal
  *
  * @param {string} metalName - Metal name ('Silver', 'Gold', 'Platinum', 'Palladium')

--- a/tests/display-composition.test.js
+++ b/tests/display-composition.test.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+// Stub minimal browser environment for utils
+global.window = global;
+global.document = {};
+
+vm.runInThisContext(fs.readFileSync('js/utils.js', 'utf8'));
+
+assert.strictEqual(getDisplayComposition('Gold Plated Silver'), 'Gold Plated', 'Should retain primary metal compositions');
+assert.strictEqual(getDisplayComposition('Copper Nickel'), 'Alloy', 'Non-precious compositions display as Alloy');
+assert.strictEqual(getDisplayComposition(''), 'Alloy', 'Empty composition defaults to Alloy');
+
+console.log('All display composition tests passed');


### PR DESCRIPTION
## Summary
- add getDisplayComposition helper to collapse non-precious compositions to "Alloy"
- render composition column with raw value for filtering but "Alloy" when appropriate
- document helper and add unit tests

## Testing
- `for f in tests/*.test.js; do node "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_689a72afbc54832ebfe5d63d7ec7472a