### PR TITLE
Handle unknown acquisition dates gracefully

### DIFF
--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -151,7 +151,7 @@
 | utils.js | pad2 | Pads a number with leading zeros to ensure two-digit format |
 | utils.js | todayStr | Returns current date as ISO string (YYYY-MM-DD) |
 | utils.js | currentMonthKey | Returns current month key in YYYY-MM format |
-| utils.js | parseDate | Parses various date formats into standard YYYY-MM-DD format |
+| utils.js | parseDate | Parses various date formats into standard YYYY-MM-DD format; returns 'Unknown' if invalid |
 | utils.js | formatDisplayDate | Formats a date string into two-digit year ISO format (YY-MM-DD) |
 | utils.js | formatCurrency | Formats a number as a currency string using the default currency |
 | utils.js | formatLossProfit | Formats a profit/loss value with color coding |

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -598,7 +598,7 @@ const filterLink = (field, value, color, displayValue = value, title) => {
   const safe = sanitizeHtml(displayStr);
   const titleStr = title ? String(title) : `Filter by ${displayStr}`;
   const safeTitle = sanitizeHtml(titleStr);
-  const isNA = displayStr === 'N/A' || displayStr === 'Numista Import';
+  const isNA = displayStr === 'N/A' || displayStr === 'Numista Import' || displayStr === 'Unknown';
   const classNames = `filter-text${isNA ? ' na-value' : ''}`;
   const styleAttr = isNA ? '' : ` style="color: ${color};"`;
   return `<span class="${classNames}"${styleAttr} onclick="${escaped}" tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' ')${escaped}" title="${safeTitle}">${safe}</span>`;
@@ -1392,7 +1392,7 @@ const importNumistaCsv = (file, override = false) => {
           const storageLocation = storageLocRaw && storageLocRaw.trim() ? storageLocRaw.trim() : 'Numista Import';
 
           const dateStrRaw = getValue(row, ['Acquisition date', 'Date acquired', 'Date']);
-          const dateStr = dateStrRaw && dateStrRaw.trim() ? dateStrRaw.trim() : todayStr();
+          const dateStr = dateStrRaw && dateStrRaw.trim() ? dateStrRaw.trim() : 'Unknown';
           const date = parseDate(dateStr);
 
           const baseNote = (getValue(row, ['Note', 'Notes']) || '').trim();
@@ -1659,7 +1659,7 @@ const importJson = (file) => {
           type: item.type || 'Other',
           weight: parseFloat(item.weight),
           price,
-          date: parseDate(item.date || todayStr()),
+          date: parseDate(item.date),
           purchaseLocation: item.purchaseLocation || "",
           storageLocation: item.storageLocation || "Unknown",
           notes: item.notes || "",

--- a/js/utils.js
+++ b/js/utils.js
@@ -266,10 +266,10 @@ const currentMonthKey = () => {
  * based on date values and context clues.
  *
  * @param {string} dateStr - Date string in any supported format
- * @returns {string} Date in YYYY-MM-DD format, or today's date if parsing fails
+ * @returns {string} Date in YYYY-MM-DD format, or 'Unknown' if parsing fails
  */
 function parseDate(dateStr) {
-  if (!dateStr) return todayStr();
+  if (!dateStr) return 'Unknown';
 
   // Clean the input string
   const cleanDateStr = dateStr.trim();
@@ -348,9 +348,9 @@ function parseDate(dateStr) {
     // Continue to fallback
   }
 
-  // If all parsing fails, return today's date
-  console.warn(`Could not parse date: "${dateStr}", using today's date`);
-  return todayStr();
+  // If all parsing fails, return 'Unknown'
+  console.warn(`Could not parse date: "${dateStr}", returning 'Unknown'`);
+  return 'Unknown';
 }
 
 /**
@@ -559,7 +559,9 @@ const sortInventoryByDateNewestFirst = (data = inventory) => {
   return [...data].sort((a, b) => {
     const dateA = new Date(a.date);
     const dateB = new Date(b.date);
-    return dateB - dateA; // Descending order (newest first)
+    const timeA = isNaN(dateA) ? 0 : dateA.getTime();
+    const timeB = isNaN(dateB) ? 0 : dateB.getTime();
+    return timeB - timeA; // Descending order (newest first)
   });
 };
 


### PR DESCRIPTION
## Summary
- Return `'Unknown'` from `parseDate` when input is empty or unparseable and adjust date sorting to treat unknowns as oldest.
- Default missing Numista acquisition dates to `'Unknown'` and render that value in gray italics via `.na-value` styling.
- Sanitize imported items without forcing today's date, preserving unknown acquisition dates.

## Testing
- `for f in tests/*.test.js; do node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_689a7538746c832e9f6ce69d04830f58