### PR TITLE
feat: store quick filters as objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# StackTrackr v3.04.11
+# StackTrackr v3.04.12
 
 
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -7,6 +7,7 @@ StackTrackr is a comprehensive client-side web application for tracking precious
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
+- **v3.04.12 - Quick filter object storage**: Quick filter now stores criteria as objects for exclude support
 - **v3.04.11 - Collectable column icon**: Collectable table header now uses a treasure chest icon with an accessible label
 - **v3.04.10 - Provider history usage display**: Provider history sections show API usage/quota only, with metal toggles managed in Provider Settings
 - **v3.04.09 - Multi-select & exclusion filters**: Filter modal supports multi-select dropdowns with exclude toggles and chips reflect selections

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,14 @@
 # StackTrackr — Changelog
 
-> **Latest release: v3.04.11**
+> **Latest release: v3.04.12**
 
 
 For upcoming work, see [roadmap](roadmap.md).
 
 ## 📋 Version History
+
+### Version 3.04.12 – Quick filter object storage (2025-08-11)
+- Quick filter stores criteria as object for exclude support
 
 ### Version 3.04.11 – Collectable column icon (2025-08-11)
 - Replaced "Collectable" table header text with treasure chest icon and aria label

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.11**
+> **Latest release: v3.04.12**
 
 
 | File | Function | Description |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,3 +1,20 @@
+# Implementation Summary: Quick Filter Object Storage
+
+> **Latest release: v3.04.12**
+
+## Version Update: 3.04.11 → 3.04.12
+
+## User Requirements Implemented
+
+- Quick filter now stores criteria as an object with exclude flag for consistency with advanced filters
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`js/filters.js`**: Updated `applyQuickFilter` to use object criteria and sync legacy `columnFilters`
+2. **`js/constants.js`**: Bumped version to 3.04.12
+3. **Documentation**: Updated changelog, roadmap, status, structure, and function table
+
 # Implementation Summary: Collectable Column Icon
 
 > **Latest release: v3.04.11**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,6 +2,7 @@
 
 This roadmap outlines upcoming patch releases for the v3.04.x series.
 
+- **v3.04.12** – Quick filter object storage *(completed)*
 - **v3.04.11** – Collectable column icon *(completed)*
 - **v3.04.10** – Provider history usage display *(completed)*
 - **v3.04.09** – Multi-select & exclusion filters *(completed)*

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,11 +1,11 @@
 # Project Status - StackTrackr
 
 
-> **Latest release: v3.04.11**
+> **Latest release: v3.04.12**
 
-## 🎯 Current State: **BETA v3.04.11** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.12** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.04.11** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.04.12** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -25,6 +25,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+ - **v3.04.12 - Quick filter object storage**: Quick filter stores criteria as objects for exclude support
  - **v3.04.11 - Collectable column icon**: Table header uses a treasure chest icon with accessible label
  - **v3.04.10 - Provider history usage display**: Provider history sections show API usage/quota only, with metal toggles managed in Provider Settings
  - **v3.04.09 - Multi-select & exclusion filters**: Filter modal supports multi-select dropdowns with exclude toggles and chips reflect selections

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.04.11**
+> **Latest release: v3.04.12**
 
 
 The repository is organized as follows:

--- a/js/constants.js
+++ b/js/constants.js
@@ -149,7 +149,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.11";
+const APP_VERSION = "3.04.12";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/filters.js
+++ b/js/filters.js
@@ -414,7 +414,7 @@ const filterInventoryAdvanced = () => {
  */
 const applyQuickFilter = (field, value) => {
   // If this exact filter is already active, remove it (toggle behavior)
-  if (activeFilters[field] === value) {
+  if (activeFilters[field]?.values?.[0] === value) {
     delete activeFilters[field];
     // Clean up legacy filters too
     if (field === 'composition' || field === 'type') {
@@ -422,14 +422,14 @@ const applyQuickFilter = (field, value) => {
     }
   } else {
     // Add or replace the filter for this field
-    activeFilters[field] = value;
-    
+    activeFilters[field] = { values: [value], exclude: false };
+
     // Update legacy filters for compatibility
     if (field === 'composition' || field === 'type') {
       columnFilters[field] = value;
     }
   }
-  
+
   // Don't clear search query - allow search + filters to work together
   currentPage = 1;
   renderTable();


### PR DESCRIPTION
## Summary
- store quick filter criteria as `{values: [], exclude: false}` objects and sync legacy `columnFilters`
- bump version to v3.04.12 and update documentation

## Testing
- `node tests/collectable-weight-numista.test.js`
- `node tests/display-composition.test.js`
- `node tests/estimate-numista.test.js`
- `node tests/export-numista-comments.test.js`
- `node tests/search-numista.test.js`
- `node tests/totals-numista.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a779ac784832e9fb78b53c92b20c9