### PR TITLE
Add item weight unit selector with gram conversion

### DIFF
--- a/index.html
+++ b/index.html
@@ -804,8 +804,14 @@
                 <input id="itemQty" min="1" required step="1" type="number" />
               </div>
               <div>
-                <label for="itemWeight">Weight (oz)</label>
-                <input id="itemWeight" min="0.0001" required step="0.0001" type="number" />
+                <label for="itemWeight">Weight</label>
+                <div style="display:flex;align-items:center;gap:var(--spacing);">
+                  <input id="itemWeight" min="0.0001" required step="0.0001" type="number" />
+                  <select id="itemWeightUnit">
+                    <option value="oz">oz</option>
+                    <option value="g">g</option>
+                  </select>
+                </div>
               </div>
             </div>
             <!-- Second row of add form fields -->

--- a/js/events.js
+++ b/js/events.js
@@ -383,6 +383,9 @@ const setupEventListeners = () => {
           const qty = parseInt(elements.itemQty.value, 10);
           const type = elements.itemType.value;
           let weight = parseFloat(elements.itemWeight.value);
+          if (elements.itemWeightUnit.value === "g") {
+            weight = gramsToOzt(weight);
+          }
           weight = isNaN(weight) ? 0 : parseFloat(weight.toFixed(2));
           let price = parseFloat(elements.itemPrice.value);
           price = isNaN(price) || price < 0 ? 0 : price;
@@ -450,6 +453,7 @@ const setupEventListeners = () => {
           saveInventory();
           renderTable();
           this.reset();
+          elements.itemWeightUnit.value = "oz";
           elements.itemDate.value = todayStr();
           if (elements.addModal) elements.addModal.style.display = "none";
         },
@@ -1408,6 +1412,7 @@ const setupSearch = () => {
         () => {
           if (elements.inventoryForm) {
             elements.inventoryForm.reset();
+            elements.itemWeightUnit.value = "oz";
             elements.itemDate.value = todayStr();
           }
           if (elements.addModal) elements.addModal.style.display = "flex";

--- a/js/init.js
+++ b/js/init.js
@@ -62,6 +62,7 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.itemQty = safeGetElement("itemQty", true);
     elements.itemType = safeGetElement("itemType", true);
     elements.itemWeight = safeGetElement("itemWeight", true);
+    elements.itemWeightUnit = safeGetElement("itemWeightUnit", true);
     elements.itemPrice = safeGetElement("itemPrice", true);
     elements.purchaseLocation = safeGetElement("purchaseLocation", true);
     elements.storageLocation = safeGetElement("storageLocation");

--- a/js/state.js
+++ b/js/state.js
@@ -51,6 +51,7 @@ const elements = {
   itemQty: null,
   itemType: null,
   itemWeight: null,
+  itemWeightUnit: null,
   itemPrice: null,
   purchaseLocation: null,
   storageLocation: null,


### PR DESCRIPTION
## Summary
- Add weight unit dropdown (oz/g) to new item form
- Convert gram input to troy ounces before storing inventory
- Reset unit selector to oz whenever the form is cleared

## Testing
- `for file in tests/*.test.js; do echo "Running $file"; node $file; done`

------
https://chatgpt.com/codex/tasks/task_e_689a792ba0ec832e92556ecf90e3929a