### PR TITLE
Use contextual colors for active filter chips

### DIFF
--- a/js/filters.js
+++ b/js/filters.js
@@ -273,7 +273,30 @@ const renderActiveFilters = () => {
   filters.forEach((f, i) => {
     const chip = document.createElement('span');
     chip.className = 'filter-chip';
-    chip.style.backgroundColor = colors[i % colors.length];
+    const firstValue = String(f.value).split(', ')[0];
+    let color;
+    switch (f.field) {
+      case 'type':
+        color = getTypeColor(firstValue);
+        break;
+      case 'composition': {
+        let key = firstValue;
+        if (!METAL_COLORS[key]) {
+          key = getCompositionFirstWords(key);
+        }
+        color = METAL_COLORS[key];
+        break;
+      }
+      case 'purchaseLocation':
+        color = getPurchaseLocationColor(firstValue);
+        break;
+      case 'storageLocation':
+        color = getStorageLocationColor(firstValue);
+        break;
+      default:
+        color = colors[i % colors.length];
+    }
+    chip.style.backgroundColor = color || colors[i % colors.length];
     const label = f.field === 'search'
       ? `${f.value}`
       : `${labels[f.field] || f.field}: ${f.value}${f.exclude ? ' (exclude)' : ''}`;


### PR DESCRIPTION
## Summary
- Replace rotating colors for active filters with contextual color mappings
- Utilize type, metal, purchase, and storage color helpers when available
- Fall back to existing color palette for unmapped filter fields

## Testing
- `for f in tests/*.test.js; do echo Running $f; node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_689a7f3ea778832e92f731f48ee56982