### PR TITLE
Inline SVG logo with theme-based rendering

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -173,26 +173,17 @@ label {
   box-shadow: var(--shadow-sm);
 }
 
-.app-title {
+.app-logo {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  margin-right: auto;
 }
 
-.app-title h1 {
-  font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
-  font-weight: 700;
-  font-size: 2rem;
-  margin: 0;
-  background: linear-gradient(135deg, var(--primary), var(--primary-hover));
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-clip: text;
-}
-
-.app-subtitle {
-  font-size: 0.9rem;
-  color: var(--text-secondary);
-  margin-top: 0.25rem;
+.app-logo svg {
+  height: 2.5rem;
+  width: auto;
+  max-width: 100%;
+  display: block;
 }
 
 .container {
@@ -2794,7 +2785,7 @@ input:disabled + .slider {
     gap: var(--spacing);
   }
 
-  .app-header h1 {
+  .app-logo {
     margin: 0;
   }
 

--- a/docs/ui_style_guide.md
+++ b/docs/ui_style_guide.md
@@ -40,10 +40,9 @@ The main application header uses the `.app-header` container with a gradient tit
 
 ```html
 <div class="app-header">
-  <div class="app-title">
-    <h1>StackTrackr</h1>
-    <p class="app-subtitle">The open source precious metals tracking tool.</p>
-  </div>
+  <h1 class="app-logo" aria-label="StackTrackr">
+    <!-- inline SVG logo -->
+  </h1>
   <!-- action buttons -->
 </div>
 ```

--- a/index.html
+++ b/index.html
@@ -66,10 +66,26 @@
   <body>
     <!-- Application Header -->
     <div class="app-header">
-      <div class="app-title">
-        <h1>StackTrackr</h1>
-        <p class="app-subtitle">The open source precious metals tracking tool.</p>
-      </div>
+      <h1 class="app-logo" aria-label="StackTrackr">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 300 40" role="img">
+          <defs>
+            <linearGradient id="logo-light" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stop-color="#2563eb" />
+              <stop offset="100%" stop-color="#1d4ed8" />
+            </linearGradient>
+            <linearGradient id="logo-dark" x1="0%" y1="0%" x2="100%" y2="0%">
+              <stop offset="0%" stop-color="#93c5fd" />
+              <stop offset="100%" stop-color="#3b82f6" />
+            </linearGradient>
+          </defs>
+          <g class="light-mode">
+            <text x="0" y="30" font-size="32" font-family="Segoe UI, Tahoma, Geneva, Verdana, sans-serif" fill="url(#logo-light)">StackTrackr</text>
+          </g>
+          <g class="dark-mode" style="display: none">
+            <text x="0" y="30" font-size="32" font-family="Segoe UI, Tahoma, Geneva, Verdana, sans-serif" fill="url(#logo-dark)">StackTrackr</text>
+          </g>
+        </svg>
+      </h1>
       <div style="margin-left: auto; display: flex; gap: 0.5rem">
         <button class="btn" id="aboutBtn" title="About" aria-label="About">
           About 📖

--- a/js/events.js
+++ b/js/events.js
@@ -1501,6 +1501,21 @@ const setupSearch = () => {
 };
 
 /**
+ * Updates logo groups to match current theme
+ */
+const updateLogoTheme = () => {
+  const isDark = document.documentElement.getAttribute("data-theme") === "dark";
+  const logo = document.querySelector(".app-logo");
+  if (!logo) return;
+  const light = logo.querySelector(".light-mode");
+  const dark = logo.querySelector(".dark-mode");
+  if (light && dark) {
+    light.style.display = isDark ? "none" : "";
+    dark.style.display = isDark ? "" : "none";
+  }
+};
+
+/**
  * Sets up theme toggle event listeners
  */
 const updateThemeButton = () => {
@@ -1523,6 +1538,8 @@ const updateThemeButton = () => {
     btn.setAttribute("aria-label", "System theme");
     btn.setAttribute("title", "System theme");
   }
+
+  updateLogoTheme();
 };
 
 window.updateThemeButton = updateThemeButton;


### PR DESCRIPTION
## Summary
- Replace header text block with inline SVG logo using light/dark groups and accessible label.
- Add responsive `.app-logo` styles and mobile tweaks to align logo with header controls.
- Extend theme toggle to show/hide SVG groups based on active theme and update style guide documentation.

## Testing
- `node tests/collectable-weight-numista.test.js`
- `node tests/display-composition.test.js`
- `node tests/estimate-numista.test.js`
- `node tests/export-numista-comments.test.js`
- `node tests/search-numista.test.js`
- `node tests/totals-numista.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689a864f8e04832ebab3c103128cab55