### PR TITLE
fix: use domain branding when available

### DIFF
--- a/js/init.js
+++ b/js/init.js
@@ -280,7 +280,7 @@ document.addEventListener("DOMContentLoaded", () => {
     document.title = getAppTitle();
     const appHeader = document.querySelector(".app-header h1");
     if (appHeader) {
-      const headerBrand = BRANDING_DOMAIN_OVERRIDE || getBrandingName();
+      const headerBrand = getBrandingName();
       appHeader.textContent = headerBrand;
     }
     const aboutVersion = document.getElementById("aboutVersion");

--- a/js/utils.js
+++ b/js/utils.js
@@ -23,9 +23,22 @@ const debugLog = (...args) => {
  *
  * @returns {string} Active branding name
  */
-const getBrandingName = () =>
-  (BRANDING_DOMAIN_OPTIONS.alwaysOverride && BRANDING_DOMAIN_OVERRIDE) ||
-  BRANDING_TITLE;
+let brandingWarned = false;
+const getBrandingName = () => {
+  if (
+    !BRANDING_DOMAIN_OVERRIDE &&
+    !brandingWarned &&
+    typeof window !== "undefined" &&
+    window.location &&
+    window.location.hostname
+  ) {
+    console.warn(
+      `No branding mapping found for domain: ${window.location.hostname}`
+    );
+    brandingWarned = true;
+  }
+  return BRANDING_DOMAIN_OVERRIDE || BRANDING_TITLE;
+};
 
 /**
  * Returns full application title with version when no branding is configured


### PR DESCRIPTION
## Summary
- ensure `getBrandingName` prefers domain-based branding
- warn in console when no branding map exists for the current domain
- simplify init header branding to rely on `getBrandingName`

## Testing
- `for f in tests/*.test.js; do node "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_689a883f4d8c832ea2e1005bc1ae9433