### PR TITLE
Refine table layout, icons, and JSON import

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1549,8 +1549,6 @@ td {
 }
 
 #inventoryTable th[data-column="collectable"] svg {
-    width: 1em;
-    height: 1em;
     display: block;
     margin: 0 auto;
     fill: currentColor;
@@ -1618,16 +1616,20 @@ td .btn {
 }
 
 td .action-btn {
-  width: 4.5rem;
-  margin: 1px auto;
+  width: 2rem;
+  height: 2rem;
+  margin: 0 auto;
   display: flex;
+  align-items: center;
   justify-content: center;
 }
 
 td .action-icon {
-  width: 4.5rem;
-  margin: 1px auto;
+  width: 1.25rem;
+  height: 1.25rem;
+  margin: 0 auto;
   display: flex;
+  align-items: center;
   justify-content: center;
   cursor: pointer;
 }
@@ -2942,3 +2944,33 @@ input:disabled + .slider {
     grid-template-columns: repeat(2, 1fr);
   }
 }
+#inventoryTable th[data-column="collectable"],
+#inventoryTable th[data-column="edit"],
+#inventoryTable th[data-column="notes"],
+#inventoryTable th[data-column="delete"],
+#inventoryTable td[data-column="collectable"],
+#inventoryTable td[data-column="edit"],
+#inventoryTable td[data-column="notes"],
+#inventoryTable td[data-column="delete"] {
+  width: 2rem;
+  height: 2rem;
+  padding: 0.25rem;
+  text-align: center;
+}
+
+.collectable-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.collectable-status svg,
+#inventoryTable th[data-column="collectable"] svg,
+td .action-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.icon-gold { color: #d4af37; }
+.icon-copper { color: #b87333; }

--- a/index.html
+++ b/index.html
@@ -434,9 +434,9 @@
             <tr>
               <th class="shrink" data-column="date">Date</th>
               <th class="shrink" data-column="type">Type</th>
-              <th class="shrink" data-column="composition">Composition</th>
-              <th class="expand" data-column="name">Name</th>
+              <th class="shrink" data-column="metal">Metal</th>
               <th class="shrink" data-column="qty">Qty</th>
+              <th class="expand" data-column="name">Name</th>
               <th class="shrink" data-column="weight">Weight</th>
               <th class="shrink" data-column="purchasePrice" title="USD">Price ($)</th>
               <th class="shrink" data-column="spot" title="USD">Spot ($)</th>
@@ -446,8 +446,8 @@
               <!-- Numista column moved before Collectable -->
               <th class="shrink" data-column="numista">N#</th>
               <th class="shrink" data-column="collectable" aria-label="Collectable" title="Collectable">
-                <svg class="collectable-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-                  <path fill="currentColor" d="M2 8V6a2 2 0 0 1 2-2h16a2 2 0 0 1 2 2v2H2zm0 2h20v9a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2v-9zm9 3v4h2v-4h-2z"/>
+                <svg class="collectable-icon icon-gold" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
+                  <path fill="currentColor" d="M2 17h20l-5-10h-10l-5 10z"/>
                 </svg>
               </th>
               <th class="shrink" data-column="edit" aria-label="Edit" title="Edit">⚙️</th>
@@ -795,7 +795,7 @@
             <!-- First row of add form fields -->
             <div class="grid grid-2">
               <div>
-                <label for="itemMetal">Composition</label>
+                <label for="itemMetal">Metal</label>
                 <select id="itemMetal">
                   <option value="Silver">Silver</option>
                   <option value="Gold">Gold</option>
@@ -921,7 +921,7 @@
           <!-- First row of edit form fields -->
           <div class="grid grid-2">
             <div>
-                <label for="editMetal">Composition</label>
+                <label for="editMetal">Metal</label>
               <select id="editMetal">
                 <option value="Silver">Silver</option>
                 <option value="Gold">Gold</option>
@@ -2222,7 +2222,7 @@
         <div class="modal-body">
           <div class="filters-grid">
             <div class="filter-group">
-              <label for="filterMetal">Metal/Composition</label>
+              <label for="filterMetal">Metal</label>
               <select id="filterMetal" class="filter-select" multiple>
                 <option value="">All Metals</option>
               </select>

--- a/js/events.js
+++ b/js/events.js
@@ -179,7 +179,7 @@ const updateColumnVisibility = () => {
         "spot",
         "weight",
         "qty",
-        "composition",
+        "metal",
       ],
     },
     {
@@ -192,7 +192,7 @@ const updateColumnVisibility = () => {
         "spot",
         "weight",
         "qty",
-        "composition",
+        "metal",
         "type",
       ],
     },
@@ -205,9 +205,9 @@ const updateColumnVisibility = () => {
   const allColumns = [
     "date",
     "type",
-    "composition",
-    "name",
+    "metal",
     "qty",
+    "name",
     "weight",
     "purchasePrice",
     "spot",
@@ -1389,9 +1389,9 @@ const setupSearch = () => {
         function () {
           const value = this.value;
           if (value) {
-            columnFilters.composition = value;
+            columnFilters.metal = value;
           } else {
-            delete columnFilters.composition;
+            delete columnFilters.metal;
           }
           searchQuery = "";
           if (elements.searchInput) elements.searchInput.value = "";

--- a/js/filters.js
+++ b/js/filters.js
@@ -52,12 +52,12 @@ const populateFilterDropdowns = () => {
   const metalSelect = document.getElementById('filterMetal');
   const metalExclude = document.getElementById('filterMetalExclude');
   if (metalSelect) {
-    const selected = activeFilters.composition?.values || [];
+    const selected = activeFilters.metal?.values || [];
     metalSelect.innerHTML = '<option value="">All Metals</option>' +
       metals.map(metal => `<option value="${metal}" ${selected.includes(metal) ? 'selected' : ''}>${metal}</option>`).join('');
   }
   if (metalExclude) {
-    metalExclude.checked = activeFilters.composition?.exclude || false;
+    metalExclude.checked = activeFilters.metal?.exclude || false;
   }
 
   // Populate type filter
@@ -140,7 +140,7 @@ const applyFilters = () => {
   if (metalSelect) {
     const values = Array.from(metalSelect.selectedOptions).map(o => o.value).filter(Boolean);
     if (values.length) {
-      activeFilters.composition = { values, exclude: metalExclude?.checked || false };
+      activeFilters.metal = { values, exclude: metalExclude?.checked || false };
     }
   }
   if (typeSelect) {
@@ -176,8 +176,8 @@ const applyFilters = () => {
 
   // Update the legacy columnFilters for compatibility
   columnFilters = {};
-  if (activeFilters.composition && !activeFilters.composition.exclude && activeFilters.composition.values.length === 1) {
-    columnFilters.composition = activeFilters.composition.values[0];
+  if (activeFilters.metal && !activeFilters.metal.exclude && activeFilters.metal.values.length === 1) {
+    columnFilters.metal = activeFilters.metal.values[0];
   }
   if (activeFilters.type && !activeFilters.type.exclude && activeFilters.type.values.length === 1) {
     columnFilters.type = activeFilters.type.values[0];
@@ -260,7 +260,7 @@ const renderActiveFilters = () => {
 
   const colors = ['var(--primary)', 'var(--secondary)', 'var(--success)', 'var(--warning)', 'var(--danger)', 'var(--info)'];
   const labels = {
-    composition: 'Metal',
+    metal: 'Metal',
     type: 'Type',
     purchaseLocation: 'Purchase Location',
     storageLocation: 'Storage Location',
@@ -279,7 +279,7 @@ const renderActiveFilters = () => {
       case 'type':
         color = getTypeColor(firstValue);
         break;
-      case 'composition': {
+      case 'metal': {
         let key = firstValue;
         if (!METAL_COLORS[key]) {
           key = getCompositionFirstWords(key);
@@ -332,7 +332,7 @@ const filterInventoryAdvanced = () => {
     if (criteria && typeof criteria === 'object' && Array.isArray(criteria.values)) {
       const { values, exclude } = criteria;
       switch (field) {
-        case 'composition': {
+        case 'metal': {
           const lowerVals = values.map(v => v.toLowerCase());
           result = result.filter(item => {
             const itemMetal = getCompositionFirstWords(item.composition || item.metal || '').toLowerCase();
@@ -385,7 +385,7 @@ const filterInventoryAdvanced = () => {
     if (!activeFilters[field]) { // Don't double-filter
       const lower = value.toLowerCase();
       result = result.filter(item => {
-        const rawVal = item[field] ?? (field === 'composition' ? item.metal : '');
+        const rawVal = item[field] ?? (field === 'metal' ? item.metal : '');
         const fieldVal = String(rawVal ?? '').toLowerCase();
         return fieldVal === lower;
       });
@@ -440,7 +440,7 @@ const applyQuickFilter = (field, value) => {
   if (activeFilters[field]?.values?.[0] === value) {
     delete activeFilters[field];
     // Clean up legacy filters too
-    if (field === 'composition' || field === 'type') {
+    if (field === 'metal' || field === 'type') {
       delete columnFilters[field];
     }
   } else {
@@ -448,7 +448,7 @@ const applyQuickFilter = (field, value) => {
     activeFilters[field] = { values: [value], exclude: false };
 
     // Update legacy filters for compatibility
-    if (field === 'composition' || field === 'type') {
+    if (field === 'metal' || field === 'type') {
       columnFilters[field] = value;
     }
   }

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -813,13 +813,13 @@ const renderTable = () => {
       <tr>
       <td class="shrink" data-column="date">${filterLink('date', item.date, 'var(--text-primary)', formatDisplayDate(item.date))}</td>
       <td class="shrink" data-column="type">${filterLink('type', item.type, getTypeColor(item.type))}</td>
-      <td class="shrink" data-column="composition" data-composition="${escapeAttribute(item.composition || item.metal || '')}">${filterLink('composition', item.composition || item.metal || 'Silver', METAL_COLORS[item.metal] || 'var(--primary)', getDisplayComposition(item.composition || item.metal || 'Silver'))}</td>
+      <td class="shrink" data-column="metal" data-metal="${escapeAttribute(item.composition || item.metal || '')}">${filterLink('metal', item.composition || item.metal || 'Silver', METAL_COLORS[item.metal] || 'var(--primary)', getDisplayComposition(item.composition || item.metal || 'Silver'))}</td>
+      <td class="shrink" data-column="qty">
+        ${filterLink('qty', item.qty, 'var(--text-primary)')}
+      </td>
       <td class="expand" data-column="name" style="text-align: left;">
         <span class="inline-edit-icon" role="button" tabindex="0" onclick="startCellEdit(${originalIdx}, 'name', this)" aria-label="Edit name" title="Edit name">✎</span>
         ${filterLink('name', item.name, 'var(--text-primary)')}
-      </td>
-      <td class="shrink" data-column="qty">
-        ${filterLink('qty', item.qty, 'var(--text-primary)')}
       </td>
       <td class="shrink" data-column="weight">
         ${filterLink('weight', item.weight, 'var(--text-primary)', formatWeight(item.weight), item.weight < 1 ? 'Grams (g)' : 'Troy ounces (ozt)')}
@@ -838,7 +838,7 @@ const renderTable = () => {
         ${item.storageLocation === 'Unknown' ? '' : filterLink('storageLocation', item.storageLocation || 'Numista Import', getStorageLocationColor(item.storageLocation || 'Numista Import'))}
       </td>
       <td class="shrink" data-column="numista">${item.numistaId ? `<a href="https://en.numista.com/catalogue/pieces${item.numistaId}.html" target="_blank" rel="noopener" title="View on Numista">N# ${sanitizeHtml(item.numistaId)}</a>` : ''}</td>
-      <td class="shrink" data-column="collectable"><span class="collectable-status" role="button" tabindex="0" onclick="toggleCollectable(${originalIdx})" onkeydown="if(event.key==='Enter'||event.key===' ') toggleCollectable(${originalIdx})" aria-label="Toggle collectable status for ${sanitizeHtml(item.name)}" title="Toggle collectable status" style="color: ${item.isCollectable ? 'var(--success)' : 'var(--text-muted)'}; cursor: pointer;">${item.isCollectable ? 'Yes' : 'No'}</span></td>
+      <td class="shrink" data-column="collectable"><span class="collectable-status" role="button" tabindex="0" onclick="toggleCollectable(${originalIdx})" onkeydown="if(event.key==='Enter'||event.key===' ') toggleCollectable(${originalIdx})" aria-label="Toggle collectable status for ${sanitizeHtml(item.name)}" title="Toggle collectable status">${item.isCollectable ? '<svg class=\"collectable-icon icon-copper\" xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><circle cx=\"12\" cy=\"12\" r=\"10\"/></svg>' : '<svg class=\"collectable-icon icon-gold\" xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"M2 17h20l-5-10h-10l-5 10z\"/></svg>'}</span></td>
       <td class="shrink" data-column="edit"><span class="action-icon" role="button" tabindex="0" onclick="editItem(${originalIdx})" aria-label="Edit ${sanitizeHtml(item.name)}" title="Edit ${sanitizeHtml(item.name)}">⚙️</span></td>
       <td class="shrink" data-column="notes"><span class="action-icon ${item.notes && item.notes.trim() ? 'success' : ''}" role="button" tabindex="0" onclick="showNotes(${originalIdx})" aria-label="View notes" title="View notes">📓</span></td>
       <td class="shrink" data-column="delete"><span class="action-icon danger" role="button" tabindex="0" onclick="deleteItem(${originalIdx})" aria-label="Delete item" title="Delete item">🗑️</span></td>
@@ -1723,40 +1723,70 @@ const importJson = (file) => {
       let processed = 0;
       let importedCount = 0;
 
-      for (const [index, item] of data.entries()) {
+      for (const [index, raw] of data.entries()) {
         processed++;
 
-        // Ensure required fields with defaults
-        let price = parseFloat(item.price);
+        const compositionRaw = raw.composition || raw.metal || 'Silver';
+        const composition = getCompositionFirstWords(compositionRaw);
+        const metal = parseNumistaMetal(composition);
+        const name = raw.name || '';
+        const qty = parseInt(raw.qty ?? raw.quantity ?? 1, 10);
+        const type = normalizeType(raw.type || raw.itemType || 'Other');
+        const weight = parseFloat(raw.weight ?? raw.weightOz ?? 0);
+        const priceStr = raw.price ?? raw.purchasePrice ?? 0;
+        let price = typeof priceStr === 'string'
+          ? parseFloat(priceStr.replace(/[^\d.-]+/g, ''))
+          : parseFloat(priceStr);
         if (price < 0) price = 0;
+        const purchaseLocation = raw.purchaseLocation || '';
+        const storageLocation = raw.storageLocation || 'Unknown';
+        const notes = raw.notes || '';
+        const date = parseDate(raw.date);
+        const isCollectable = raw.isCollectable === true || raw.collectable === true || raw.isCollectable === 'true' || raw.collectable === 'true';
 
-        const processedItem = {
-          metal: item.metal || 'Silver',
-          name: item.name,
-          qty: parseInt(item.qty, 10),
-          type: item.type || 'Other',
-          weight: parseFloat(item.weight),
-          price,
-          date: parseDate(item.date),
-          purchaseLocation: item.purchaseLocation || "",
-          storageLocation: item.storageLocation || "Unknown",
-          notes: item.notes || "",
-          spotPriceAtPurchase: item.spotPriceAtPurchase || spotPrices[item.metal.toLowerCase()],
-          isCollectable: item.isCollectable === true,
-          premiumPerOz: item.premiumPerOz || 0,
-          totalPremium: item.totalPremium || 0,
-          numistaId: item.numistaId || '',
-          serial: item.serial || getNextSerial()
-        };
-
-        // Recalculate premium if needed
-        if (!processedItem.isCollectable && processedItem.spotPriceAtPurchase > 0) {
-          const pricePerOz = processedItem.price / processedItem.weight;
-          processedItem.premiumPerOz = pricePerOz - processedItem.spotPriceAtPurchase;
-          processedItem.totalPremium = processedItem.premiumPerOz * processedItem.qty * processedItem.weight;
+        let spotPriceAtPurchase;
+        if (raw.spotPriceAtPurchase) {
+          spotPriceAtPurchase = parseFloat(raw.spotPriceAtPurchase);
+        } else if (raw.spotPrice || raw.spot) {
+          spotPriceAtPurchase = parseFloat(raw.spotPrice || raw.spot);
+        } else {
+          const metalKey = metal.toLowerCase();
+          spotPriceAtPurchase = isCollectable ? 0 : spotPrices[metalKey];
         }
 
-        // Validate the item
+        let premiumPerOz = 0;
+        let totalPremium = 0;
+        if (!isCollectable && spotPriceAtPurchase > 0) {
+          const pricePerOz = price / (weight || 1);
+          premiumPerOz = pricePerOz - spotPriceAtPurchase;
+          totalPremium = premiumPerOz * qty * weight;
+        }
+
+        const numistaRaw = (raw.numistaId || raw.numista || raw['N#'] || '').toString();
+        const numistaMatch = numistaRaw.match(/\d+/);
+        const numistaId = numistaMatch ? numistaMatch[0] : '';
+        const serial = raw.serial || getNextSerial();
+
+        const processedItem = sanitizeImportedItem({
+          metal,
+          composition,
+          name,
+          qty,
+          type,
+          weight,
+          price,
+          date,
+          purchaseLocation,
+          storageLocation,
+          notes,
+          spotPriceAtPurchase,
+          premiumPerOz,
+          totalPremium,
+          isCollectable,
+          numistaId,
+          serial
+        });
+
         const validation = validateInventoryItem(processedItem);
         if (!validation.isValid) {
           const reason = validation.errors.join(', ');
@@ -1765,6 +1795,7 @@ const importJson = (file) => {
           continue;
         }
 
+        addCompositionOption(composition);
         imported.push(processedItem);
         importedCount++;
         updateImportProgress(processed, importedCount, totalItems);

--- a/js/search.js
+++ b/js/search.js
@@ -18,7 +18,7 @@ const filterInventory = () => {
   Object.entries(columnFilters).forEach(([field, value]) => {
     const lower = value.toLowerCase();
     result = result.filter((item) => {
-      const rawVal = item[field] ?? (field === 'composition' ? item.metal : '');
+      const rawVal = item[field] ?? (field === 'metal' ? item.metal : '');
       const fieldVal = String(rawVal ?? '').toLowerCase();
       return fieldVal === lower;
     });

--- a/js/sorting.js
+++ b/js/sorting.js
@@ -17,9 +17,9 @@ const sortInventory = (data = inventory) => {
     switch(sortColumn) {
       case 0: valA = a.date; valB = b.date; break; // Date
       case 1: valA = a.type; valB = b.type; break; // Type
-      case 2: valA = a.composition || a.metal; valB = b.composition || b.metal; break; // Composition
-      case 3: valA = a.name; valB = b.name; break; // Name
-      case 4: valA = a.qty; valB = b.qty; break; // Qty
+      case 2: valA = a.composition || a.metal; valB = b.composition || b.metal; break; // Metal
+      case 3: valA = a.qty; valB = b.qty; break; // Qty
+      case 4: valA = a.name; valB = b.name; break; // Name
       case 5: valA = a.weight; valB = b.weight; break; // Weight
       case 6: valA = a.price; valB = b.price; break; // Price
       case 7: valA = a.spotPriceAtPurchase; valB = b.spotPriceAtPurchase; break; // Spot


### PR DESCRIPTION
## Summary
- Move quantity before name and rename Composition column to Metal
- Replace collectable column text with gold bar / copper coin icons and normalize action column sizes
- Align JSON import validation with CSV to support older exports

## Testing
- `for f in tests/*.test.js; do node $f; done` *(fails: estimate-numista.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_689a93a92148832ea13fce50a0de1ebc