### PR TITLE
feat: add sepia theme option and persist system mode

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -95,6 +95,48 @@
     0 10px 15px -3px rgb(0 0 0 / 0.3), 0 4px 6px -4px rgb(0 0 0 / 0.3);
 }
 
+[data-theme="sepia"] {
+  /* Primary Colors - Sepia Mode */
+  --primary: #b35c1f;
+  --primary-hover: #934a17;
+  --secondary: #8b7355;
+  --secondary-hover: #6d5c3f;
+  --success: #698f3f;
+  --success-hover: #577a34;
+  --info: #0ea5e9;
+  --warning: #d97706;
+  --warning-hover: #b45309;
+  --danger: #dc2626;
+  --danger-hover: #b91c1c;
+
+  /* Metal-specific Colors - Sepia tone */
+  --silver: #a8a29e;
+  --gold: #b58900;
+  --platinum: #8d8d8d;
+  --palladium: #a58b6f;
+
+  /* Background Colors - Sepia Mode */
+  --bg-primary: #f4ecd8;
+  --bg-secondary: #ede3ce;
+  --bg-tertiary: #e1d5bf;
+  --bg-card: #f4ecd8;
+
+  /* Text Colors - Sepia Mode */
+  --text-primary: #4b3f2f;
+  --text-secondary: #6d5e4b;
+  --text-muted: #9c8d7b;
+
+  /* Border & Shadow - Sepia Mode */
+  --border: #d3c4a8;
+  --border-hover: #c2b396;
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --shadow-lg:
+    0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+
+  filter: sepia(30%);
+}
+
 /* =============================================================================
    BASE STYLES & RESET
    ============================================================================= */

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -131,9 +131,9 @@
 | spot.js | updateManualSpot | Updates spot price for specified metal from user input |
 | spot.js | resetSpot | Resets spot price for specified metal to default or API cached value |
 | spot.js | resetSpotByName | Alternative reset function that works with metal name instead of key |
-| theme.js | setTheme | Sets application theme and updates localStorage |
+| theme.js | setTheme | Sets application theme (dark, light, sepia, or system) and updates localStorage |
 | theme.js | initTheme | Initializes theme based on user preference and system settings |
-| theme.js | toggleTheme | Toggles between dark and light themes |
+| theme.js | toggleTheme | Cycles through dark, light, sepia, and system themes |
 | theme.js | setupSystemThemeListener | Sets up system theme change listener |
 | constants.js | getVersionString | Returns formatted version string |
 | constants.js | injectVersionString | Inserts formatted version string into a target element |

--- a/js/events.js
+++ b/js/events.js
@@ -1547,7 +1547,7 @@ const updateThemeButton = () => {
   if (!btn) return;
   const savedTheme = localStorage.getItem(THEME_KEY);
   const mode = savedTheme ? savedTheme : "system";
-  btn.classList.remove("dark", "light", "system");
+  btn.classList.remove("dark", "light", "sepia", "system");
   btn.classList.add(mode);
   if (mode === "dark") {
     btn.textContent = "🌙";
@@ -1557,6 +1557,10 @@ const updateThemeButton = () => {
     btn.textContent = "☀️";
     btn.setAttribute("aria-label", "Light mode");
     btn.setAttribute("title", "Light mode");
+  } else if (mode === "sepia") {
+    btn.textContent = "📜";
+    btn.setAttribute("aria-label", "Sepia mode");
+    btn.setAttribute("title", "Sepia mode");
   } else {
     btn.textContent = "💻";
     btn.setAttribute("aria-label", "System theme");
@@ -1576,7 +1580,7 @@ const setupThemeToggle = () => {
     if (typeof initTheme === "function") {
       initTheme();
     } else {
-      const savedTheme = localStorage.getItem(THEME_KEY) || "light";
+      const savedTheme = localStorage.getItem(THEME_KEY) || "system";
       setTheme(savedTheme);
     }
 
@@ -1591,7 +1595,7 @@ const setupThemeToggle = () => {
       window
         .matchMedia("(prefers-color-scheme: dark)")
         .addEventListener("change", () => {
-          if (!localStorage.getItem(THEME_KEY)) {
+          if (localStorage.getItem(THEME_KEY) === "system") {
             updateThemeButton();
           }
         });
@@ -1603,10 +1607,12 @@ const setupThemeToggle = () => {
         "click",
         (e) => {
           e.preventDefault();
-          const savedTheme = localStorage.getItem(THEME_KEY);
+          const savedTheme = localStorage.getItem(THEME_KEY) || "system";
           if (savedTheme === "dark") {
             setTheme("light");
           } else if (savedTheme === "light") {
+            setTheme("sepia");
+          } else if (savedTheme === "sepia") {
             setTheme("system");
           } else {
             setTheme("dark");

--- a/js/init.js
+++ b/js/init.js
@@ -396,15 +396,17 @@ function setupBasicEventListeners() {
     };
   }
 
-  // Appearance button (three-state theme toggle)
+  // Appearance button (four-state theme toggle)
   const appearanceBtn = document.getElementById("appearanceBtn");
   if (appearanceBtn) {
     appearanceBtn.onclick = function (e) {
       e.preventDefault();
-      const savedTheme = localStorage.getItem(THEME_KEY);
+      const savedTheme = localStorage.getItem(THEME_KEY) || "system";
       if (savedTheme === "dark") {
         setTheme("light");
       } else if (savedTheme === "light") {
+        setTheme("sepia");
+      } else if (savedTheme === "sepia") {
         setTheme("system");
       } else {
         setTheme("dark");

--- a/js/theme.js
+++ b/js/theme.js
@@ -4,26 +4,27 @@
 /**
  * Sets application theme and updates localStorage
  *
- * @param {string} theme - 'dark', 'light', or 'system'
- */
+ * @param {string} theme - 'dark', 'light', 'sepia', or 'system'
+*/
 const setTheme = (theme) => {
   if (theme === "dark") {
     document.documentElement.setAttribute("data-theme", "dark");
     localStorage.setItem(THEME_KEY, "dark");
+  } else if (theme === "light") {
+    document.documentElement.removeAttribute("data-theme");
+    localStorage.setItem(THEME_KEY, "light");
+  } else if (theme === "sepia") {
+    document.documentElement.setAttribute("data-theme", "sepia");
+    localStorage.setItem(THEME_KEY, "sepia");
   } else {
-    if (theme === "light") {
-      document.documentElement.removeAttribute("data-theme");
-      localStorage.setItem(THEME_KEY, "light");
+    localStorage.setItem(THEME_KEY, "system");
+    const systemPrefersDark =
+      window.matchMedia &&
+      window.matchMedia("(prefers-color-scheme: dark)").matches;
+    if (systemPrefersDark) {
+      document.documentElement.setAttribute("data-theme", "dark");
     } else {
-      localStorage.removeItem(THEME_KEY);
-      const systemPrefersDark =
-        window.matchMedia &&
-        window.matchMedia("(prefers-color-scheme: dark)").matches;
-      if (systemPrefersDark) {
-        document.documentElement.setAttribute("data-theme", "dark");
-      } else {
-        document.documentElement.removeAttribute("data-theme");
-      }
+      document.documentElement.removeAttribute("data-theme");
     }
   }
   if (typeof renderTable === "function") {
@@ -48,11 +49,19 @@ const initTheme = () => {
 };
 
 /**
- * Toggles between dark and light themes
+ * Cycles through available themes
  */
 const toggleTheme = () => {
-  const currentTheme = document.documentElement.getAttribute("data-theme");
-  setTheme(currentTheme === "dark" ? "light" : "dark");
+  const current = localStorage.getItem(THEME_KEY) || "system";
+  if (current === "dark") {
+    setTheme("light");
+  } else if (current === "light") {
+    setTheme("sepia");
+  } else if (current === "sepia") {
+    setTheme("system");
+  } else {
+    setTheme("dark");
+  }
 };
 
 /**
@@ -63,8 +72,8 @@ const setupSystemThemeListener = () => {
     window
       .matchMedia("(prefers-color-scheme: dark)")
       .addEventListener("change", (e) => {
-        // Only auto-switch if user hasn't set a preference
-        if (!localStorage.getItem(THEME_KEY)) {
+        // Only auto-switch if user preference is system
+        if (localStorage.getItem(THEME_KEY) === "system") {
           setTheme(e.matches ? "dark" : "light");
         }
       });


### PR DESCRIPTION
## Summary
- add sepia theme variables and filter
- rotate themes through dark, light, sepia, and system with icon updates
- remember last theme including system

## Testing
- `node tests/collectable-weight-numista.test.js`
- `node tests/display-composition.test.js`
- `node tests/estimate-numista.test.js` (fails: AssertionError [ERR_ASSERTION]: estimate value should be used as purchase price)
- `node tests/export-numista-comments.test.js`
- `node tests/search-numista.test.js`
- `node tests/totals-numista.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689a96f3e240832ea528123f7cc5beb9