### PR TITLE
Fix quick filter for name and price columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# StackTrackr v3.04.17
+# StackTrackr v3.04.18
 
 
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -7,6 +7,7 @@ StackTrackr is a comprehensive client-side web application for tracking precious
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
+- **v3.04.18 - Name and price quick-filter fix**: clicking name or price cells now applies filters correctly
 - **v3.04.17 - Gold & silver responsive logo**: theme-aware SVG with premium gradients and tagline
 - **v3.04.16 - Layout and footer refinements**: silver Change Log button, added spacing, new footer message, safe favicon
 - **v3.04.15 - Footer version injection**: footer displays current `APP_VERSION`

--- a/archive/v_previous/README.md
+++ b/archive/v_previous/README.md
@@ -1,5 +1,5 @@
 
-# StackTrackr v3.04.17
+# StackTrackr v3.04.18
 
 
 StackTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -7,6 +7,7 @@ StackTrackr is a comprehensive client-side web application for tracking precious
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
+- **v3.04.18 - Name and price quick-filter fix**: clicking name or price cells now applies filters correctly
 - **v3.04.17 - Gold & silver responsive logo**: theme-aware SVG with premium gradients and tagline
 - **v3.04.16 - Layout and footer refinements**: silver Change Log button, added spacing, new footer message, safe favicon
 - **v3.04.15 - Footer version injection**: footer displays current `APP_VERSION`

--- a/archive/v_previous/docs/MULTI_AGENT_WORKFLOW.md
+++ b/archive/v_previous/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackTrackr v3.04.17
+# Multi-Agent Development Workflow - StackTrackr v3.04.18
 
 
-> **Latest release: v3.04.17**
+> **Latest release: v3.04.18**
 
 
 ## 🎯 Project Overview
 
 You are contributing to the **StackTrackr v3.04.16**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.04.17 (beta)
+**Current Status**: v3.04.18 (beta)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/archive/v_previous/docs/changelog.md
+++ b/archive/v_previous/docs/changelog.md
@@ -1,11 +1,14 @@
 # StackTrackr — Changelog
 
-> **Latest release: v3.04.17**
+> **Latest release: v3.04.18**
 
 
 For upcoming work, see [roadmap](roadmap.md).
 
 ## 📋 Version History
+
+### Version 3.04.18 – Name and price quick-filter fix (2025-08-12)
+- Clicking name or price cells now applies table filters correctly
 
 ### Version 3.04.17 – Gold & silver responsive logo (2025-08-12)
 - Introduced gold/silver SVG logo with automatic light/dark mode and tagline

--- a/archive/v_previous/docs/functionstable.md
+++ b/archive/v_previous/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.17**
+> **Latest release: v3.04.18**
 
 
 | File | Function | Description |

--- a/archive/v_previous/docs/implementation_summary.md
+++ b/archive/v_previous/docs/implementation_summary.md
@@ -1,6 +1,20 @@
 # Implementation Summary: Gold & Silver Logo
 
-> **Latest release: v3.04.17**
+> **Latest release: v3.04.18**
+
+## Version Update: 3.04.17 → 3.04.18
+
+## User Requirements Implemented
+
+- Fixed quick-filter so clicking name or price cells applies filters
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`js/filters.js`**: Added generic field support for quick filters
+2. **`js/constants.js`**: Bumped version to 3.04.18
+3. **`README.md`** and **docs/**: Updated documentation and changelog entries
+4. **`tests/quick-filter-generic.test.js`**: Ensures name and price filtering works
 
 ## Version Update: 3.04.16 → 3.04.17
 

--- a/archive/v_previous/docs/roadmap.md
+++ b/archive/v_previous/docs/roadmap.md
@@ -2,6 +2,7 @@
 
 This roadmap outlines upcoming patch releases for the v3.04.x series.
 
+- **v3.04.18** – Name and price quick-filter fix *(completed)*
 - **v3.04.17** – Gold & silver responsive logo *(completed)*
 - **v3.04.16** – Layout and footer refinements *(completed)*
 - **v3.04.15** – Footer version injection *(completed)*

--- a/archive/v_previous/docs/status.md
+++ b/archive/v_previous/docs/status.md
@@ -1,9 +1,9 @@
 # Project Status - StackTrackr
 
 
-> **Latest release: v3.04.17**
+> **Latest release: v3.04.18**
 
-## 🎯 Current State: **BETA v3.04.17** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.18** ✅ MAINTAINED & OPTIMIZED
 
 **StackTrackr v3.04.17** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
@@ -25,7 +25,8 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
- - **v3.04.17 - Gold & silver responsive logo**: theme-aware SVG branding and tagline
+- **v3.04.18 - Name and price quick-filter fix**: clicking name or price cells now filters inventory
+- **v3.04.17 - Gold & silver responsive logo**: theme-aware SVG branding and tagline
  - **v3.04.16 - Layout and footer refinements**: silver Change Log button restored, extra spacing, footer message, safe favicon
  - **v3.04.15 - Dynamic footer version**: footer displays `APP_VERSION` automatically
  - **v3.04.14 - UI and filter enhancements**: date sanitization, type summary, icon polish

--- a/archive/v_previous/docs/structure.md
+++ b/archive/v_previous/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.04.17**
+> **Latest release: v3.04.18**
 
 
 The repository is organized as follows:

--- a/archive/v_previous/js/constants.js
+++ b/archive/v_previous/js/constants.js
@@ -149,7 +149,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.17";
+const APP_VERSION = "3.04.18";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/archive/v_previous/js/filters.js
+++ b/archive/v_previous/js/filters.js
@@ -366,6 +366,15 @@ const filterInventoryAdvanced = () => {
             return exclude ? !match : match;
           });
           break;
+        default: {
+          const lowerVals = values.map(v => String(v).toLowerCase());
+          result = result.filter(item => {
+            const fieldVal = String(item[field] ?? '').toLowerCase();
+            const match = lowerVals.includes(fieldVal);
+            return exclude ? !match : match;
+          });
+          break;
+        }
       }
     } else {
       const value = criteria;

--- a/archive/v_previous/tests/quick-filter-generic.test.js
+++ b/archive/v_previous/tests/quick-filter-generic.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+// Minimal environment stubs
+global.inventory = [];
+global.searchQuery = '';
+global.currentPage = 1;
+global.columnFilters = {};
+global.renderTable = () => {};
+global.updateFiltersButtonState = () => {};
+global.renderActiveFilters = () => {};
+global.getCompositionFirstWords = str => str.split(' ')[0];
+global.window = global;
+global.document = { addEventListener: () => {}, getElementById: () => null };
+
+// Load filtering and search modules
+vm.runInThisContext(fs.readFileSync('js/filters.js', 'utf8'));
+vm.runInThisContext(fs.readFileSync('js/search.js', 'utf8'));
+
+// Sample inventory
+inventory = [
+  { name: 'Coin A', price: 10, metal: 'Silver', type: 'Coin' },
+  { name: 'Coin B', price: 20, metal: 'Gold', type: 'Coin' }
+];
+
+// Filter by name
+applyColumnFilter('name', 'Coin A');
+let result = filterInventory();
+assert.strictEqual(result.length, 1, 'filter by name should return one item');
+assert.strictEqual(result[0].name, 'Coin A');
+
+// Reset and filter by price
+activeFilters = {};
+applyColumnFilter('price', 10);
+result = filterInventory();
+assert.strictEqual(result.length, 1, 'filter by price should return one item');
+assert.strictEqual(result[0].price, 10);
+
+console.log('Quick filter generic tests passed');

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackTrackr v3.04.17
+# Multi-Agent Development Workflow - StackTrackr v3.04.18
 
 
-> **Latest release: v3.04.17**
+> **Latest release: v3.04.18**
 
 
 ## 🎯 Project Overview
 
 You are contributing to the **StackTrackr v3.04.16**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.04.17 (beta)
+**Current Status**: v3.04.18 (beta)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,14 @@
 # StackTrackr — Changelog
 
-> **Latest release: v3.04.17**
+> **Latest release: v3.04.18**
 
 
 For upcoming work, see [roadmap](roadmap.md).
 
 ## 📋 Version History
+
+### Version 3.04.18 – Name and price quick-filter fix (2025-08-12)
+- Clicking name or price cells now applies table filters correctly
 
 ### Version 3.04.17 – Gold & silver responsive logo (2025-08-12)
 - Introduced gold/silver SVG logo with automatic light/dark mode and tagline

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.17**
+> **Latest release: v3.04.18**
 
 
 | File | Function | Description |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,6 +1,20 @@
 # Implementation Summary: Gold & Silver Logo
 
-> **Latest release: v3.04.17**
+> **Latest release: v3.04.18**
+
+## Version Update: 3.04.17 → 3.04.18
+
+## User Requirements Implemented
+
+- Fixed quick-filter so clicking name or price cells applies filters
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`js/filters.js`**: Added generic field support for quick filters
+2. **`js/constants.js`**: Bumped version to 3.04.18
+3. **`README.md`** and **docs/**: Updated documentation and changelog entries
+4. **`tests/quick-filter-generic.test.js`**: Ensures name and price filtering works
 
 ## Version Update: 3.04.16 → 3.04.17
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,6 +2,7 @@
 
 This roadmap outlines upcoming patch releases for the v3.04.x series.
 
+- **v3.04.18** – Name and price quick-filter fix *(completed)*
 - **v3.04.17** – Gold & silver responsive logo *(completed)*
 - **v3.04.16** – Layout and footer refinements *(completed)*
 - **v3.04.15** – Footer version injection *(completed)*

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,11 +1,11 @@
 # Project Status - StackTrackr
 
 
-> **Latest release: v3.04.17**
+> **Latest release: v3.04.18**
 
-## 🎯 Current State: **BETA v3.04.17** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.18** ✅ MAINTAINED & OPTIMIZED
 
-**StackTrackr v3.04.17** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackTrackr v3.04.18** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -25,7 +25,8 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
- - **v3.04.17 - Gold & silver responsive logo**: theme-aware SVG branding and tagline
+- **v3.04.18 - Name and price quick-filter fix**: clicking name or price cells now filters inventory
+- **v3.04.17 - Gold & silver responsive logo**: theme-aware SVG branding and tagline
  - **v3.04.16 - Layout and footer refinements**: silver Change Log button restored, extra spacing, footer message, safe favicon
  - **v3.04.15 - Dynamic footer version**: footer displays `APP_VERSION` automatically
  - **v3.04.14 - UI and filter enhancements**: date sanitization, type summary, icon polish

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.04.17**
+> **Latest release: v3.04.18**
 
 
 The repository is organized as follows:

--- a/js/constants.js
+++ b/js/constants.js
@@ -149,7 +149,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.17";
+const APP_VERSION = "3.04.18";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/filters.js
+++ b/js/filters.js
@@ -366,6 +366,15 @@ const filterInventoryAdvanced = () => {
             return exclude ? !match : match;
           });
           break;
+        default: {
+          const lowerVals = values.map(v => String(v).toLowerCase());
+          result = result.filter(item => {
+            const fieldVal = String(item[field] ?? '').toLowerCase();
+            const match = lowerVals.includes(fieldVal);
+            return exclude ? !match : match;
+          });
+          break;
+        }
       }
     } else {
       const value = criteria;

--- a/tests/quick-filter-generic.test.js
+++ b/tests/quick-filter-generic.test.js
@@ -1,0 +1,40 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+// Minimal environment stubs
+global.inventory = [];
+global.searchQuery = '';
+global.currentPage = 1;
+global.columnFilters = {};
+global.renderTable = () => {};
+global.updateFiltersButtonState = () => {};
+global.renderActiveFilters = () => {};
+global.getCompositionFirstWords = str => str.split(' ')[0];
+global.window = global;
+global.document = { addEventListener: () => {}, getElementById: () => null };
+
+// Load filtering and search modules
+vm.runInThisContext(fs.readFileSync('js/filters.js', 'utf8'));
+vm.runInThisContext(fs.readFileSync('js/search.js', 'utf8'));
+
+// Sample inventory
+inventory = [
+  { name: 'Coin A', price: 10, metal: 'Silver', type: 'Coin' },
+  { name: 'Coin B', price: 20, metal: 'Gold', type: 'Coin' }
+];
+
+// Filter by name
+applyColumnFilter('name', 'Coin A');
+let result = filterInventory();
+assert.strictEqual(result.length, 1, 'filter by name should return one item');
+assert.strictEqual(result[0].name, 'Coin A');
+
+// Reset and filter by price
+activeFilters = {};
+applyColumnFilter('price', 10);
+result = filterInventory();
+assert.strictEqual(result.length, 1, 'filter by price should return one item');
+assert.strictEqual(result[0].price, 10);
+
+console.log('Quick filter generic tests passed');


### PR DESCRIPTION
## Summary
- handle generic fields in advanced filters so name and price cells filter correctly
- bump version to 3.04.18 and document quick-filter fix
- add regression test for name and price quick-filter

## Testing
- `node tests/collectable-weight-numista.test.js`
- `node tests/display-composition.test.js`
- `node tests/estimate-numista.test.js`
- `node tests/export-numista-comments.test.js`
- `node tests/search-numista.test.js`
- `node tests/totals-numista.test.js`
- `node tests/quick-filter-generic.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689aa96397d8832e883ca9a88ad59ca8