### PR TITLE
fix: standardize header height and type colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# StackrTrackr v3.04.18
+# StackrTrackr v3.04.21
 
 
 StackrTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -7,6 +7,7 @@ StackrTrackr is a comprehensive client-side web application for tracking preciou
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
+- **v3.04.21 - Header height and type color theming**: consistent header sizing and themed type chips
 - **v3.04.18 - Name and price quick-filter fix**: clicking name or price cells now applies filters correctly
 - **v3.04.17 - Gold & silver responsive logo**: theme-aware SVG with premium gradients and tagline
 - **v3.04.16 - Layout and footer refinements**: silver Change Log button, added spacing, new footer message, safe favicon

--- a/css/styles.css
+++ b/css/styles.css
@@ -42,6 +42,18 @@
   --platinum: #4b5563;
   --palladium: #7c3aed;
 
+  /* Inventory Type Colors */
+  --type-coin-bg: #d97706;
+  --type-coin-text: #ffffff;
+  --type-round-bg: #6b7280;
+  --type-round-text: #ffffff;
+  --type-bar-bg: #eab308;
+  --type-bar-text: #000000;
+  --type-note-bg: #059669;
+  --type-note-text: #ffffff;
+  --type-other-bg: #7c3aed;
+  --type-other-text: #ffffff;
+
   /* Component Spacing */
   --radius: 8px;
   --radius-lg: 12px;
@@ -74,6 +86,18 @@
   --gold: #fbbf24;
   --platinum: #f3f4f6;
   --palladium: #d8b4fe;
+
+  /* Inventory Type Colors */
+  --type-coin-bg: #b45309;
+  --type-coin-text: #ffffff;
+  --type-round-bg: #9ca3af;
+  --type-round-text: #1e293b;
+  --type-bar-bg: #fde047;
+  --type-bar-text: #1e293b;
+  --type-note-bg: #047857;
+  --type-note-text: #ffffff;
+  --type-other-bg: #8b5cf6;
+  --type-other-text: #ffffff;
 
   /* Background Colors - Dark Mode */
   --bg-primary: #0f172a;
@@ -114,6 +138,18 @@
   --gold: #b58900;
   --platinum: #8d8d8d;
   --palladium: #a58b6f;
+
+  /* Inventory Type Colors */
+  --type-coin-bg: #c4650e;
+  --type-coin-text: #ffffff;
+  --type-round-bg: #807363;
+  --type-round-text: #ffffff;
+  --type-bar-bg: #d8a500;
+  --type-bar-text: #3e2f1e;
+  --type-note-bg: #0b7d61;
+  --type-note-text: #ffffff;
+  --type-other-bg: #7b4dbf;
+  --type-other-text: #ffffff;
 
   /* Background Colors - Sepia Mode */
   --bg-primary: #f2e7d5;
@@ -213,6 +249,7 @@ label {
   border-radius: var(--radius-lg);
   border: 1px solid var(--border);
   box-shadow: var(--shadow-sm);
+  min-height: 120px; /* match dark mode banner height */
 }
 
 .app-logo {
@@ -220,6 +257,7 @@ label {
   align-items: center;
   margin-right: auto;
   margin: 0;
+  height: 100%;
 }
 
 .app-logo svg {
@@ -3213,23 +3251,37 @@ th {
   text-align: center !important;
 }
 
-/* Type-specific colors - Unique colors far apart on color wheel */
-.type-coin { background-color: #d97706; color: white; } /* Orange */
-.type-round { background-color: #6b7280; color: white; } /* Gray */
-.type-bar { background-color: #eab308; color: black; } /* Yellow */
-.type-note { background-color: #059669; color: white; } /* Green */
-.type-other { background-color: #7c3aed; color: white; } /* Purple */
+/* Type-specific color helpers */
+.type-coin { color: var(--type-coin-bg); }
+.type-round { color: var(--type-round-bg); }
+.type-bar { color: var(--type-bar-bg); }
+.type-note { color: var(--type-note-bg); }
+.type-other { color: var(--type-other-bg); }
 
 #typeSummary .type-chip {
   padding: 0.15rem 0.5rem;
   border-radius: var(--radius);
   font-size: 0.75rem;
-  color: #fff;
   font-weight: 500;
 }
 
-.type-chip.coin { background-color: #d97706; } /* Orange */
-.type-chip.round { background-color: #6b7280; } /* Gray */
-.type-chip.bar { background-color: #eab308; color: black; } /* Yellow */
-.type-chip.note { background-color: #059669; } /* Green */
-.type-chip.other { background-color: #7c3aed; } /* Purple */
+.type-chip.coin {
+  background-color: var(--type-coin-bg);
+  color: var(--type-coin-text);
+}
+.type-chip.round {
+  background-color: var(--type-round-bg);
+  color: var(--type-round-text);
+}
+.type-chip.bar {
+  background-color: var(--type-bar-bg);
+  color: var(--type-bar-text);
+}
+.type-chip.note {
+  background-color: var(--type-note-bg);
+  color: var(--type-note-text);
+}
+.type-chip.other {
+  background-color: var(--type-other-bg);
+  color: var(--type-other-text);
+}

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,7 +1,8 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.18
+
+# Multi-Agent Development Workflow - StackrTrackr v3.04.21
 
 
-> **Latest release: v3.04.18**
+> **Latest release: v3.04.21**
 
 
 ## 🎯 Project Overview

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,15 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.18**
+> **Latest release: v3.04.21**
 
 
 For upcoming work, see [roadmap](roadmap.md).
 
 ## 📋 Version History
+
+### Version 3.04.21 – Header height and type color theming (2025-08-12)
+- Unified application header height across themes
+- Type summary chips now use static contrasting colors with light, dark, and sepia support
 
 ### Version 3.04.18 – Name and price quick-filter fix (2025-08-12)
 - Clicking name or price cells now applies table filters correctly

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.18**
+> **Latest release: v3.04.21**
 
 
 | File | Function | Description |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,6 +1,21 @@
 # Implementation Summary: Gold & Silver Logo
 
-> **Latest release: v3.04.18**
+> **Latest release: v3.04.21**
+
+## Version Update: 3.04.20 → 3.04.21
+
+## User Requirements Implemented
+
+- Standardized header height across themes
+- Static, contrasting type colors with light, dark, and sepia support
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`css/styles.css`**: Enforced header height and added theme-aware type color variables
+2. **`js/inventory.js`**: Switched to static type color mapping and updated type summary
+3. **`js/constants.js`**: Bumped version to 3.04.21
+4. **Documentation**: Updated changelog and status entries
 
 ## Version Update: 3.04.17 → 3.04.18
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,11 +1,12 @@
 # Project Status - StackrTrackr
 
 
-> **Latest release: v3.04.18**
 
-## 🎯 Current State: **BETA v3.04.18** ✅ MAINTAINED & OPTIMIZED
+> **Latest release: v3.04.21**
 
-**StackrTrackr v3.04.18** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+## 🎯 Current State: **BETA v3.04.21** ✅ MAINTAINED & OPTIMIZED
+
+**StackrTrackr v3.04.21** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -25,6 +26,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.04.21 - Header height and type color theming**: consistent header height and contrasting type chips across themes
 - **v3.04.18 - Name and price quick-filter fix**: clicking name or price cells now filters inventory
 - **v3.04.17 - Gold & silver responsive logo**: theme-aware SVG branding and tagline
  - **v3.04.16 - Layout and footer refinements**: silver Change Log button restored, extra spacing, footer message, safe favicon

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.04.18**
+> **Latest release: v3.04.21**
 
 
 The repository is organized as follows:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.04.04**
+> **Latest release: v3.04.21**
 
 ## Overview 
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -149,7 +149,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.20";
+const APP_VERSION = "3.04.21";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -563,12 +563,18 @@ const METAL_COLORS = {
   Palladium: 'var(--palladium)'
 };
 
-const typeColors = {};
+const typeColors = {
+  Coin: 'var(--type-coin-bg)',
+  Round: 'var(--type-round-bg)',
+  Bar: 'var(--type-bar-bg)',
+  Note: 'var(--type-note-bg)',
+  Other: 'var(--type-other-bg)'
+};
 const purchaseLocationColors = {};
 const storageLocationColors = {};
 
 const getColor = (map, key) => {
-  if (!map[key]) {
+  if (!(key in map)) {
     map[key] = (Object.keys(map).length * 137) % 360; // distribute hues using golden angle
   }
   const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
@@ -604,7 +610,7 @@ const filterLink = (field, value, color, displayValue = value, title) => {
   return `<span class="${classNames}"${styleAttr} onclick="${escaped}" tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' ')${escaped}" title="${safeTitle}">${safe}</span>`;
 };
 
-const getTypeColor = type => getColor(typeColors, type);
+const getTypeColor = type => typeColors[type] || 'var(--type-other-bg)';
 const getPurchaseLocationColor = loc => getColor(purchaseLocationColors, loc);
 const getStorageLocationColor = loc => getColor(storageLocationColors, loc);
 
@@ -780,7 +786,11 @@ const updateTypeSummary = () => {
     return acc;
   }, {});
   el.innerHTML = Object.entries(counts)
-    .map(([type, count]) => `<span class="type-chip" style="background-color:${getTypeColor(type)}">${sanitizeHtml(type)}: ${count}</span>`)
+    .map(([type, count]) => {
+      const safeType = sanitizeHtml(type);
+      const cls = type.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+      return `<span class="type-chip ${cls}">${safeType}: ${count}</span>`;
+    })
     .join('');
 };
 window.updateTypeSummary = updateTypeSummary;


### PR DESCRIPTION
## Summary
- enforce a consistent application header height regardless of theme or SVG logo
- introduce static, contrasting type colors with light, dark, and sepia theme variables
- map inventory types to the new colors and update type summary rendering

## Testing
- `for f in tests/*.test.js; do node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_689ac38faa6c832ea294ed763b81ecad