### PR TITLE
feat: highlight spot price increases

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -625,6 +625,15 @@ input[type="submit"] {
   color: var(--primary);
 }
 
+/* Spot price change indicators */
+.spot-up {
+  color: var(--success);
+}
+
+.spot-down {
+  color: var(--danger);
+}
+
 .spot-card-timestamp {
   font-size: 0.7rem;
   color: var(--text-muted);

--- a/index.html
+++ b/index.html
@@ -236,9 +236,7 @@
           <div class="spot-input platinum">
             <div class="spot-card">
               <div class="spot-card-label">Platinum Spot Price</div>
-              <div class="spot-card-value" id="spotPriceDisplayPlatinum">
-                $ -
-              </div>
+              <div class="spot-card-value" id="spotPriceDisplayPlatinum">$ -</div>
               <div class="spot-card-timestamp" id="spotTimestampPlatinum">
                 No data
               </div>
@@ -292,9 +290,7 @@
           <div class="spot-input palladium">
             <div class="spot-card">
               <div class="spot-card-label">Palladium Spot Price</div>
-              <div class="spot-card-value" id="spotPriceDisplayPalladium">
-                $ -
-              </div>
+              <div class="spot-card-value" id="spotPriceDisplayPalladium">$ -</div>
               <div class="spot-card-timestamp" id="spotTimestampPalladium">
                 No data
               </div>

--- a/js/api.js
+++ b/js/api.js
@@ -701,6 +701,8 @@ const refreshFromCache = () => {
       // Update display
       elements.spotPriceDisplay[metal].textContent = formatCurrency(price);
 
+      updateSpotCardColor(metal, price);
+
       // Record in history as 'cached' to distinguish from fresh API calls
       recordSpot(
         price,
@@ -1149,6 +1151,8 @@ const syncSpotPricesFromApi = async (
         // Update display
         elements.spotPriceDisplay[metal].textContent = formatCurrency(price);
 
+        updateSpotCardColor(metal, price);
+
         // Record in history
         recordSpot(
           price,
@@ -1309,6 +1313,7 @@ const handleProviderSync = async (provider) => {
         localStorage.setItem(metalConfig.spotKey, price.toString());
         spotPrices[metal] = price;
         elements.spotPriceDisplay[metal].textContent = formatCurrency(price);
+        updateSpotCardColor(metal, price);
         recordSpot(
           price,
           "api",
@@ -1591,6 +1596,8 @@ const resetSpotPrice = (metal) => {
   // Update display
   elements.spotPriceDisplay[metalConfig.key].textContent =
     formatCurrency(resetPrice);
+
+  updateSpotCardColor(metalConfig.key, resetPrice);
 
   // Record in history
   recordSpot(resetPrice, source, metalConfig.name, providerName);

--- a/js/spot.js
+++ b/js/spot.js
@@ -37,6 +37,39 @@ const recordSpot = (newSpot, source, metal, provider = null) => {
 };
 
 /**
+ * Updates spot card color based on price movement compared to last history entry
+ *
+ * @param {string} metalKey - Metal key ('silver', 'gold', etc.)
+ * @param {number} newPrice - Newly set spot price
+ */
+const updateSpotCardColor = (metalKey, newPrice) => {
+  const metalConfig = Object.values(METALS).find((m) => m.key === metalKey);
+  if (!metalConfig) return;
+
+  const el = elements.spotPriceDisplay[metalKey];
+  if (!el) return;
+
+  const lastEntry = [...spotHistory]
+    .reverse()
+    .find((e) => e.metal === metalConfig.name);
+
+  if (!lastEntry) {
+    el.classList.remove("spot-up", "spot-down");
+    return;
+  }
+
+  if (newPrice > lastEntry.spot) {
+    el.classList.add("spot-up");
+    el.classList.remove("spot-down");
+  } else if (newPrice < lastEntry.spot) {
+    el.classList.add("spot-down");
+    el.classList.remove("spot-up");
+  } else {
+    el.classList.remove("spot-up", "spot-down");
+  }
+};
+
+/**
  * Fetches and displays current spot prices from localStorage or defaults
  */
 const fetchSpotPrice = () => {
@@ -75,6 +108,9 @@ const fetchSpotPrice = () => {
     if (timestampElement) {
       timestampElement.innerHTML = getLastUpdateTime(metalConfig.name);
     }
+
+    // Update card color based on price movement
+    updateSpotCardColor(metalConfig.key, spotPrices[metalConfig.key]);
   });
 
   updateSummary();
@@ -109,6 +145,8 @@ const updateManualSpot = (metalKey) => {
       spotPrices[metalKey],
     );
   }
+
+  updateSpotCardColor(metalKey, num);
   recordSpot(num, "manual", metalConfig.name);
 
   // Update timestamp display
@@ -167,6 +205,8 @@ const resetSpot = (metalKey) => {
     );
   }
 
+  updateSpotCardColor(metalKey, resetPrice);
+
   // Record in history
   recordSpot(resetPrice, source, metalConfig.name, providerName);
 
@@ -204,3 +244,4 @@ const resetSpotByName = (metalName) => {
 
 // Ensure global availability
 window.fetchSpotPrice = fetchSpotPrice;
+window.updateSpotCardColor = updateSpotCardColor;


### PR DESCRIPTION
## Summary
- add `.spot-up` and `.spot-down` classes for positive or negative spot moves
- update spot prices to recolor cards when prices change
- streamline spot price value markup for consistent class handling

## Testing
- `node tests/collectable-weight-numista.test.js`
- `node tests/display-composition.test.js`
- `node tests/estimate-numista.test.js`
- `node tests/export-numista-comments.test.js`
- `node tests/quick-filter-generic.test.js`
- `node tests/search-numista.test.js`
- `node tests/totals-numista.test.js`

------
https://chatgpt.com/codex/tasks/task_e_689ac6ef5468832eb6175043a5518989