### PR TITLE
Handle historical spot price data

### DIFF
--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -127,7 +127,8 @@
 | sorting.js | sortInventory | Sorts inventory based on current sort column and direction |
 | spot.js | saveSpotHistory | Saves spot history to localStorage |
 | spot.js | loadSpotHistory | Loads spot history from localStorage |
-| spot.js | recordSpot | Records a new spot price entry in history |
+| spot.js | purgeSpotHistory | Removes spot history entries older than a set number of days |
+| spot.js | recordSpot | Records a new spot price entry in history with optional timestamp |
 | spot.js | fetchSpotPrice | Fetches and displays current spot prices from localStorage or defaults |
 | spot.js | updateManualSpot | Updates spot price for specified metal from user input |
 | spot.js | resetSpot | Resets spot price for specified metal to default or API cached value |

--- a/js/api.js
+++ b/js/api.js
@@ -910,14 +910,15 @@ const fetchBatchSpotPrices = async (provider, apiKey, selectedMetals, historyDay
 
     const data = await response.json();
     usage.used++; // Only increment by 1 for batch request
-    
-    const results = providerConfig.parseBatchResponse(data);
-    
+
+    const { current = {}, history = {} } =
+      providerConfig.parseBatchResponse(data) || {};
+
     // Filter results to only include selected metals
     const filteredResults = {};
-    selectedMetals.forEach(metal => {
-      if (results[metal] && results[metal] > 0) {
-        filteredResults[metal] = results[metal];
+    selectedMetals.forEach((metal) => {
+      if (current[metal] && current[metal] > 0) {
+        filteredResults[metal] = current[metal];
       }
     });
 
@@ -925,10 +926,22 @@ const fetchBatchSpotPrices = async (provider, apiKey, selectedMetals, historyDay
       throw new Error("No valid prices retrieved from batch request");
     }
 
+    // Record historical data if provided
+    const providerName = providerConfig.name;
+    Object.entries(history).forEach(([metal, entries]) => {
+      const metalName = METALS[metal]?.name || metal;
+      entries.forEach(({ timestamp, price }) => {
+        recordSpot(price, "api", metalName, providerName, timestamp);
+      });
+    });
+    if (Object.keys(history).length) {
+      renderApiHistoryTable();
+    }
+
     // Update usage
     config.usage[provider] = usage;
     saveApiConfig(config);
-    
+
     return filteredResults;
   } catch (error) {
     throw new Error(`Batch request failed: ${error.message}`);

--- a/js/constants.js
+++ b/js/constants.js
@@ -27,13 +27,35 @@ const API_PROVIDERS = {
     batchSupported: true,
     batchEndpoint: "/metals/spot?api_key={API_KEY}&metals={METALS}&days={DAYS}&currency=USD",
     parseBatchResponse: (data) => {
-      const results = {};
+      const current = {};
+      const history = {};
       if (data.data) {
         Object.entries(data.data).forEach(([metal, info]) => {
-          results[metal] = info.price || info.rate?.price || null;
+          const price = info.price || info.rate?.price || null;
+          if (price) current[metal] = price;
+          if (info.history) {
+            const entries = [];
+            if (Array.isArray(info.history)) {
+              info.history.forEach((h) => {
+                const hPrice = h.price || h.rate?.price || h.value;
+                const ts =
+                  h.timestamp || h.datetime || h.date || h.time || h[0];
+                if (hPrice && ts) entries.push({ timestamp: ts, price: hPrice });
+              });
+            } else if (typeof info.history === "object") {
+              Object.entries(info.history).forEach(([ts, val]) => {
+                const hPrice =
+                  typeof val === "object"
+                    ? val.price || val.rate?.price || val.value
+                    : val;
+                if (hPrice) entries.push({ timestamp: ts, price: hPrice });
+              });
+            }
+            if (entries.length) history[metal] = entries;
+          }
         });
       }
-      return results;
+      return { current, history };
     },
   },
   METALS_API: {
@@ -62,17 +84,44 @@ const API_PROVIDERS = {
     batchSupported: true,
     batchEndpoint: "/latest?access_key={API_KEY}&base=USD&symbols={SYMBOLS}",
     parseBatchResponse: (data) => {
-      const results = {};
-      const symbolMap = { XAG: 'silver', XAU: 'gold', XPT: 'platinum', XPD: 'palladium' };
+      const current = {};
+      const history = {};
+      const symbolMap = {
+        XAG: "silver",
+        XAU: "gold",
+        XPT: "platinum",
+        XPD: "palladium",
+      };
       if (data.rates) {
-        Object.entries(data.rates).forEach(([symbol, rate]) => {
-          const metal = symbolMap[symbol];
-          if (metal && rate) {
-            results[metal] = 1 / rate; // Convert from metal per USD to USD per ounce
-          }
-        });
+        const firstKey = Object.keys(data.rates)[0];
+        if (
+          firstKey &&
+          typeof data.rates[firstKey] === "object" &&
+          /^\d{4}-\d{2}-\d{2}$/.test(firstKey)
+        ) {
+          // Timeseries format: { date: { symbol: rate } }
+          Object.entries(data.rates).forEach(([date, symbols]) => {
+            Object.entries(symbols).forEach(([symbol, rate]) => {
+              const metal = symbolMap[symbol];
+              if (metal && rate) {
+                const price = 1 / rate;
+                if (!history[metal]) history[metal] = [];
+                history[metal].push({
+                  timestamp: `${date} 00:00:00`,
+                  price,
+                });
+                current[metal] = price;
+              }
+            });
+          });
+        } else {
+          Object.entries(data.rates).forEach(([symbol, rate]) => {
+            const metal = symbolMap[symbol];
+            if (metal && rate) current[metal] = 1 / rate;
+          });
+        }
       }
-      return results;
+      return { current, history };
     },
   },
   METAL_PRICE_API: {
@@ -101,17 +150,43 @@ const API_PROVIDERS = {
     batchSupported: true,
     batchEndpoint: "/latest?api_key={API_KEY}&base=USD&currencies={CURRENCIES}",
     parseBatchResponse: (data) => {
-      const results = {};
-      const symbolMap = { XAG: 'silver', XAU: 'gold', XPT: 'platinum', XPD: 'palladium' };
+      const current = {};
+      const history = {};
+      const symbolMap = {
+        XAG: "silver",
+        XAU: "gold",
+        XPT: "platinum",
+        XPD: "palladium",
+      };
       if (data.rates) {
-        Object.entries(data.rates).forEach(([symbol, rate]) => {
-          const metal = symbolMap[symbol];
-          if (metal && rate) {
-            results[metal] = 1 / rate; // Convert from metal per USD to USD per ounce
-          }
-        });
+        const firstKey = Object.keys(data.rates)[0];
+        if (
+          firstKey &&
+          typeof data.rates[firstKey] === "object" &&
+          /^\d{4}-\d{2}-\d{2}$/.test(firstKey)
+        ) {
+          Object.entries(data.rates).forEach(([date, symbols]) => {
+            Object.entries(symbols).forEach(([symbol, rate]) => {
+              const metal = symbolMap[symbol];
+              if (metal && rate) {
+                const price = 1 / rate;
+                if (!history[metal]) history[metal] = [];
+                history[metal].push({
+                  timestamp: `${date} 00:00:00`,
+                  price,
+                });
+                current[metal] = price;
+              }
+            });
+          });
+        } else {
+          Object.entries(data.rates).forEach(([symbol, rate]) => {
+            const metal = symbolMap[symbol];
+            if (metal && rate) current[metal] = 1 / rate;
+          });
+        }
       }
-      return results;
+      return { current, history };
     },
   },
   CUSTOM: {
@@ -135,7 +210,7 @@ const API_PROVIDERS = {
     batchEndpoint: "",
     parseBatchResponse: (data) => {
       // Custom batch parsing would depend on the provider's API format
-      return {};
+      return { current: {}, history: {} };
     },
   },
 };

--- a/js/spot.js
+++ b/js/spot.js
@@ -12,14 +12,38 @@ const saveSpotHistory = () => saveData(SPOT_HISTORY_KEY, spotHistory);
 const loadSpotHistory = () => (spotHistory = loadData(SPOT_HISTORY_KEY, []));
 
 /**
+ * Removes spot history entries older than the specified number of days
+ *
+ * @param {number} days - Number of days to retain
+ */
+const purgeSpotHistory = (days = 180) => {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+  spotHistory = spotHistory.filter(
+    (entry) => new Date(entry.timestamp) >= cutoff,
+  );
+};
+
+/**
  * Records a new spot price entry in history
  *
  * @param {number} newSpot - New spot price value
  * @param {string} source - Source of spot price ('manual', 'api', etc.)
  * @param {string} metal - Metal type ('Silver', 'Gold', 'Platinum', or 'Palladium')
  * @param {string|null} provider - Provider name if source is API-based
+ * @param {string|null} timestamp - Optional ISO timestamp for historical entries
  */
-const recordSpot = (newSpot, source, metal, provider = null) => {
+const recordSpot = (
+  newSpot,
+  source,
+  metal,
+  provider = null,
+  timestamp = null,
+) => {
+  purgeSpotHistory();
+  const entryTimestamp = timestamp
+    ? new Date(timestamp).toISOString().replace("T", " ").slice(0, 19)
+    : new Date().toISOString().replace("T", " ").slice(0, 19);
   if (
     !spotHistory.length ||
     spotHistory[spotHistory.length - 1].spot !== newSpot ||
@@ -30,10 +54,10 @@ const recordSpot = (newSpot, source, metal, provider = null) => {
       metal,
       source,
       provider,
-      timestamp: new Date().toISOString().replace("T", " ").slice(0, 19),
+      timestamp: entryTimestamp,
     });
-    saveSpotHistory();
   }
+  saveSpotHistory();
 };
 
 /**


### PR DESCRIPTION
## Summary
- Parse batch API responses for per-day historical prices and record each entry
- Purge spot history older than 180 days and allow recordSpot to accept timestamps
- Refresh API history table after recording new history entries

## Testing
- `node tests/collectable-weight-numista.test.js`
- `node tests/display-composition.test.js`
- `node tests/estimate-numista.test.js`
- `node tests/export-numista-comments.test.js`
- `node tests/quick-filter-generic.test.js`
- `node tests/search-numista.test.js`
- `node tests/totals-numista.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689ad58fab40832eb7943c034672c48a