### PR TITLE
Limit metals.dev history to 30 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# StackrTrackr v3.04.21
+# StackrTrackr v3.04.22
 
 
 StackrTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -7,6 +7,7 @@ StackrTrackr is a comprehensive client-side web application for tracking preciou
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
+- **v3.04.22 - Metals.dev history limit**: limits Metals.dev API to 30-day history and logs daily prices
 - **v3.04.21 - Header height and type color theming**: consistent header sizing and themed type chips
 - **v3.04.18 - Name and price quick-filter fix**: clicking name or price cells now applies filters correctly
 - **v3.04.17 - Gold & silver responsive logo**: theme-aware SVG with premium gradients and tagline

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -1,8 +1,8 @@
 
-# Multi-Agent Development Workflow - StackrTrackr v3.04.21
+# Multi-Agent Development Workflow - StackrTrackr v3.04.22
 
 
-> **Latest release: v3.04.21**
+> **Latest release: v3.04.22**
 
 
 ## 🎯 Project Overview

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,15 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.21**
+> **Latest release: v3.04.22**
 
 
 For upcoming work, see [roadmap](roadmap.md).
 
 ## 📋 Version History
+
+### Version 3.04.22 – Metals.dev history limit (2025-08-12)
+- Enforced 30-day history limit for Metals.dev API with default 29 days
+- Recorded daily metals.dev price history with normalized timestamps
 
 ### Version 3.04.21 – Header height and type color theming (2025-08-12)
 - Unified application header height across themes

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.21**
+> **Latest release: v3.04.22**
 
 
 | File | Function | Description |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,23 +1,23 @@
 # Implementation Summary: Gold & Silver Logo
 
-> **Latest release: v3.04.21**
+> **Latest release: v3.04.22**
 
-## Version Update: 3.04.20 → 3.04.21
+## Version Update: 3.04.21 → 3.04.22
 
 ## User Requirements Implemented
 
-- Standardized header height across themes
-- Static, contrasting type colors with light, dark, and sepia support
+- Enforced 30-day history limit for Metals.dev API with default 29 days
+- Recorded each Metals.dev historical price in API history table
 
 ## Technical Changes Made
 
 ### Files Modified:
-1. **`css/styles.css`**: Enforced header height and added theme-aware type color variables
-2. **`js/inventory.js`**: Switched to static type color mapping and updated type summary
-3. **`js/constants.js`**: Bumped version to 3.04.21
-4. **Documentation**: Updated changelog and status entries
+1. **`index.html`**: Restricted Metals.dev history input to max 30 days and default 29
+2. **`js/api.js`**: Clamped Metals.dev history days and saved entries with correct timestamps
+3. **`js/constants.js`**: Improved Metals.dev batch response parsing and bumped version to 3.04.22
+4. **Documentation**: Updated changelog and status references
 
-## Version Update: 3.04.17 → 3.04.18
+## Version Update: 3.04.20 → 3.04.21
 
 ## User Requirements Implemented
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,6 +3,7 @@
 This roadmap tracks upcoming goals without committing to specific patch numbers.
 
 ## Patch Goals (v3.04.xx)
+- [x] Enforce Metals.dev 30-day history limit and record daily price history
 - Update milestone process and documentation.
 
 ## Version Goals (v4.x)

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,11 +2,11 @@
 
 
 
-> **Latest release: v3.04.21**
+> **Latest release: v3.04.22**
 
-## 🎯 Current State: **BETA v3.04.21** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.22** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.21** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.22** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -26,6 +26,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.04.22 - Metals.dev history limit**: restricts Metals.dev history requests to 30 days and records daily prices
 - **v3.04.21 - Header height and type color theming**: consistent header height and contrasting type chips across themes
 - **v3.04.18 - Name and price quick-filter fix**: clicking name or price cells now filters inventory
 - **v3.04.17 - Gold & silver responsive logo**: theme-aware SVG branding and tagline

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.04.21**
+> **Latest release: v3.04.22**
 
 
 The repository is organized as follows:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.04.21**
+> **Latest release: v3.04.22**
 
 ## Overview 
 

--- a/index.html
+++ b/index.html
@@ -1788,7 +1788,7 @@
                   <div class="provider-setting-row">
                     <label for="historyDays_METALS_DEV">History Days:</label>
                     <input type="number" id="historyDays_METALS_DEV" class="provider-history-input"
-                           min="1" max="365" value="30" placeholder="1-365">
+                           min="1" max="30" value="29" placeholder="1-30">
                   </div>
 
                   <div class="provider-setting-row">

--- a/js/api.js
+++ b/js/api.js
@@ -76,7 +76,11 @@ const loadApiConfig = () => {
             if (typeof metals[p][m] === "undefined") metals[p][m] = true;
           });
         }
-        if (typeof historyDays[p] !== "number") historyDays[p] = 30;
+        if (typeof historyDays[p] !== "number") {
+          historyDays[p] = p === "METALS_DEV" ? 29 : 30;
+        } else if (p === "METALS_DEV" && historyDays[p] > 30) {
+          historyDays[p] = 30;
+        }
         if (!Array.isArray(historyTimes[p])) historyTimes[p] = [];
       });
       let needsSave = false;
@@ -116,7 +120,7 @@ const loadApiConfig = () => {
   Object.keys(API_PROVIDERS).forEach((p) => {
     usage[p] = { quota: DEFAULT_API_QUOTA, used: 0 };
     metals[p] = { silver: true, gold: true, platinum: true, palladium: true };
-    historyDays[p] = 30;
+    historyDays[p] = p === "METALS_DEV" ? 29 : 30;
     historyTimes[p] = [];
   });
   return {
@@ -255,7 +259,8 @@ const updateBatchCalculation = (provider) => {
   const providerConfig = API_PROVIDERS[provider];
   const selected = config.metals?.[provider] || {};
   const selectedMetals = Object.keys(selected).filter(metal => selected[metal] !== false);
-  const historyDays = parseInt(document.getElementById(`historyDays_${provider}`)?.value || 0);
+  let historyDays = parseInt(document.getElementById(`historyDays_${provider}`)?.value || 0);
+  if (provider === "METALS_DEV" && historyDays > 30) historyDays = 30;
   
   const batchInfoEl = document.getElementById(`batchInfo_${provider}`);
   if (!batchInfoEl) return;
@@ -291,7 +296,9 @@ const updateProviderSettings = (provider) => {
   const historyInput = document.getElementById(`historyDays_${provider}`);
   if (historyInput) {
     if (!config.historyDays) config.historyDays = {};
-    config.historyDays[provider] = parseInt(historyInput.value) || 0;
+    let days = parseInt(historyInput.value) || 0;
+    if (provider === "METALS_DEV" && days > 30) days = 30;
+    config.historyDays[provider] = days;
   }
 
   // Update history times
@@ -583,7 +590,10 @@ const showApiProvidersModal = () => {
       // Set history days
       const historyInput = document.getElementById(`historyDays_${provider}`);
       if (historyInput) {
-        const days = config.historyDays?.[provider] || 30;
+        const defaultDays = provider === "METALS_DEV" ? 29 : 30;
+        let days = config.historyDays?.[provider];
+        if (typeof days !== "number" || isNaN(days)) days = defaultDays;
+        if (provider === "METALS_DEV" && days > 30) days = 30;
         historyInput.value = days;
       }
 
@@ -854,6 +864,8 @@ const fetchBatchSpotPrices = async (provider, apiKey, selectedMetals, historyDay
     throw new Error("Provider does not support batch requests");
   }
 
+  if (provider === "METALS_DEV" && historyDays > 30) historyDays = 30;
+
   const config = loadApiConfig();
   const usage = config.usage?.[provider] || { quota: DEFAULT_API_QUOTA, used: 0 };
 
@@ -979,7 +991,8 @@ const fetchSpotPricesFromApi = async (provider, apiKey) => {
   // Try batch request first if supported
   if (providerConfig.batchSupported) {
     try {
-      const historyDays = config.historyDays?.[provider] || 0;
+      let historyDays = config.historyDays?.[provider] || 0;
+      if (provider === "METALS_DEV" && historyDays > 30) historyDays = 30;
       const historyTimes = config.historyTimes?.[provider] || [];
       return await fetchBatchSpotPrices(
         provider,

--- a/js/constants.js
+++ b/js/constants.js
@@ -29,7 +29,28 @@ const API_PROVIDERS = {
     parseBatchResponse: (data) => {
       const current = {};
       const history = {};
-      if (data.data) {
+      if (Array.isArray(data?.data)) {
+        data.data.forEach((entry) => {
+          const ts =
+            entry.timestamp || entry.datetime || entry.date || entry.time || entry[0];
+          const metalsData = entry.metals || entry.prices || entry;
+          Object.entries(metalsData).forEach(([metal, val]) => {
+            if (["timestamp", "datetime", "date", "time"].includes(metal)) return;
+            const hPrice =
+              val.price || val.rate?.price || val.value || val;
+            if (hPrice) {
+              const key = metal.toLowerCase();
+              if (!history[key]) history[key] = [];
+              const tsNorm =
+                typeof ts === "string" && /^\d{4}-\d{2}-\d{2}$/.test(ts)
+                  ? `${ts} 00:00:00`
+                  : ts;
+              history[key].push({ timestamp: tsNorm, price: hPrice });
+              current[key] = hPrice;
+            }
+          });
+        });
+      } else if (data?.data) {
         Object.entries(data.data).forEach(([metal, info]) => {
           const price = info.price || info.rate?.price || null;
           if (price) current[metal] = price;
@@ -40,7 +61,13 @@ const API_PROVIDERS = {
                 const hPrice = h.price || h.rate?.price || h.value;
                 const ts =
                   h.timestamp || h.datetime || h.date || h.time || h[0];
-                if (hPrice && ts) entries.push({ timestamp: ts, price: hPrice });
+                if (hPrice && ts) {
+                  const tsNorm =
+                    typeof ts === "string" && /^\d{4}-\d{2}-\d{2}$/.test(ts)
+                      ? `${ts} 00:00:00`
+                      : ts;
+                  entries.push({ timestamp: tsNorm, price: hPrice });
+                }
               });
             } else if (typeof info.history === "object") {
               Object.entries(info.history).forEach(([ts, val]) => {
@@ -48,7 +75,13 @@ const API_PROVIDERS = {
                   typeof val === "object"
                     ? val.price || val.rate?.price || val.value
                     : val;
-                if (hPrice) entries.push({ timestamp: ts, price: hPrice });
+                if (hPrice) {
+                  const tsNorm =
+                    typeof ts === "string" && /^\d{4}-\d{2}-\d{2}$/.test(ts)
+                      ? `${ts} 00:00:00`
+                      : ts;
+                  entries.push({ timestamp: tsNorm, price: hPrice });
+                }
               });
             }
             if (entries.length) history[metal] = entries;
@@ -224,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.21";
+const APP_VERSION = "3.04.22";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting


### PR DESCRIPTION
## Summary
- Restrict Metals.dev history input to a default 29 days and cap requests at 30 days
- Parse Metals.dev timeseries data and log each day's price with normalized timestamps
- Bump version to 3.04.22 and update project documentation

## Testing
- `node tests/collectable-weight-numista.test.js && node tests/display-composition.test.js && node tests/estimate-numista.test.js && node tests/export-numista-comments.test.js && node tests/quick-filter-generic.test.js && node tests/search-numista.test.js && node tests/totals-numista.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689ad80c6130832e87d41b9581739c6f