### PR TITLE
Show Numista reference column

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1685,11 +1685,6 @@ td {
   display: none;
 }
 
-#inventoryTable th[data-column="numista"],
-#inventoryTable td[data-column="numista"] {
-    display: none;
-}
-
 #inventoryTable th[data-column="collectable"] svg {
     display: block;
     margin: 0 auto;

--- a/js/events.js
+++ b/js/events.js
@@ -214,6 +214,7 @@ const updateColumnVisibility = () => {
     "premium",
     "purchaseLocation",
     "storageLocation",
+    "numista",
     "collectable",
     "notes",
     "delete",


### PR DESCRIPTION
## Summary
- Remove CSS rule hiding the Numista (N#) column so references are visible.
- Include `numista` in responsive column list to manage visibility like other columns.

## Testing
- `for f in tests/*.test.js; do node "$f"; done`
- Verified sample Numista link generation with `node` snippet.

------
https://chatgpt.com/codex/tasks/task_e_689adf779758832ea8afac0ab5137972