### PR TITLE
fix: align action columns and theme controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# StackrTrackr v3.04.22
+# StackrTrackr v3.04.23
 
 
 StackrTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -7,6 +7,7 @@ StackrTrackr is a comprehensive client-side web application for tracking preciou
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
+- **v3.04.23 - Inventory actions alignment**: row icons match header order and theme-aware controls
 - **v3.04.22 - Metals.dev history limit**: limits Metals.dev API to 30-day history and logs daily prices
 - **v3.04.21 - Header height and type color theming**: consistent header sizing and themed type chips
 - **v3.04.18 - Name and price quick-filter fix**: clicking name or price cells now applies filters correctly

--- a/docs/MULTI_AGENT_WORKFLOW.md
+++ b/docs/MULTI_AGENT_WORKFLOW.md
@@ -2,7 +2,7 @@
 # Multi-Agent Development Workflow - StackrTrackr v3.04.22
 
 
-> **Latest release: v3.04.22**
+> **Latest release: v3.04.23**
 
 
 ## 🎯 Project Overview

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,15 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.22**
+> **Latest release: v3.04.23**
 
 
 For upcoming work, see [roadmap](roadmap.md).
 
 ## 📋 Version History
+
+### Version 3.04.23 – Inventory actions alignment (2025-08-13)
+- Fixed inventory row action order to Collect, Notes, Edit, Delete
+- Change Log and theme picker buttons now match active theme with next-mode icons
 
 ### Version 3.04.22 – Metals.dev history limit (2025-08-12)
 - Enforced 30-day history limit for Metals.dev API with default 29 days

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.22**
+> **Latest release: v3.04.23**
 
 
 | File | Function | Description |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,6 +1,22 @@
 # Implementation Summary: Gold & Silver Logo
 
-> **Latest release: v3.04.22**
+> **Latest release: v3.04.23**
+
+## Version Update: 3.04.22 → 3.04.23
+
+## User Requirements Implemented
+
+- Corrected inventory action column order to match headers
+- Themed Change Log and theme toggle buttons with next-mode icons
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`js/inventory.js`**: Swapped Notes and Edit columns for proper order
+2. **`js/events.js`**: Theme button displays next mode icon without hard-coded colors
+3. **`index.html`**: Change Log button now uses active theme styling
+4. **`js/constants.js`**: Bumped version to 3.04.23
+5. **Documentation**: Updated README, changelog, roadmap, status, structure, versioning, workflow, and function table
 
 ## Version Update: 3.04.21 → 3.04.22
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -3,6 +3,7 @@
 This roadmap tracks upcoming goals without committing to specific patch numbers.
 
 ## Patch Goals (v3.04.xx)
+- [x] Align inventory action buttons and theme controls
 - [x] Enforce Metals.dev 30-day history limit and record daily price history
 - Update milestone process and documentation.
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,11 +2,11 @@
 
 
 
-> **Latest release: v3.04.22**
+> **Latest release: v3.04.23**
 
-## 🎯 Current State: **BETA v3.04.22** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.23** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.22** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.23** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -26,6 +26,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.04.23 - Inventory actions alignment**: row icons reordered and theme-aware controls
 - **v3.04.22 - Metals.dev history limit**: restricts Metals.dev history requests to 30 days and records daily prices
 - **v3.04.21 - Header height and type color theming**: consistent header height and contrasting type chips across themes
 - **v3.04.18 - Name and price quick-filter fix**: clicking name or price cells now filters inventory

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.04.22**
+> **Latest release: v3.04.23**
 
 
 The repository is organized as follows:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.04.22**
+> **Latest release: v3.04.23**
 
 ## Overview 
 
@@ -9,7 +9,7 @@ The StackrTrackr now uses a dynamic version management system that automatically
 ## How It Works
 
 ### Single Source of Truth
-- Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.04'`
+- Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.23'`
   - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation
@@ -19,7 +19,7 @@ The StackrTrackr now uses a dynamic version management system that automatically
 
 ### Utility Functions
 - `js/constants.js` provides:
-- `getVersionString(prefix)`: Returns formatted version (e.g., "v3.04.04")
+- `getVersionString(prefix)`: Returns formatted version (e.g., "v3.04.23")
   - `injectVersionString(elementId, prefix)`: Inserts formatted version into a target element
 - `js/utils.js` provides:
   - `getAppTitle(baseTitle)`: Returns full app title with version
@@ -31,13 +31,13 @@ To release a new version:
 1. **Update ONLY the constants file:**
    ```javascript
    // In js/constants.js
-    const APP_VERSION = '3.04.04';  // Change this line only
+    const APP_VERSION = '3.04.23';  // Change this line only
    ```
 
 2. **All these will automatically update:**
-  - Page title: "StackrTrackr v3.04.04"
-  - Page heading: "StackrTrackr v3.04.04"
-  - Browser tab title: "StackrTrackr v3.04.04"
+  - Page title: "StackrTrackr v3.04.23"
+  - Page heading: "StackrTrackr v3.04.23"
+  - Browser tab title: "StackrTrackr v3.04.23"
    - App header: "StackrTrackr v3.03.07b"
 
 3. **Update changelog:** Add entry to `/docs/changelog.md` for documentation

--- a/index.html
+++ b/index.html
@@ -543,7 +543,7 @@
       </section>
       <section class="table-controls-section">
         <div class="table-controls">
-          <button type="button" id="changeLogBtn" class="btn silver">Change Log</button>
+          <button type="button" id="changeLogBtn" class="btn">Change Log</button>
           <span class="table-disclaimer"
             >All data is stored locally. Back up often.</span
           >

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.22";
+const APP_VERSION = "3.04.23";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/events.js
+++ b/js/events.js
@@ -1543,24 +1543,19 @@ const updateThemeButton = () => {
   const savedTheme = localStorage.getItem(THEME_KEY);
   const mode = savedTheme ? savedTheme : "system";
   btn.classList.remove("dark", "light", "sepia", "system");
-  btn.classList.add(mode);
-  if (mode === "dark") {
-    btn.textContent = "🌙";
-    btn.setAttribute("aria-label", "Dark mode");
-    btn.setAttribute("title", "Dark mode");
-  } else if (mode === "light") {
-    btn.textContent = "☀️";
-    btn.setAttribute("aria-label", "Light mode");
-    btn.setAttribute("title", "Light mode");
-  } else if (mode === "sepia") {
-    btn.textContent = "📜";
-    btn.setAttribute("aria-label", "Sepia mode");
-    btn.setAttribute("title", "Sepia mode");
-  } else {
-    btn.textContent = "💻";
-    btn.setAttribute("aria-label", "System theme");
-    btn.setAttribute("title", "System theme");
-  }
+
+  const nextMap = { dark: "light", light: "sepia", sepia: "system", system: "dark" };
+  const iconMap = { dark: "🌙", light: "☀️", sepia: "📜", system: "💻" };
+  const labelMap = {
+    dark: "Dark mode",
+    light: "Light mode",
+    sepia: "Sepia mode",
+    system: "System theme",
+  };
+  const next = nextMap[mode];
+  btn.textContent = iconMap[next];
+  btn.setAttribute("aria-label", `Switch to ${labelMap[next]}`);
+  btn.setAttribute("title", `Switch to ${labelMap[next]}`);
 
   updateLogoTheme();
 };

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -862,8 +862,8 @@ const renderTable = () => {
       </td>
       <td class="shrink" data-column="numista">${item.numistaId ? `<a href="https://en.numista.com/catalogue/pieces${item.numistaId}.html" target="_blank" rel="noopener" title="View on Numista">N# ${sanitizeHtml(item.numistaId)}</a>` : ''}</td>
       <td class="icon-col" data-column="collectable"><span class="collectable-status" role="button" tabindex="0" onclick="toggleCollectable(${originalIdx})" onkeydown="if(event.key==='Enter'||event.key===' ') toggleCollectable(${originalIdx})" aria-label="Toggle collectable status for ${sanitizeHtml(item.name)}" title="Toggle collectable status">${item.isCollectable ? '<svg class=\"collectable-icon icon-copper\" xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><circle cx=\"12\" cy=\"12\" r=\"10\"/></svg>' : '<svg class=\"collectable-icon icon-gold\" xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"M3 3h18v18H3V3zm2 2v14h14V5H5zm5 10h6v2H10v-2zm2-8a2 2 0 100 4 2 2 0 000-4z\"/></svg>'}</span></td>
-      <td class="icon-col" data-column="edit"><span class="action-icon" role="button" tabindex="0" onclick="editItem(${originalIdx})" aria-label="Edit ${sanitizeHtml(item.name)}" title="Edit ${sanitizeHtml(item.name)}">⚙️</span></td>
       <td class="icon-col" data-column="notes"><span class="action-icon ${item.notes && item.notes.trim() ? 'success' : ''}" role="button" tabindex="0" onclick="showNotes(${originalIdx})" aria-label="View notes" title="View notes">📓</span></td>
+      <td class="icon-col" data-column="edit"><span class="action-icon" role="button" tabindex="0" onclick="editItem(${originalIdx})" aria-label="Edit ${sanitizeHtml(item.name)}" title="Edit ${sanitizeHtml(item.name)}">⚙️</span></td>
       <td class="icon-col" data-column="delete"><span class="action-icon danger" role="button" tabindex="0" onclick="deleteItem(${originalIdx})" aria-label="Delete item" title="Delete item">🗑️</span></td>
       </tr>
       `);


### PR DESCRIPTION
## Summary
- reorder inventory row action buttons to match header order
- theme-aware Change Log button and theme switcher showing next mode icon
- bump version to 3.04.23 and update docs

## Testing
- `node tests/collectable-weight-numista.test.js`
- `node tests/display-composition.test.js`
- `node tests/estimate-numista.test.js`
- `node tests/export-numista-comments.test.js`
- `node tests/quick-filter-generic.test.js`
- `node tests/search-numista.test.js`
- `node tests/totals-numista.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689af84abd54832e8a0f8c12bbba221d