### PR TITLE
Add spot price trend arrows and history button placeholder

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -634,6 +634,10 @@ input[type="submit"] {
   color: var(--danger);
 }
 
+.spot-unchanged {
+  color: var(--warning);
+}
+
 .spot-card-timestamp {
   font-size: 0.7rem;
   color: var(--text-muted);

--- a/index.html
+++ b/index.html
@@ -151,10 +151,10 @@
               </button>
               <button
                 class="btn spot-action-btn"
-                id="resetBtnSilver"
-                title="Reset to Default/API"
+                id="historyBtnSilver"
+                title="View Spot History"
               >
-                Reset
+                History
               </button>
             </div>
             <div
@@ -205,10 +205,10 @@
               </button>
               <button
                 class="btn spot-action-btn"
-                id="resetBtnGold"
-                title="Reset to Default/API"
+                id="historyBtnGold"
+                title="View Spot History"
               >
-                Reset
+                History
               </button>
             </div>
             <div
@@ -259,10 +259,10 @@
               </button>
               <button
                 class="btn spot-action-btn"
-                id="resetBtnPlatinum"
-                title="Reset to Default/API"
+                id="historyBtnPlatinum"
+                title="View Spot History"
               >
-                Reset
+                History
               </button>
             </div>
             <div
@@ -313,10 +313,10 @@
               </button>
               <button
                 class="btn spot-action-btn"
-                id="resetBtnPalladium"
-                title="Reset to Default/API"
+                id="historyBtnPalladium"
+                title="View Spot History"
               >
-                Reset
+                History
               </button>
             </div>
             <div

--- a/js/events.js
+++ b/js/events.js
@@ -750,7 +750,7 @@ const setupEventListeners = () => {
 
       // Main spot price action buttons
         const addBtn = document.getElementById(`addBtn${metalName}`);
-        const resetBtn = document.getElementById(`resetBtn${metalName}`);
+        const historyBtn = document.getElementById(`historyBtn${metalName}`);
         const syncBtn = document.getElementById(`syncBtn${metalName}`);
         const spotCard = document.querySelector(
           `.spot-input.${metalKey} .spot-card`,
@@ -804,31 +804,15 @@ const setupEventListeners = () => {
         );
       }
 
-      // Reset button
-      if (resetBtn) {
+      // History button (placeholder)
+      if (historyBtn) {
         safeAttachListener(
-          resetBtn,
+          historyBtn,
           "click",
           () => {
-            debugLog(`Reset button clicked for ${metalName}`);
-            if (typeof resetSpotPrice === "function") {
-              resetSpotPrice(metalName);
-            } else {
-              // Fallback reset functionality
-              const defaultPrice = metalConfig.defaultPrice;
-              localStorage.setItem(
-                metalConfig.localStorageKey,
-                defaultPrice.toString(),
-              );
-              spotPrices[metalKey] = defaultPrice;
-              if (elements.spotPriceDisplay[metalKey]) {
-                elements.spotPriceDisplay[metalKey].textContent =
-                  formatCurrency(defaultPrice);
-              }
-              updateSummary();
-            }
+            debugLog(`History button clicked for ${metalName}`);
           },
-          `Reset spot price for ${metalName}`,
+          `Spot history for ${metalName}`,
         );
       }
 

--- a/js/init.js
+++ b/js/init.js
@@ -207,7 +207,7 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.spotPriceDisplay = {};
     elements.userSpotPriceInput = {};
     elements.saveSpotBtn = {};
-    elements.resetSpotBtn = {};
+    elements.historyBtn = {};
 
     Object.values(METALS).forEach((metalConfig) => {
       const metalKey = metalConfig.key;
@@ -225,8 +225,8 @@ document.addEventListener("DOMContentLoaded", () => {
       elements.saveSpotBtn[metalKey] = safeGetElement(
         `saveSpotBtn${metalName}`,
       );
-      elements.resetSpotBtn[metalKey] = safeGetElement(
-        `resetSpotBtn${metalName}`,
+      elements.historyBtn[metalKey] = safeGetElement(
+        `historyBtn${metalName}`,
       );
 
       // Debug log for each metal

--- a/js/spot.js
+++ b/js/spot.js
@@ -77,20 +77,32 @@ const updateSpotCardColor = (metalKey, newPrice) => {
     .reverse()
     .find((e) => e.metal === metalConfig.name);
 
+  let arrow = "";
+  const formatted = typeof formatCurrency === "function"
+    ? formatCurrency(newPrice)
+    : newPrice.toFixed(2);
+
   if (!lastEntry) {
-    el.classList.remove("spot-up", "spot-down");
+    el.classList.remove("spot-up", "spot-down", "spot-unchanged");
+    el.textContent = formatted;
     return;
   }
 
   if (newPrice > lastEntry.spot) {
     el.classList.add("spot-up");
-    el.classList.remove("spot-down");
+    el.classList.remove("spot-down", "spot-unchanged");
+    arrow = "\u25B2"; // Up arrow
   } else if (newPrice < lastEntry.spot) {
     el.classList.add("spot-down");
-    el.classList.remove("spot-up");
+    el.classList.remove("spot-up", "spot-unchanged");
+    arrow = "\u25BC"; // Down arrow
   } else {
+    el.classList.add("spot-unchanged");
     el.classList.remove("spot-up", "spot-down");
+    arrow = "=";
   }
+
+  el.textContent = `${arrow} ${formatted}`.trim();
 };
 
 /**

--- a/js/state.js
+++ b/js/state.js
@@ -41,7 +41,7 @@ const elements = {
   spotPriceDisplay: {},
   userSpotPriceInput: {},
   saveSpotBtn: {},
-  resetSpotBtn: {},
+  historyBtn: {},
 
   // Form elements
   inventoryForm: null,
@@ -63,8 +63,8 @@ const elements = {
   // Spot price buttons
   saveSpotBtnSilver: null,
   saveSpotBtnGold: null,
-  resetSpotBtnSilver: null,
-  resetSpotBtnGold: null,
+  historyBtnSilver: null,
+  historyBtnGold: null,
 
   // Import elements
   importCsvFile: null,


### PR DESCRIPTION
## Summary
- Show price change indicators with green up, red down, or yellow `=` based on last spot record
- Replace Reset spot-price button with a History placeholder for future charting

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_689aff251d90832eb0bd2d9a24c61163