### PR TITLE
Use SVG logo across themes

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -261,13 +261,26 @@ label {
 .app-logo {
   display: flex;
   align-items: center;
-  margin-right: auto;
   margin: 0;
   height: 100%;
 }
 
 .app-logo svg {
   display: block;
+}
+
+.logo-box {
+  display: flex;
+  align-items: center;
+  margin-right: auto;
+  padding: var(--spacing-sm);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+
+[data-theme="dark"] .logo-box {
+  background: var(--bg-primary);
 }
 
 /* StackrTrackr Logo Styles */

--- a/index.html
+++ b/index.html
@@ -67,7 +67,15 @@
   <body>
     <!-- Application Header -->
     <div class="app-header">
-      <h1 class="app-logo" id="appLogo">StackrTrackr</h1>
+      <div class="logo-box">
+        <h1 class="app-logo" id="appLogo" aria-label="StackrTrackr">
+          <img
+            src="./stackrtrackr_text.svg"
+            alt="StackrTrackr logo"
+            class="stackr-logo"
+          />
+        </h1>
+      </div>
       <div style="margin-left: auto; display: flex; gap: 0.5rem">
         <button class="btn" id="aboutBtn" title="About" aria-label="About">
           About 📖

--- a/js/theme.js
+++ b/js/theme.js
@@ -73,13 +73,8 @@ const toggleTheme = () => {
 const updateHeaderLogo = () => {
   const logo = document.getElementById("appLogo");
   if (!logo) return;
-  const currentTheme = document.documentElement.getAttribute("data-theme");
-  if (currentTheme === "dark") {
-    logo.innerHTML =
-      '<img src="./stackrtrackr_text.svg" alt="StackrTrackr logo" class="stackr-logo">';
-  } else {
-    logo.textContent = "StackrTrackr";
-  }
+  logo.innerHTML =
+    '<img src="./stackrtrackr_text.svg" alt="StackrTrackr logo" class="stackr-logo">';
 };
 
 /**


### PR DESCRIPTION
## Summary
- Display SVG banner in the header for all color modes
- Enclose the logo in a themed dark box using existing palette
- Simplify header logo update logic to always render the SVG

## Testing
- `for f in tests/*.test.js; do node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_689b11443b08832ea98bb335968135ca