### PR TITLE
feat: replace white with grays in light theme

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -24,7 +24,7 @@
   --bg-primary: #f8fafc;
   --bg-secondary: #f1f5f9;
   --bg-tertiary: #cbd5e1; /* Darker for better logo contrast */
-  --bg-card: #ffffff;
+  --bg-card: #f9fafb;
 
   /* Text Colors */
   --text-primary: #1e293b;
@@ -47,15 +47,15 @@
 
   /* Inventory Type Colors */
   --type-coin-bg: #d97706;
-  --type-coin-text: #ffffff;
+  --type-coin-text: #f8fafc;
   --type-round-bg: #6b7280;
-  --type-round-text: #ffffff;
+  --type-round-text: #f8fafc;
   --type-bar-bg: #eab308;
   --type-bar-text: #000000;
   --type-note-bg: #059669;
-  --type-note-text: #ffffff;
+  --type-note-text: #f8fafc;
   --type-other-bg: #7c3aed;
-  --type-other-text: #ffffff;
+  --type-other-text: #f8fafc;
 
   /* Component Spacing */
   --radius: 8px;
@@ -270,13 +270,14 @@ label {
 }
 
 .logo-box {
-  display: flex;
+  display: inline-flex;
   align-items: center;
   margin-right: auto;
   padding: var(--spacing-sm);
-  background: var(--bg-tertiary);
+  background: #94a3b8;
   border: 1px solid var(--border);
   border-radius: var(--radius);
+  width: fit-content;
 }
 
 [data-theme="dark"] .logo-box {
@@ -285,10 +286,9 @@ label {
 
 /* StackrTrackr Logo Styles */
 .stackr-logo {
-  max-width: 600px;
-  width: 100%;
+  display: block;
   height: auto;
-  max-height: 120px;
+  max-width: 100%;
 }
 
 /* Theme switching for logo */
@@ -520,7 +520,7 @@ input[type="submit"] {
   overflow: hidden;
   min-height: 2.75rem;
   background: var(--primary);
-  color: white;
+  color: #f8fafc;
 }
 
 .btn:hover {
@@ -543,7 +543,7 @@ input[type="submit"] {
   background: linear-gradient(
     90deg,
     transparent,
-    rgba(255, 255, 255, 0.2),
+    rgba(248, 250, 252, 0.2),
     transparent
   );
   transition: left 0.5s;
@@ -771,7 +771,7 @@ input[type="submit"] {
 .provider-batch-badge {
   display: inline-block;
   background: linear-gradient(135deg, var(--success), var(--success-hover));
-  color: white;
+  color: #f8fafc;
   font-size: 0.75rem;
   font-weight: 500;
   padding: 0.25rem 0.5rem;
@@ -1123,11 +1123,11 @@ input[type="submit"] {
 
 .theme-btn.dark {
   background: #000;
-  color: #fff;
+  color: #f8fafc;
 }
 
 .theme-btn.light {
-  background: #fff;
+  background: var(--bg-card);
   color: #000;
   border: 1px solid var(--border);
 }
@@ -1185,7 +1185,7 @@ input[type="submit"] {
 
 #apiHistoryModal .modal-header {
   background: linear-gradient(135deg, var(--primary), var(--primary-hover));
-  color: white;
+  color: #f8fafc;
   padding: var(--spacing-xl);
   position: relative;
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
@@ -1194,7 +1194,7 @@ input[type="submit"] {
 
 #apiHistoryModal .modal-header h2 {
   margin: 0;
-  color: white;
+  color: #f8fafc;
   text-align: center;
 }
 
@@ -1297,7 +1297,7 @@ input[type="submit"] {
 #apiModal .modal-header,
 #filesModal .modal-header {
   background: linear-gradient(135deg, var(--primary), var(--primary-hover));
-  color: white;
+  color: #f8fafc;
   padding: var(--spacing-xl);
   position: relative;
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
@@ -1307,7 +1307,7 @@ input[type="submit"] {
 #apiModal .modal-header h2,
 #filesModal .modal-header h2 {
   margin: 0;
-  color: white;
+  color: #f8fafc;
   text-align: center;
 }
 
@@ -1387,7 +1387,7 @@ input[type="submit"] {
 
 #cloudSyncModal .modal-header {
   background: linear-gradient(135deg, var(--primary), var(--primary-hover));
-  color: white;
+  color: #f8fafc;
   padding: var(--spacing-xl);
   position: relative;
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
@@ -1396,7 +1396,7 @@ input[type="submit"] {
 
 #cloudSyncModal .modal-header h2 {
   margin: 0;
-  color: white;
+  color: #f8fafc;
   text-align: center;
 }
 
@@ -1418,7 +1418,7 @@ input[type="submit"] {
 
 #apiProvidersModal .modal-header {
   background: linear-gradient(135deg, var(--primary), var(--primary-hover));
-  color: white;
+  color: #f8fafc;
   padding: var(--spacing-xl);
   position: sticky;
   top: 0;
@@ -1428,7 +1428,7 @@ input[type="submit"] {
 
 #apiProvidersModal .modal-header h2 {
   margin: 0;
-  color: white;
+  color: #f8fafc;
   text-align: center;
 }
 
@@ -1460,7 +1460,7 @@ input[type="submit"] {
 #storageReportModal .modal-header,
 #editModal .modal-header {
   background: linear-gradient(135deg, var(--primary), var(--primary-hover));
-  color: white;
+  color: #f8fafc;
   padding: var(--spacing-xl);
   position: relative;
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
@@ -1472,7 +1472,7 @@ input[type="submit"] {
 #storageReportModal .modal-header h2,
 #editModal .modal-header h2 {
   margin: 0;
-  color: white;
+  color: #f8fafc;
   text-align: center;
 }
 
@@ -1931,10 +1931,10 @@ td input:checked + .slider:before {
 }
 
 .modal-content {
-  background: rgba(255, 255, 255, 0.95);
+  background: rgba(248, 250, 252, 0.95);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid rgba(248, 250, 252, 0.2);
   border-radius: var(--radius-lg);
   padding: var(--spacing-xl);
   max-width: 1200px;
@@ -1943,8 +1943,8 @@ td input:checked + .slider:before {
   overflow-y: auto;
   box-shadow: 
     0 25px 50px -12px rgba(0, 0, 0, 0.25),
-    0 0 0 1px rgba(255, 255, 255, 0.05),
-    inset 0 1px 0 rgba(255, 255, 255, 0.1);
+    0 0 0 1px rgba(248, 250, 252, 0.05),
+    inset 0 1px 0 rgba(248, 250, 252, 0.1);
   animation: modalSlideIn 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   position: relative;
 }
@@ -1985,7 +1985,7 @@ td input:checked + .slider:before {
 
 .about-modal-header {
   background: linear-gradient(135deg, var(--primary), var(--primary-hover));
-  color: white;
+  color: #f8fafc;
   padding: var(--spacing-xl);
   position: relative;
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
@@ -1994,7 +1994,7 @@ td input:checked + .slider:before {
 
 .about-modal-header h1 {
   margin: 0;
-  color: white;
+  color: #f8fafc;
   text-align: center;
 }
 
@@ -2021,7 +2021,7 @@ td input:checked + .slider:before {
   background: none;
   border: none;
   font-size: 1.5rem;
-  color: rgba(255, 255, 255, 0.8);
+  color: rgba(248, 250, 252, 0.8);
   cursor: pointer;
   padding: var(--spacing-sm);
   border-radius: var(--radius);
@@ -2034,8 +2034,8 @@ td input:checked + .slider:before {
 }
 
 .modal-close:hover {
-  color: white;
-  background: rgba(255, 255, 255, 0.1);
+  color: #f8fafc;
+  background: rgba(248, 250, 252, 0.1);
 }
 
 .about-modal-body {
@@ -2079,7 +2079,7 @@ td input:checked + .slider:before {
 
 
 .about-alert {
-  background: linear-gradient(135deg, #fef2f2, #fff8f8);
+  background: linear-gradient(135deg, #fef2f2, #f5f5f5);
   border: 1px solid #fecaca;
   border-left: 4px solid var(--danger);
   border-radius: var(--radius);
@@ -2229,7 +2229,7 @@ td input:checked + .slider:before {
 
 .about-accept-btn {
   background: linear-gradient(135deg, var(--success), #047857);
-  color: white;
+  color: #f8fafc;
   font-size: 1.125rem;
   padding: var(--spacing) var(--spacing-xl);
   border: none;
@@ -2502,7 +2502,7 @@ td input:checked + .slider:before {
 
 .pagination-btn.active {
   background: var(--primary);
-  color: white;
+  color: #f8fafc;
   border-color: var(--primary);
   font-weight: 600;
 }
@@ -2551,7 +2551,7 @@ td input:checked + .slider:before {
   width: auto;
   padding: 0.75rem 1.5rem;
   background: var(--secondary);
-  color: white;
+  color: #f8fafc;
 }
 
 #clearSearchBtn:hover {
@@ -2577,7 +2577,7 @@ td input:checked + .slider:before {
   display: inline-flex;
   align-items: center;
   gap: var(--spacing-xs);
-  color: #fff;
+  color: #f8fafc;
   padding: 0.25rem 0.5rem;
   border-radius: var(--radius);
   font-size: 0.75rem;
@@ -2711,7 +2711,7 @@ td input:checked + .slider:before {
   width: 18px;
   left: 3px;
   bottom: 3px;
-  background-color: white;
+  background-color: #f8fafc;
   transition: var(--transition);
   border-radius: 50%;
   box-shadow: var(--shadow-sm);

--- a/js/charts.js
+++ b/js/charts.js
@@ -41,7 +41,7 @@ const generateColors = (count) => {
  */
 const getChartBackgroundColor = () => {
   const isDark = document.documentElement.getAttribute('data-theme') === 'dark';
-  return isDark ? '#1e293b' : '#ffffff';
+  return isDark ? '#1e293b' : '#f8fafc';
 };
 
 /**

--- a/js/utils.js
+++ b/js/utils.js
@@ -1278,7 +1278,7 @@ const getStorageReportCSS = () => {
         --info: #17a2b8;
         --light: #f8f9fa;
         --dark: #343a40;
-        --bg-primary: #ffffff;
+        --bg-primary: #f9fafb;
         --bg-secondary: #f8f9fa;
         --text-primary: #333333;
         --text-secondary: #666666;
@@ -1288,7 +1288,7 @@ const getStorageReportCSS = () => {
     [data-theme="dark"] {
         --bg-primary: #1a1a1a;
         --bg-secondary: #2d2d2d;
-        --text-primary: #ffffff;
+        --text-primary: #f8fafc;
         --text-secondary: #cccccc;
         --border: #404040;
         --light: #2d2d2d;
@@ -1495,19 +1495,19 @@ const getStorageReportCSS = () => {
     
     .btn.premium {
         background: var(--primary);
-        color: white;
+        color: #f8fafc;
         border-color: var(--primary);
     }
     
     .btn.success {
         background: var(--success);
-        color: white;
+        color: #f8fafc;
         border-color: var(--success);
     }
     
     .btn.secondary {
         background: var(--text-secondary);
-        color: white;
+        color: #f8fafc;
         border-color: var(--text-secondary);
     }
     
@@ -1688,7 +1688,7 @@ const getStorageReportCSS = () => {
     
     .print-btn {
         background: var(--primary);
-        color: white;
+        color: #f8fafc;
         border: none;
         padding: 0.75rem 1.5rem;
         border-radius: 0.5rem;
@@ -1789,7 +1789,7 @@ const getStorageReportCSS = () => {
     
     .item-percentage {
         background: var(--primary);
-        color: white;
+        color: #f8fafc;
         padding: 0.25rem 0.5rem;
         border-radius: 1rem;
         font-size: 0.8rem;
@@ -1817,7 +1817,7 @@ const getStorageReportCSS = () => {
     
     .view-details-btn {
         background: var(--success);
-        color: white;
+        color: #f8fafc;
         border: none;
         padding: 0.5rem 1rem;
         border-radius: 0.25rem;
@@ -1844,7 +1844,7 @@ const getStorageReportCSS = () => {
     }
     
     .modal-content-large {
-        background: white;
+        background: #f9fafb;
         border-radius: 0.5rem;
         width: 90%;
         max-width: 800px;
@@ -1856,7 +1856,7 @@ const getStorageReportCSS = () => {
     
     .modal-header {
         background: var(--primary);
-        color: white;
+        color: #f8fafc;
         padding: 1rem;
         display: flex;
         justify-content: space-between;
@@ -1866,7 +1866,7 @@ const getStorageReportCSS = () => {
     .modal-close {
         background: none;
         border: none;
-        color: white;
+        color: #f8fafc;
         font-size: 1.5rem;
         cursor: pointer;
         padding: 0;
@@ -1979,7 +1979,7 @@ const getStorageReportCSS = () => {
     
     @media print {
         body {
-            background: white;
+            background: #f9fafb;
         }
         
         .print-controls {
@@ -2076,7 +2076,7 @@ const getStorageReportJS = () => {
             datasets: [{
                 data: currentChartItems.map(item => item.size),
                 backgroundColor: currentChartItems.map((_, index) => getChartColor(index)),
-                borderColor: isDark ? '#404040' : '#ffffff',
+                borderColor: isDark ? '#404040' : '#f8fafc',
                 borderWidth: 2,
                 hoverBorderWidth: 3,
                 hoverOffset: 10
@@ -2091,9 +2091,9 @@ const getStorageReportJS = () => {
                     display: false
                 },
                 tooltip: {
-                    backgroundColor: isDark ? '#343a40' : '#ffffff',
-                    titleColor: isDark ? '#ffffff' : '#000000',
-                    bodyColor: isDark ? '#ffffff' : '#000000',
+                    backgroundColor: isDark ? '#343a40' : '#f8fafc',
+                    titleColor: isDark ? '#f8fafc' : '#000000',
+                    bodyColor: isDark ? '#f8fafc' : '#000000',
                     borderColor: isDark ? '#6c757d' : '#dee2e6',
                     borderWidth: 1,
                     callbacks: {


### PR DESCRIPTION
## Summary
- remove pure white from light theme variables and component styles
- darken header logo box and auto-size banner svg
- update chart/utility scripts to use light gray backgrounds instead of white

## Testing
- `for f in tests/*.test.js; do node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_689b13682648832e92ba9f5a2ffd5dd3