### PR TITLE
style: standardize Files modal buttons

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -12,6 +12,7 @@
   --success: #059669;
   --success-hover: #047857;
   --info: #0ea5e9;
+  --info-hover: #0284c7;
   --warning: #d97706;
   --warning-hover: #b45309;
   --danger: #dc2626;
@@ -79,6 +80,7 @@
   --success: #10b981;
   --success-hover: #059669;
   --info: #38bdf8;
+  --info-hover: #0ea5e9;
   --warning: #f59e0b;
   --warning-hover: #d97706;
   --danger: #ef4444;
@@ -134,6 +136,7 @@
   --success: #698f3f;
   --success-hover: #577a34;
   --info: #0ea5e9;
+  --info-hover: #0284c7;
   --warning: #d97706;
   --warning-hover: #b45309;
   --danger: #dc2626;
@@ -567,6 +570,14 @@ input[type="submit"] {
 
 .btn.success:hover {
   background: var(--success-hover);
+}
+
+.btn.info {
+  background: var(--info);
+}
+
+.btn.info:hover {
+  background: var(--info-hover);
 }
 
 .btn.secondary {
@@ -2779,18 +2790,6 @@ input:disabled + .slider {
   padding: var(--spacing) var(--spacing-lg);
 }
 
-.import-icon,
-.export-icon {
-  margin-left: 0.25rem;
-}
-
-.import-icon {
-  color: var(--success);
-}
-
-.export-icon {
-  color: var(--info);
-}
 
 /* =============================================================================
    FILTERS MODAL

--- a/index.html
+++ b/index.html
@@ -1642,16 +1642,16 @@
               <div class="import-block">
                 <div class="import-export-grid">
                   <div class="import-csv-grid">
-                    <button class="btn" id="importCsvOverride">Import</button>
-                    <button class="btn" id="importCsvMerge">Merge</button>
+                    <button class="btn danger" id="importCsvOverride">Import</button>
+                    <button class="btn success" id="importCsvMerge">Merge</button>
                     <input accept=".csv" hidden id="importCsvFile" type="file" />
                   </div>
-                  <label class="btn" id="importJsonBtn">
-                    Import JSON <span class="import-icon">⬇️</span>
+                  <label class="btn success" id="importJsonBtn">
+                    Import JSON
                     <input accept=".json" hidden id="importJsonFile" type="file" />
                   </label>
-                  <label class="btn" id="importExcelBtn">
-                    Import Excel <span class="import-icon">⬇️</span>
+                  <label class="btn success" id="importExcelBtn">
+                    Import Excel
                     <input
                       accept=".xlsx,.xls"
                       hidden
@@ -1676,17 +1676,17 @@
               <p class="settings-subtext">Export your data files.</p>
               <div class="export-block">
                 <div class="import-export-grid">
-                  <button class="btn" id="exportCsvBtn">
-                    Export CSV <span class="export-icon">⬆️</span>
+                  <button class="btn info" id="exportCsvBtn">
+                    Export CSV
                   </button>
-                  <button class="btn" id="exportJsonBtn">
-                    Export JSON <span class="export-icon">⬆️</span>
+                  <button class="btn info" id="exportJsonBtn">
+                    Export JSON
                   </button>
-                  <button class="btn" id="exportExcelBtn">
-                    Export Excel <span class="export-icon">⬆️</span>
+                  <button class="btn info" id="exportExcelBtn">
+                    Export Excel
                   </button>
-                  <button class="btn" id="exportPdfBtn">
-                    Export PDF <span class="export-icon">⬆️</span>
+                  <button class="btn info" id="exportPdfBtn">
+                    Export PDF
                   </button>
                 </div>
               </div>
@@ -1698,8 +1698,8 @@
                 <div class="third-party-block">
                   <div class="import-export-grid">
                     <div class="grid grid-2">
-                      <button class="btn" id="importNumistaBtn">Import Numista</button>
-                      <button class="btn" id="mergeNumistaBtn">Merge Numista</button>
+                      <button class="btn success" id="importNumistaBtn">Import Numista</button>
+                      <button class="btn secondary" id="mergeNumistaBtn">Merge Numista</button>
                     </div>
                     <button class="btn warning" id="clearNumistaInventoryBtn">Clear Numista Cache</button>
                     <input type="file" id="numistaImportFile" accept=".csv" hidden />
@@ -1713,9 +1713,9 @@
               <p class="settings-subtext">Define regex rules to map imported fields.</p>
               <div class="third-party-block">
                 <div class="import-export-grid">
-                  <button class="btn" id="addMappingBtn">Add Mapping</button>
-                  <button class="btn" id="applyMappingsBtn">Apply Mappings</button>
-                  <button class="btn" id="clearMappingsBtn">Clear Mappings</button>
+                  <button class="btn secondary" id="addMappingBtn">Add Mapping</button>
+                  <button class="btn success" id="applyMappingsBtn">Apply Mappings</button>
+                  <button class="btn danger" id="clearMappingsBtn">Clear Mappings</button>
                 </div>
                 <div class="beta-warning">⚠️ Custom mapping is a beta feature</div>
               </div>


### PR DESCRIPTION
## Summary
- remove obsolete import/export icon spans and use `.btn` variants in Files modal
- add `--info-hover` theme variable and new `.btn.info` style
- drop deprecated `.import-icon` and `.export-icon` rules

## Testing
- `for f in tests/*.test.js; do node "$f"; done`
- `node - <<'NODE'
const fs=require('fs');
const css=fs.readFileSync('css/styles.css','utf8');
function block(sel){
 const m=css.match(new RegExp(sel+"\\s*{([\\s\\S]*?)}"));
 return m?m[1]:'';
}
function get(b,v){
 const m=b.match(new RegExp('--'+v+'\s*:\s*([^;]+);'));
 return m?m[1].trim():null;
}
const root=block(':root');
const dark=block('\\[data-theme="dark"\\]');
const sepia=block('\\[data-theme="sepia"\\]');
console.log('root', get(root,'info'), get(root,'info-hover'));
console.log('dark', get(dark,'info'), get(dark,'info-hover'));
console.log('sepia', get(sepia,'info'), get(sepia,'info-hover'));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_689b546d6c54832e8e2966f16be1e022