### PR TITLE
Rename Clear Data section heading

### DIFF
--- a/archive/v_previous/index.html
+++ b/archive/v_previous/index.html
@@ -1604,7 +1604,7 @@
             </div>
 
             <div class="settings-card boating-accident-section">
-              <h3>Clear Data</h3>
+              <h3>Backup, Restore, Clear</h3>
               <p class="settings-subtext">Manage local application data.</p>
               <div class="backup-buttons">
                 <button class="btn warning" id="removeInventoryDataBtn">

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.26
+# Multi-Agent Development Workflow - StackrTrackr v3.04.29
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.26**
+> **Latest release: v3.04.29**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.26**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.29**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.04.26 (stable)
+**Current Status**: v3.04.29 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,14 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.28**
+> **Latest release: v3.04.29**
 
 
 For upcoming work, see [roadmap](roadmap.md).
 
 ## 📋 Version History
+
+### Version 3.04.29 – Backup, Restore, Clear Heading (2025-08-12)
+- **Unified Backup Section**: Renamed "Clear Data" settings card to "Backup, Restore, Clear" for clearer data management.
 
 ### Version 3.04.28 – Enhanced Light Theme Styling (2025-08-12)
 - **Improved Light Theme**: Updated light theme to use light/middle grays and light blues for better visual appeal

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -9,6 +9,7 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - [x] Adopt unified logo across all themes
 - [x] Implement new StackrTrackr logo with triple theme support
 - [x] Enhanced light theme with light/middle grays and light blues (v3.04.28)
+- [x] Rename "Clear Data" settings card to "Backup, Restore, Clear" (v3.04.29)
 - Update milestone process and documentation.
 
 ## Version Goals (v4.x)

--- a/index.html
+++ b/index.html
@@ -1815,7 +1815,7 @@
               </div>
 
             <div class="settings-card boating-accident-section">
-              <h3>Clear Data</h3>
+              <h3>Backup, Restore, Clear</h3>
               <p class="settings-subtext">Manage local application data.</p>
               <div class="backup-buttons">
                 <button class="btn warning" id="removeInventoryDataBtn">

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.28";
+const APP_VERSION = "3.04.29";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/tests/test_light_theme.html
+++ b/tests/test_light_theme.html
@@ -106,7 +106,7 @@
     </section>
 
     <div style="margin-top: 2rem; text-align: center;">
-        <p><strong>Testing Light Theme v3.04.28</strong></p>
+        <p><strong>Testing Light Theme v3.04.29</strong></p>
         <p>Colors: Light/middle grays and light blues</p>
         <p><a href="index.html">← Back to Main App</a></p>
     </div>


### PR DESCRIPTION
## Summary
- Rename the Boating Accident settings card from "Clear Data" to "Backup, Restore, Clear".
- Bump app version to 3.04.29 and update roadmap and changelog with the new heading.
- Synchronize multi-agent workflow docs and light theme test with current version.

## Testing
- `python - <<'PY'
import re
with open('index.html') as f:
    content = f.read()
match = re.search(r'class="settings-card boating-accident-section">\s*<h3>([^<]+)</h3>', content)
print(match.group(1))
PY`
- `python - <<'PY'
import re
with open('index.html') as f:
    content = f.read()
section_match = re.search(r'class="settings-card boating-accident-section">(.*?)</div>\s*</div>', content, re.DOTALL)
if section_match:
    section = section_match.group(1)
    buttons = re.findall(r'<button', section)
    print("Buttons in boating-accident-section:", len(buttons))
PY`
- `tidy -q -e index.html` (fails: command not found)
- `apt-get update` (fails: repository not signed)

------
https://chatgpt.com/codex/tasks/task_e_689b76000ad8832e8888ba3b7cbfe495