### PR TITLE
Clarify Numista cache clearing prompt

### DIFF
--- a/js/events.js
+++ b/js/events.js
@@ -1124,7 +1124,11 @@ const setupEventListeners = () => {
         elements.clearNumistaCacheBtn,
         "click",
         function () {
-          if (confirm("Clear Numista cache?")) {
+          if (
+            confirm(
+              "This will remove all cached Numista data from the lookup tables.",
+            )
+          ) {
             localStorage.removeItem('numista-cache');
             alert("Numista cache cleared.");
             elements.clearNumistaCacheBtn.style.display = 'none';


### PR DESCRIPTION
## Summary
- Clarify Numista cache clearing prompt text
- Keep cache-cleared alert accurate and hide button after clearing

## Testing
- `node -e "<script verifying handler>"` (see logs above)
- `for f in tests/*.test.js; do node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_689b77e85fb4832e902a9ff818d743b3