### PR TITLE
Allow URL purchase locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# StackrTrackr v3.04.25
+# StackrTrackr v3.04.30
 
 
 StackrTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -7,6 +7,7 @@ StackrTrackr is a comprehensive client-side web application for tracking preciou
 The public hosted version of the app is available at [stackrtrackr.com](https://stackrtrackr.com).
 
 ## Recent Updates
+- **v3.04.30 - URL-friendly purchase locations**: Purchase Location field accepts web addresses and renders them as clickable links
 - **v3.04.25 - Unified logo**: single SVG logo for all themes, removed theme-specific assets
 - **v3.04.24 - Backup warning theming**: local storage warning uses theme colors with centered type summary and backup link
 - **v3.04.23 - Inventory actions alignment**: row icons match header order and theme-aware controls

--- a/docs/agents/agents.ai
+++ b/docs/agents/agents.ai
@@ -1,7 +1,7 @@
 # StackTrackr Project Instructions
 
 ## CONTEXT
-Precious metals inventory app (v3.04.26+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
+Precious metals inventory app (v3.04.30+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
 
 ## FILES
 - `index.html` - main UI

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.29
+# Multi-Agent Development Workflow - StackrTrackr v3.04.30
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.29**
+> **Latest release: v3.04.30**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.29**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.30**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.04.29 (stable)
+**Current Status**: v3.04.30 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,14 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.29**
+> **Latest release: v3.04.30**
 
 
 For upcoming work, see [roadmap](roadmap.md).
 
 ## 📋 Version History
+
+### Version 3.04.30 – URL Purchase Location Links (2025-08-12)
+- **Clickable Purchase Locations**: Purchase Location accepts web addresses and renders them as hyperlinks.
 
 ### Version 3.04.29 – Backup, Restore, Clear Heading (2025-08-12)
 - **Unified Backup Section**: Renamed "Clear Data" settings card to "Backup, Restore, Clear" for clearer data management.

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.25**
+> **Latest release: v3.04.30**
 
 
 | File | Function | Description |
@@ -100,7 +100,8 @@
 | inventory.js | getNextSerial | Generates a unique serial number for inventory items |
 | inventory.js | getColor |  |
 | inventory.js | escapeAttribute | Escapes text for safe use in HTML attributes |
-| inventory.js | filterLink |  |
+| inventory.js | filterLink | Builds clickable filter span with optional HTML content |
+| inventory.js | formatPurchaseLocation | Detects URLs and wraps Purchase Location in a hyperlink |
 | inventory.js | renderTable |  |
 | inventory.js | updateTypeSummary | Displays colored counts of items by type |
 | inventory.js | updateSummary | Calculates and updates all financial summary displays across the application |
@@ -163,7 +164,8 @@
 | utils.js | formatWeight | Formats a weight in ozt to grams or ounces |
 | utils.js | convertToUsd | Converts amount from specified currency to USD using static rates |
 | utils.js | stripNonAlphanumeric | Removes all characters except letters, numbers, and spaces |
-| utils.js | sanitizeObjectFields | Strips non-alphanumeric characters from all string properties in an object |
+| utils.js | cleanString | Removes HTML tags and control characters while preserving punctuation |
+| utils.js | sanitizeObjectFields | Strips non-alphanumeric characters from string fields except purchaseLocation, which uses cleanString |
 | utils.js | normalizeType | Ensures item type matches predefined options (Coin, Bar, Round, Note, Aurum, Other) |
 | utils.js | mapNumistaType | Maps Numista type strings to internal categories (Coin, Bar, Round, Note, Aurum, Other) |
 | utils.js | parseNumistaMetal | Parses composition into Silver, Gold, Platinum, Palladium, Paper, or Alloy |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,6 +1,6 @@
 # Implementation Summary: Unified Logo
 
-> **Latest release: v3.04.25**
+> **Latest release: v3.04.30**
 
 ## Version Update: 3.04.24 → 3.04.25
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -10,6 +10,7 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - [x] Implement new StackrTrackr logo with triple theme support
 - [x] Enhanced light theme with light/middle grays and light blues (v3.04.28)
 - [x] Rename "Clear Data" settings card to "Backup, Restore, Clear" (v3.04.29)
+- [x] Allow URL purchase locations to render as hyperlinks (v3.04.30)
 - Update milestone process and documentation.
 
 ## Version Goals (v4.x)

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,11 +2,11 @@
 
 
 
-> **Latest release: v3.04.25**
+> **Latest release: v3.04.30**
 
-## 🎯 Current State: **BETA v3.04.25** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.30** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.25** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.30** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.04.25**
+> **Latest release: v3.04.30**
 
 ## Overview 
 
@@ -9,7 +9,7 @@ The StackrTrackr now uses a dynamic version management system that automatically
 ## How It Works
 
 ### Single Source of Truth
-- Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.25'`
+- Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.30'`
   - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.29";
+const APP_VERSION = "3.04.30";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -596,12 +596,12 @@ const escapeAttribute = (text) =>
     .replace(/"/g, '&quot;')
     .replace(/'/g, '&#39;');
 
-const filterLink = (field, value, color, displayValue = value, title) => {
+const filterLink = (field, value, color, displayValue = value, title, allowHtml = false) => {
   const handler = `applyColumnFilter('${field}', ${JSON.stringify(value)})`;
   // Escape characters for safe inline handler usage
   const escaped = escapeAttribute(handler);
   const displayStr = String(displayValue);
-  const safe = sanitizeHtml(displayStr);
+  const safe = allowHtml ? displayStr : sanitizeHtml(displayStr);
   const titleStr = title ? String(title) : `Filter by ${displayStr}`;
   const safeTitle = sanitizeHtml(titleStr);
   const isNA = displayStr === 'N/A' || displayStr === 'Numista Import' || displayStr === 'Unknown';
@@ -613,6 +613,31 @@ const filterLink = (field, value, color, displayValue = value, title) => {
 const getTypeColor = type => typeColors[type] || 'var(--type-other-bg)';
 const getPurchaseLocationColor = loc => getColor(purchaseLocationColors, loc);
 const getStorageLocationColor = loc => getColor(storageLocationColors, loc);
+
+/**
+ * Formats Purchase Location for table display, wrapping URLs in hyperlinks
+ * while preserving filter behavior.
+ *
+ * @param {string} loc - Purchase location value
+ * @returns {string} HTML string for table cell
+ */
+const formatPurchaseLocation = (loc) => {
+  const value = loc || 'Numista Import';
+  const color = getPurchaseLocationColor(value);
+  const urlPattern = /^(https?:\/\/)?[\w.-]+\.[A-Za-z]{2,}(\S*)?$/;
+  if (urlPattern.test(value)) {
+    let href = value;
+    if (!/^https?:\/\//i.test(href)) {
+      href = `https://${href}`;
+    }
+    const safeHref = escapeAttribute(href);
+    const safeText = sanitizeHtml(value);
+    const link = `<a href="${safeHref}" target="_blank" rel="noopener" onclick="event.stopPropagation()">${safeText}</a>`;
+    return filterLink('purchaseLocation', value, color, link, undefined, true);
+  }
+  return filterLink('purchaseLocation', value, color);
+};
+window.formatPurchaseLocation = formatPurchaseLocation;
 
 /**
  * Recalculates premium values for an inventory item
@@ -855,7 +880,7 @@ const renderTable = () => {
       </td>
       <td class="shrink" data-column="premium" style="color: ${item.isCollectable ? 'var(--text-muted)' : (item.totalPremium > 0 ? 'var(--warning)' : 'inherit')}">${filterLink('totalPremium', premiumValue, 'var(--text-primary)', premiumDisplay)}</td>
       <td class="shrink" data-column="purchaseLocation">
-        ${filterLink('purchaseLocation', item.purchaseLocation || 'Numista Import', getPurchaseLocationColor(item.purchaseLocation || 'Numista Import'))}
+        ${formatPurchaseLocation(item.purchaseLocation)}
       </td>
       <td class="shrink" data-column="storageLocation">
         ${item.storageLocation === 'Unknown' ? '' : filterLink('storageLocation', item.storageLocation || 'Numista Import', getStorageLocationColor(item.storageLocation || 'Numista Import'))}

--- a/js/utils.js
+++ b/js/utils.js
@@ -485,6 +485,23 @@ const stripNonAlphanumeric = (str = "", allowHyphen = false) =>
   str.toString().replace(allowHyphen ? /[^a-zA-Z0-9 -]/g : /[^a-zA-Z0-9 ]/g, "");
 
 /**
+ * Cleans a string by stripping HTML tags and control characters while
+ * preserving punctuation. Normalizes whitespace and removes diacritics.
+ *
+ * @param {string} str - Input string
+ * @returns {string} Cleaned string
+ */
+const cleanString = (str = "") =>
+  str
+    .toString()
+    .replace(/<[^>]*>/g, "")
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .replace(/[\u0000-\u001F\u007F'\"]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+/**
  * Sanitizes all string properties of an object by stripping non-alphanumeric characters.
  *
  * @param {Object} obj - Object whose string fields will be sanitized
@@ -495,7 +512,10 @@ const sanitizeObjectFields = (obj) => {
   for (const key of Object.keys(cleaned)) {
     if (typeof cleaned[key] === "string" && key !== 'notes') {
       const allowHyphen = key === 'date';
-      cleaned[key] = stripNonAlphanumeric(cleaned[key], allowHyphen);
+      cleaned[key] =
+        key === 'purchaseLocation'
+          ? cleanString(cleaned[key])
+          : stripNonAlphanumeric(cleaned[key], allowHyphen);
     }
   }
   return cleaned;
@@ -675,15 +695,6 @@ const sanitizeImportedItem = (item) => {
 
   // Normalize and sanitize string fields
   const basicFields = ['name', 'type', 'purchaseLocation', 'storageLocation'];
-  const cleanString = (str = '') =>
-    str
-      .toString()
-      .replace(/<[^>]*>/g, '')
-      .normalize('NFD')
-      .replace(/\p{Diacritic}/gu, '')
-      .replace(/[\u0000-\u001F\u007F'\"]/g, '')
-      .replace(/\s+/g, ' ')
-      .trim();
   const cleanMultilineString = (str = '') =>
     str
       .toString()

--- a/tests/purchase-location-url.test.js
+++ b/tests/purchase-location-url.test.js
@@ -1,0 +1,38 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+// Minimal DOM stubs for sanitizeHtml and theming
+global.document = {
+  createElement: () => ({
+    textContent: '',
+    get innerHTML() {
+      return this.textContent
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+  }),
+  documentElement: { getAttribute: () => 'light' },
+  getElementById: () => null
+};
+
+global.window = global;
+
+// Load utilities and inventory code
+vm.runInThisContext(fs.readFileSync('js/utils.js', 'utf8'));
+vm.runInThisContext(fs.readFileSync('js/inventory.js', 'utf8'));
+
+// Sanitize object with URL purchase location
+const item = { purchaseLocation: 'example.com/shop/item' };
+const cleaned = sanitizeObjectFields(item);
+assert.strictEqual(cleaned.purchaseLocation, 'example.com/shop/item', 'URL punctuation should remain');
+
+// Format purchase location for table display
+const html = formatPurchaseLocation(cleaned.purchaseLocation);
+assert(html.includes('<a href="https://example.com/shop/item"'), 'URL should be wrapped in hyperlink');
+assert(html.includes('example.com/shop/item'), 'Link text should retain punctuation');
+
+console.log('Purchase location URL tests passed');

--- a/tests/test_light_theme.html
+++ b/tests/test_light_theme.html
@@ -106,7 +106,7 @@
     </section>
 
     <div style="margin-top: 2rem; text-align: center;">
-        <p><strong>Testing Light Theme v3.04.29</strong></p>
+        <p><strong>Testing Light Theme v3.04.30</strong></p>
         <p>Colors: Light/middle grays and light blues</p>
         <p><a href="index.html">← Back to Main App</a></p>
     </div>


### PR DESCRIPTION
## Summary
- Allow Purchase Location strings to retain punctuation while sanitizing HTML/control characters
- Detect Purchase Location URLs and render them as hyperlinks in the inventory table
- Bump app version to v3.04.30 with documentation and tests

## Testing
- `node tests/quick-filter-generic.test.js`
- `node tests/collectable-weight-numista.test.js`
- `node tests/export-numista-comments.test.js`
- `node tests/estimate-numista.test.js`
- `node tests/display-composition.test.js`
- `node tests/purchase-location-url.test.js`
- `node tests/search-numista.test.js` *(fails: ENOENT docs/numista.csv)*
- `node tests/totals-numista.test.js` *(fails: ENOENT docs/numista.csv)*

------
https://chatgpt.com/codex/tasks/task_e_689b7dde4b9c832e98db9528b166f85a