### PR TITLE
Add alpha release link to footer

### DIFF
--- a/archive/v_previous/index.html
+++ b/archive/v_previous/index.html
@@ -1217,7 +1217,7 @@
     <footer class="app-footer">
       <div class="storage-line">Storage: <span id="storageUsage"></span> <progress id="storageUsageBar" max="5120" value="0"></progress> <a href="#" id="storageReportLink">Storage report</a></div>
       <div class="footer-meta">
-        <span>Thank you for using StackTrackr (<span id="footerVersion"></span>). © 2025 <span id="footerDomain">stacktrackr.com</span> | Created with love on Apple Silicon | If you are having trouble try the <a href="../index.html">previous build</a>, and report the issue on our <a href="https://www.reddit.com/r/StackTrackr" target="_blank" rel="noopener">subreddit</a> or on our <a href="https://github.com/lbruton/StackTrackr/issues" target="_blank" rel="noopener">GitHub Issues Page</a>.</span>
+        <span>Thank you for using StackTrackr (<span id="footerVersion"></span>). © 2025 <span id="footerDomain">stacktrackr.com</span> | Created with love on Apple Silicon |<br>If you are having trouble try the <a href="../index.html">previous build</a>, and report the issue on our <a href="https://www.reddit.com/r/StackTrackr" target="_blank" rel="noopener">subreddit</a> or on our <a href="https://github.com/lbruton/StackTrackr/issues" target="_blank" rel="noopener">GitHub Issues Page</a>. You can also try the <a href="https://alpha.stackrtrackr.com" target="_blank" rel="noopener">alpha release here</a>.</span>
       </div>
     </footer>
     <!-- =============================================================================

--- a/index.html
+++ b/index.html
@@ -1441,7 +1441,7 @@
     <footer class="app-footer">
       <div class="storage-line">Storage: <span id="storageUsage"></span> <progress id="storageUsageBar" max="5120" value="0"></progress> <a href="#" id="storageReportLink">Storage report</a></div>
       <div class="footer-meta">
-        <span>Thank you for using StackrTrackr (<span id="footerVersion"></span>). © 2025 <span id="footerDomain">stackrtrackr.com</span> | Created with love on Apple Silicon | If you are having trouble try the <a href="./archive/v_previous/index.html">previous build</a>, and report the issue on our <a href="https://www.reddit.com/r/stackrtrackr" target="_blank" rel="noopener">subreddit</a> or on our <a href="https://github.com/lbruton/StackTrackr/issues" target="_blank" rel="noopener">GitHub Issues Page</a>.</span>
+        <span>Thank you for using StackrTrackr (<span id="footerVersion"></span>). © 2025 <span id="footerDomain">stackrtrackr.com</span> | Created with love on Apple Silicon |<br>If you are having trouble try the <a href="./archive/v_previous/index.html">previous build</a>, and report the issue on our <a href="https://www.reddit.com/r/stackrtrackr" target="_blank" rel="noopener">subreddit</a> or on our <a href="https://github.com/lbruton/StackTrackr/issues" target="_blank" rel="noopener">GitHub Issues Page</a>. You can also try the <a href="https://alpha.stackrtrackr.com" target="_blank" rel="noopener">alpha release here</a>.</span>
       </div>
     </footer>
     <!-- =============================================================================


### PR DESCRIPTION
## Summary
- add alpha release link to main footer with line break for readability
- replicate updated footer in previous build archive

## Testing
- `for f in tests/*.test.js; do echo Running $f; node $f; done` *(search-numista and totals-numista tests failed: ENOENT docs/numista.csv)*

------
https://chatgpt.com/codex/tasks/task_e_689b819e6284832e8e1389d836cda8f3