### PR TITLE
Unify header buttons with theme selector styling

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1150,6 +1150,11 @@ input[type="submit"] {
   align-items: center;
 }
 
+/* Larger icons for header theme buttons */
+.app-header .theme-btn {
+  font-size: 1.5rem;
+}
+
 /* Theme button styling - shows current theme */
 .theme-btn {
   border: 2px solid var(--border);

--- a/docs/agents/agents.ai
+++ b/docs/agents/agents.ai
@@ -1,7 +1,7 @@
 # StackTrackr Project Instructions
 
 ## CONTEXT
-Precious metals inventory app (v3.04.31+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
+Precious metals inventory app (v3.04.32+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
 
 ## FILES
 - `index.html` - main UI
@@ -60,7 +60,7 @@ AUTO_WARN: "⚠️ Chat approaching limit. Start new conversation soon and refer
 `index.html` `events.js` `styles.css` - coordinate changes, minimal edits
 
 ## NOTES
-- Current version: 3.04.31 (API history charts removed)
+- Current version: 3.04.32 (header buttons match theme selector)
 - **THEME TOGGLE FIXED**: Button now shows current theme color/icon, removed system mode
 - **THEME ROTATION**: dark → light → sepia → dark (no system mode)
 - **BUTTON STYLING**: Shows current theme with matching background color

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.31
+# Multi-Agent Development Workflow - StackrTrackr v3.04.32
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.31**
+> **Latest release: v3.04.32**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.31**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.32**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.04.31 (stable)
+**Current Status**: v3.04.32 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,6 +1,7 @@
 # StackrTrackr Announcements
 
 ## What's New
+- **v3.04.32 – Header button icons**: Header buttons now match theme selector with icon-only design.
 - **v3.04.31 – Streamlined API History**: Removed canvas-based charts and expanded API history table.
 
 ## Development Roadmap

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,14 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.31**
+> **Latest release: v3.04.32**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.32 – Header Buttons Theming (2025-08-12)
+- **Unified header styling**: Header buttons now match theme selector with icon-only layout and larger icons.
 
 ### Version 3.04.31 – API History Charts Removed (2025-08-12)
 - **Streamlined API History**: Removed canvas-based charts and expanded table to fill modal.

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.31**
+> **Latest release: v3.04.32**
 
 
 | File | Function | Description |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,6 +1,6 @@
 # Implementation Summary: Unified Logo
 
-> **Latest release: v3.04.31**
+> **Latest release: v3.04.32**
 
 ## Version Update: 3.04.24 → 3.04.25
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -15,6 +15,7 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - Rename "Clear Data" settings card to "Backup, Restore, Clear" (v3.04.29)
 - Allow URL purchase locations to render as hyperlinks (v3.04.30)
 - Remove API history charts and expand API history table (v3.04.31)
+- Header buttons match theme selector styling with enlarged icons (v3.04.32)
 - Update milestone process and documentation.
 
 ## Version Goals (v4.x)

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,13 +2,13 @@
 
 
 
-> **Latest release: v3.04.31**
+> **Latest release: v3.04.32**
 
 See [announcements](announcements.md) for recent changes and upcoming milestones.
 
-## 🎯 Current State: **BETA v3.04.31** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.32** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.31** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.32** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.04.31**
+> **Latest release: v3.04.32**
 
 ## Overview 
 
@@ -9,7 +9,7 @@ The StackrTrackr now uses a dynamic version management system that automatically
 ## How It Works
 
 ### Single Source of Truth
-- Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.31'`
+- Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.32'`
   - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation

--- a/index.html
+++ b/index.html
@@ -183,12 +183,8 @@
         </h1>
       </div>
       <div style="margin-left: auto; display: flex; gap: 0.5rem">
-        <button class="btn" id="aboutBtn" title="About" aria-label="About">
-          About 📖
-        </button>
-        <button class="btn" id="apiBtn" title="API" aria-label="API">
-          API 🔌
-        </button>
+        <button class="btn theme-btn" id="aboutBtn" title="About" aria-label="About">📖</button>
+        <button class="btn theme-btn" id="apiBtn" title="API" aria-label="API">🔌</button>
         <!-- Community button commented out for revision
         <a
           class="btn"
@@ -207,15 +203,8 @@
           Community
         </a>
         -->
-        <button class="btn" id="filesBtn" title="Files" aria-label="Files">
-          Files 📁
-        </button>
-        <button
-          class="btn theme-btn"
-          id="appearanceBtn"
-          title="Theme"
-          aria-label="Theme"
-        ></button>
+        <button class="btn theme-btn" id="filesBtn" title="Files" aria-label="Files">📁</button>
+        <button class="btn theme-btn" id="appearanceBtn" title="Theme" aria-label="Theme"></button>
       </div>
     </div>
     <div class="container">

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.31";
+const APP_VERSION = "3.04.32";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/events.js
+++ b/js/events.js
@@ -1484,23 +1484,24 @@ const setupSearch = () => {
  * Sets up theme toggle event listeners
  */
 const updateThemeButton = () => {
+  const savedTheme = localStorage.getItem(THEME_KEY) || "light";
+
+  // Apply theme classes to all theme buttons
+  document.querySelectorAll(".theme-btn").forEach((btn) => {
+    btn.classList.remove("dark", "light", "sepia");
+    btn.classList.add(savedTheme);
+  });
+
   const btn = elements.appearanceBtn;
   if (!btn) return;
-  const savedTheme = localStorage.getItem(THEME_KEY) || "light";
-  
-  // Remove all theme classes
-  btn.classList.remove("dark", "light", "sepia");
-  
-  // Add current theme class for styling
-  btn.classList.add(savedTheme);
-  
-  // Show current theme icon and color
+
+  // Show current theme icon and color on selector button
   const themeConfig = {
     dark: { icon: "🌙", label: "Dark mode", color: "#1e293b" },
     light: { icon: "☀️", label: "Light mode", color: "#f8fafc" },
     sepia: { icon: "📜", label: "Sepia mode", color: "#f2e7d5" }
   };
-  
+
   const config = themeConfig[savedTheme] || themeConfig.light;
   btn.textContent = config.icon;
   btn.style.backgroundColor = config.color;


### PR DESCRIPTION
## Summary
- Restyled About, API, and Files header buttons to use theme-driven icon-only layout
- Enlarged header icons and synchronized all theme buttons with the current theme
- Bumped app version to 3.04.32 and updated docs and roadmap

## Testing
- `for f in tests/*.test.js; do node "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_689ba0208818832e9953f587902f63f9