### PR TITLE
Add overwrite confirmation for CSV imports

### DIFF
--- a/docs/agents/agents.ai
+++ b/docs/agents/agents.ai
@@ -1,7 +1,7 @@
 # StackTrackr Project Instructions
 
 ## CONTEXT
-Precious metals inventory app (v3.04.32+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
+Precious metals inventory app (v3.04.33+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
 
 ## FILES
 - `index.html` - main UI
@@ -60,7 +60,7 @@ AUTO_WARN: "⚠️ Chat approaching limit. Start new conversation soon and refer
 `index.html` `events.js` `styles.css` - coordinate changes, minimal edits
 
 ## NOTES
-- Current version: 3.04.32 (header buttons match theme selector)
+- Current version: 3.04.33 (import overwrite warnings & red Numista button)
 - **THEME TOGGLE FIXED**: Button now shows current theme color/icon, removed system mode
 - **THEME ROTATION**: dark → light → sepia → dark (no system mode)
 - **BUTTON STYLING**: Shows current theme with matching background color

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.32
+# Multi-Agent Development Workflow - StackrTrackr v3.04.33
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.32**
+> **Latest release: v3.04.33**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.32**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.33**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.04.32 (stable)
+**Current Status**: v3.04.33 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,6 +1,7 @@
 # StackrTrackr Announcements
 
 ## What's New
+- **v3.04.33 – Import overwrite warnings**: Import CSV and Numista CSV now confirm before replacing existing data.
 - **v3.04.32 – Header button icons**: Header buttons now match theme selector with icon-only design.
 - **v3.04.31 – Streamlined API History**: Removed canvas-based charts and expanded API history table.
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,15 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.32**
+> **Latest release: v3.04.33**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.33 – Import Overwrite Confirmation (2025-08-12)
+- **Overwrite warnings**: Import CSV and Numista CSV now require confirmation before replacing existing data.
+- **Numista button styling**: Import Numista CSV button uses red danger styling to indicate overwrite.
 
 ### Version 3.04.32 – Header Buttons Theming (2025-08-12)
 - **Unified header styling**: Header buttons now match theme selector with icon-only layout and larger icons.

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.32**
+> **Latest release: v3.04.33**
 
 
 | File | Function | Description |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,6 +1,25 @@
+# Implementation Summary: Import Overwrite Confirmation
+
+> **Latest release: v3.04.33**
+
+## Version Update: 3.04.32 → 3.04.33
+
+## User Requirements Implemented
+
+- Import Numista CSV button uses red danger styling.
+- Import CSV and Numista CSV buttons warn before overwriting data.
+
+## Technical Changes Made
+
+### Files Modified:
+1. **`index.html`**: Updated Numista import button to danger styling.
+2. **`js/events.js`**: Added overwrite confirmation prompts for CSV and Numista imports.
+3. **`js/constants.js`**: Bumped version to 3.04.33.
+4. **Documentation**: Updated announcements, changelog, status, versioning, function table, workflow, and summary.
+
 # Implementation Summary: Unified Logo
 
-> **Latest release: v3.04.32**
+> **Latest release: v3.04.33**
 
 ## Version Update: 3.04.24 → 3.04.25
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,13 +2,13 @@
 
 
 
-> **Latest release: v3.04.32**
+> **Latest release: v3.04.33**
 
 See [announcements](announcements.md) for recent changes and upcoming milestones.
 
-## 🎯 Current State: **BETA v3.04.32** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.33** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.32** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.33** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.04.32**
+> **Latest release: v3.04.33**
 
 ## Overview 
 
@@ -9,7 +9,7 @@ The StackrTrackr now uses a dynamic version management system that automatically
 ## How It Works
 
 ### Single Source of Truth
-- Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.32'`
+- Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.33'`
   - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation

--- a/index.html
+++ b/index.html
@@ -1793,7 +1793,7 @@
                 <div class="third-party-block">
                   <div class="import-export-grid">
                     <div class="grid grid-2">
-                      <button class="btn success" id="importNumistaBtn">Import Numista CSV</button>
+                      <button class="btn danger" id="importNumistaBtn">Import Numista CSV</button>
                       <button class="btn secondary" id="mergeNumistaBtn">Merge Numista CSV</button>
                     </div>
                     <button class="btn warning" id="clearNumistaInventoryBtn">Clear Numista Cache</button>

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.32";
+const APP_VERSION = "3.04.33";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/events.js
+++ b/js/events.js
@@ -912,8 +912,14 @@ const setupEventListeners = () => {
         elements.importCsvOverride,
         "click",
         () => {
-          csvImportOverride = true;
-          elements.importCsvFile.click();
+          if (
+            confirm(
+              "Importing CSV will overwrite all existing data. To combine data, choose Merge instead. Press OK to continue.",
+            )
+          ) {
+            csvImportOverride = true;
+            elements.importCsvFile.click();
+          }
         },
         "CSV override button",
       );
@@ -986,8 +992,14 @@ const setupEventListeners = () => {
         importNumistaBtn,
         "click",
         () => {
-          numistaOverride = true;
-          elements.numistaImportFile.click();
+          if (
+            confirm(
+              "Importing Numista CSV will overwrite all existing data. To combine data, choose Merge instead. Press OK to continue.",
+            )
+          ) {
+            numistaOverride = true;
+            elements.numistaImportFile.click();
+          }
         },
         "Import Numista CSV button",
       );


### PR DESCRIPTION
## Summary
- Style Import Numista CSV button as danger
- Confirm before overwriting data on CSV and Numista imports
- Bump version to 3.04.33 and update docs

## Testing
- `for f in tests/*.test.js; do node "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_689ba23eeca0832e966f721aafd3ce99