### PR TITLE
Sort summary chips and relocate backup notice

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2515,6 +2515,12 @@ td input:checked + .slider:before {
   align-items: center;
 }
 
+.summary-wrapper {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+}
+
 .table-disclaimer {
   font-size: 0.75rem;
   color: var(--disclaimer-color);

--- a/docs/agents/agents.ai
+++ b/docs/agents/agents.ai
@@ -1,7 +1,7 @@
 # StackTrackr Project Instructions
 
 ## CONTEXT
-Precious metals inventory app (v3.04.37+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
+Precious metals inventory app (v3.04.38+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
 
 ## FILES
 - `index.html` - main UI

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.37
+# Multi-Agent Development Workflow - StackrTrackr v3.04.38
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.37**
+> **Latest release: v3.04.38**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.37**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.38**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.04.37 (stable)
+**Current Status**: v3.04.38 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,6 +1,7 @@
 # StackrTrackr Announcements
 
 ## What's New
+- **v3.04.38 – Sorted summary chips**: Summary chips consolidated in a container, sorted by count, and backup warning moved below the table.
 - **v3.04.37 – Fuzzy search engine**: Introduced standalone fuzzy search module with typo-tolerant matching.
 - **v3.04.36 – Dynamic summary bubbles**: Added color-coded counts for type, metal, purchase location, and storage location, and preserved link colors for URL purchases.
 - **v3.04.35 – JSON import options**: Split JSON import into Import and Merge buttons and removed Excel support.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,15 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.37**
+> **Latest release: v3.04.38**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.38 – Sorted Summary Chips (2025-08-16)
+- Summary chips now appear in a dedicated container sorted by count.
+- Backup warning moved directly beneath the inventory table.
 
 ### Version 3.04.37 – Fuzzy Search Engine Module (2025-08-15)
 - Added standalone fuzzy search engine with Levenshtein, n-gram, and word-order independent matching.

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.37**
+> **Latest release: v3.04.38**
 
 
 | File | Function | Description |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,6 +1,6 @@
 # Implementation Summary: Dynamic Summary Bubbles
 
-> **Latest release: v3.04.37**
+> **Latest release: v3.04.38**
 
 ## Version Update: 3.04.35 → 3.04.36
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -19,6 +19,7 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - Header buttons match theme selector styling with enlarged icons (v3.04.32)
 - Update milestone process and documentation.
 - Added standalone fuzzy search engine module (v3.04.37)
+- Sorted summary chips in table controls and repositioned backup warning (v3.04.38)
 
 ## Version Goals (v4.x)
 - Remove file:// protocol support and adopt a framework.

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,13 +2,13 @@
 
 
 
-> **Latest release: v3.04.37**
+> **Latest release: v3.04.38**
 
 See [announcements](announcements.md) for recent changes and upcoming milestones.
 
-## 🎯 Current State: **BETA v3.04.37** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.38** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.37** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.38** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.04.37**
+> **Latest release: v3.04.38**
 
 ## Overview 
 
@@ -9,7 +9,7 @@ The StackrTrackr now uses a dynamic version management system that automatically
 ## How It Works
 
 ### Single Source of Truth
- - Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.37'`
+ - Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.38'`
   - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation

--- a/index.html
+++ b/index.html
@@ -639,15 +639,17 @@
           </thead>
           <tbody></tbody>
         </table>
+        <div class="disclaimer-wrapper">
+          <span class="table-disclaimer">
+            All data is stored locally.
+            <span id="backupReminder" class="backup-link">Back up often.</span>
+          </span>
+        </div>
       </section>
       <section class="table-controls-section">
         <div class="table-controls">
           <button type="button" id="changeLogBtn" class="btn">Change Log</button>
-          <div class="disclaimer-wrapper">
-            <span class="table-disclaimer">
-              All data is stored locally. 
-              <span id="backupReminder" class="backup-link">Back up often.</span>
-            </span>
+          <div class="summary-wrapper">
             <div id="typeSummary"></div>
           </div>
           <div class="items-per-page">

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.37";
+const APP_VERSION = "3.04.38";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -785,25 +785,26 @@ const updateTypeSummary = () => {
     }
   ];
 
-  const html = categories
-    .map(cat => {
-      const counts = inventory.reduce((acc, item) => {
-        const key = item[cat.field] || (cat.field === 'purchaseLocation' ? 'Numista Import' : 'Unknown');
-        acc[key] = (acc[key] || 0) + 1;
-        return acc;
-      }, {});
-      return Object.entries(counts)
-        .map(([val, count]) => {
-          const safeVal = sanitizeHtml(val);
-          const colors = cat.getColors(val);
-          const cls = cat.getClass ? ` ${cat.getClass(val)}` : '';
-          return `<span class="summary-chip${cls}" style="background-color: ${colors.bg}; color: ${colors.text};">${safeVal}: ${count}</span>`;
-        })
-        .join('');
-    })
-    .join('');
+  const chips = [];
+  categories.forEach(cat => {
+    const counts = inventory.reduce((acc, item) => {
+      const key = item[cat.field] || (cat.field === 'purchaseLocation' ? 'Numista Import' : 'Unknown');
+      acc[key] = (acc[key] || 0) + 1;
+      return acc;
+    }, {});
+    Object.entries(counts).forEach(([val, count]) => {
+      const safeVal = sanitizeHtml(val);
+      const colors = cat.getColors(val);
+      const cls = cat.getClass ? ` ${cat.getClass(val)}` : '';
+      chips.push({
+        count,
+        html: `<span class="summary-chip${cls}" style="background-color: ${colors.bg}; color: ${colors.text};">${safeVal}: ${count}</span>`
+      });
+    });
+  });
 
-  el.innerHTML = html;
+  chips.sort((a, b) => b.count - a.count);
+  el.innerHTML = chips.map(c => c.html).join('');
 };
 window.updateTypeSummary = updateTypeSummary;
 


### PR DESCRIPTION
## Summary
- Display summary chips inside dedicated container sorted by count
- Move "All data is stored locally" notice beneath inventory table
- Bump version to 3.04.38 and update documentation

## Testing
- `for f in tests/*.test.js; do node "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_689bbc698b58832eb3336cd46e6c702a