### PR TITLE
Reposition pagination controls and theme warning

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -18,8 +18,8 @@
   --danger: #dc2626;
   --danger-hover: #b91c1c;
 
-    /* Disclaimer warning color */
-    --disclaimer-color: var(--warning);
+  /* Disclaimer warning color */
+  --disclaimer-color: var(--success);
 
   /* Background Colors - Light grays and light blues */
   --bg-primary: #f1f5f9;
@@ -87,7 +87,7 @@
   --danger-hover: #dc2626;
 
   /* Disclaimer warning color */
-  --disclaimer-color: var(--danger);
+  --disclaimer-color: var(--text-muted);
 
   /* Metal-specific Colors - dark mode */
   --silver: #d1d5db;
@@ -141,6 +141,9 @@
   --warning-hover: #b45309;
   --danger: #dc2626;
   --danger-hover: #b91c1c;
+
+  /* Disclaimer warning color */
+  --disclaimer-color: var(--warning);
 
   /* Metal-specific Colors - Sepia tone */
   --silver: #a8a29e;
@@ -2436,7 +2439,8 @@ td input:checked + .slider:before {
    ============================================================================= */
 
 .pagination-section {
-  margin: var(--spacing) 0;
+  margin-top: var(--spacing);
+  margin-bottom: 0;
 }
 
 .pagination-controls {
@@ -2509,6 +2513,7 @@ td input:checked + .slider:before {
 }
 
 .disclaimer-wrapper {
+  margin-top: var(--spacing);
   flex: 1;
   display: flex;
   flex-direction: column;
@@ -2531,6 +2536,14 @@ td input:checked + .slider:before {
 .backup-link {
   text-decoration: underline;
   cursor: pointer;
+}
+
+[data-theme="dark"] .backup-link {
+  color: var(--danger);
+}
+
+[data-theme="sepia"] .backup-link {
+  color: var(--success);
 }
 
 .pagination-select {

--- a/docs/agents/agents.ai
+++ b/docs/agents/agents.ai
@@ -1,7 +1,7 @@
 # StackTrackr Project Instructions
 
 ## CONTEXT
-Precious metals inventory app (v3.04.38+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
+Precious metals inventory app (v3.04.39+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
 
 ## FILES
 - `index.html` - main UI

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.38
+# Multi-Agent Development Workflow - StackrTrackr v3.04.39
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.38**
+> **Latest release: v3.04.39**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.38**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.39**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: v3.04.38 (stable)
+**Current Status**: v3.04.39 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,6 +1,7 @@
 # StackrTrackr Announcements
 
 ## What's New
+- **v3.04.39 – Pagination reposition & warning styling**: Pagination controls placed directly under the table with theme-aware backup warning colors.
 - **v3.04.38 – Sorted summary chips**: Summary chips consolidated in a container, sorted by count, and backup warning moved below the table.
 - **v3.04.37 – Fuzzy search engine**: Introduced standalone fuzzy search module with typo-tolerant matching.
 - **v3.04.36 – Dynamic summary bubbles**: Added color-coded counts for type, metal, purchase location, and storage location, and preserved link colors for URL purchases.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,15 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.38**
+> **Latest release: v3.04.39**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.39 – Pagination Controls Reposition (2025-08-17)
+- Pagination controls moved directly beneath the inventory table with added spacing.
+- Backup warning styled per theme: gray with red link on dark, green on light, and green link on sepia.
 
 ### Version 3.04.38 – Sorted Summary Chips (2025-08-16)
 - Summary chips now appear in a dedicated container sorted by count.

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.38**
+> **Latest release: v3.04.39**
 
 
 | File | Function | Description |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,6 +1,6 @@
 # Implementation Summary: Dynamic Summary Bubbles
 
-> **Latest release: v3.04.38**
+> **Latest release: v3.04.39**
 
 ## Version Update: 3.04.35 → 3.04.36
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -20,6 +20,7 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - Update milestone process and documentation.
 - Added standalone fuzzy search engine module (v3.04.37)
 - Sorted summary chips in table controls and repositioned backup warning (v3.04.38)
+- Repositioned pagination below inventory table with theme-specific warning styling (v3.04.39)
 
 ## Version Goals (v4.x)
 - Remove file:// protocol support and adopt a framework.

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,13 +2,13 @@
 
 
 
-> **Latest release: v3.04.38**
+> **Latest release: v3.04.39**
 
 See [announcements](announcements.md) for recent changes and upcoming milestones.
 
-## 🎯 Current State: **BETA v3.04.38** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.39** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.38** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.39** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.04.38**
+> **Latest release: v3.04.39**
 
 ## Overview 
 
@@ -9,7 +9,7 @@ The StackrTrackr now uses a dynamic version management system that automatically
 ## How It Works
 
 ### Single Source of Truth
- - Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.38'`
+ - Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.39'`
   - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation

--- a/index.html
+++ b/index.html
@@ -639,6 +639,24 @@
           </thead>
           <tbody></tbody>
         </table>
+        <!-- Pagination Controls -->
+        <section class="pagination-section">
+          <div class="pagination-container">
+            <div class="pagination-controls">
+              <div class="pagination-buttons">
+                <div class="pagination-left">
+                  <button class="pagination-btn" id="firstPage" title="First Page">«</button>
+                  <button class="pagination-btn" id="prevPage" title="Previous Page">‹</button>
+                </div>
+                <div class="pagination-center" id="pageNumbers"></div>
+                <div class="pagination-right">
+                  <button class="pagination-btn" id="nextPage" title="Next Page">›</button>
+                  <button class="pagination-btn" id="lastPage" title="Last Page">»</button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
         <div class="disclaimer-wrapper">
           <span class="table-disclaimer">
             All data is stored locally.
@@ -663,40 +681,6 @@
             </select>
           </div>
         </div>
-      </section>
-      <!-- Pagination Controls -->
-      <section class="pagination-section">
-          <div class="pagination-container">
-            <div class="pagination-controls">
-              <div class="pagination-buttons">
-                <div class="pagination-left">
-                  <button
-                    class="pagination-btn"
-                    id="firstPage"
-                    title="First Page"
-                  >
-                    «
-                  </button>
-                  <button
-                    class="pagination-btn"
-                    id="prevPage"
-                    title="Previous Page"
-                  >
-                    ‹
-                  </button>
-                </div>
-                <div class="pagination-center" id="pageNumbers"></div>
-                <div class="pagination-right">
-                  <button class="pagination-btn" id="nextPage" title="Next Page">
-                    ›
-                  </button>
-                  <button class="pagination-btn" id="lastPage" title="Last Page">
-                    »
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
       </section>
     </section>
     <!-- =============================================================================

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.38";
+const APP_VERSION = "3.04.39";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting


### PR DESCRIPTION
## Summary
- place pagination controls directly below the inventory table with added spacing before the local-data warning
- theme the warning: green in light mode, gray with red link in dark mode, and green link in sepia mode
- bump version to 3.04.39 and update documentation

## Testing
- `for f in tests/*.test.js; do node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_689bbf766f6c832e9ba8119a4ff04412