### PR TITLE
Reorder pagination controls and add padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# {{VERSION_TITLE}}
+# StackrTrackr v3.04.40
 
 
 StackrTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -9,6 +9,7 @@ The public hosted version of the app is available at [stackrtrackr.com](https://
 See [docs/announcements.md](docs/announcements.md) for the latest release notes and upcoming milestones.
 
 ## Recent Updates
+- **v3.04.40 - Pagination reposition & padding**: pagination controls now appear above the Change Log section with added edge spacing
 - **v3.04.34 - Streamlined Numista imports**: Removed stored Numista CSV cache and clear-cache button
 - **v3.04.31 - Streamlined API history**: Removed charts and expanded API history table to fill modal
 - **v3.04.30 - URL-friendly purchase locations**: Purchase Location field accepts web addresses and renders them as clickable links
@@ -357,7 +358,7 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: {{VERSION}}
+**Current Version**: 3.04.40
 **Last Updated**: August 12, 2025
 **Status**: Feature complete release candidate
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -2452,6 +2452,7 @@ td input:checked + .slider:before {
   width: 100%;
   align-items: center;
   justify-content: space-between;
+  padding: 0 var(--spacing-xs);
 }
 
 .pagination-left,

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.37
+# Multi-Agent Development Workflow - StackrTrackr v3.04.40
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: {{VERSION_WITH_V}}**
+> **Latest release: v3.04.40**
 
 ## 🎯 Project Overview
 
-You are contributing to **{{VERSION_TITLE}}**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.40**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: {{VERSION}} (stable)
+**Current Status**: 3.04.40 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/agents/prompt.md
+++ b/docs/agents/prompt.md
@@ -1,6 +1,6 @@
-# {{BRANDING_NAME}} Development Prompt
+# StackrTrackr Development Prompt
 
-You're working on **{{BRANDING_NAME}} {{VERSION_WITH_V}}+**, a client-side precious metals inventory web app. Your job is to pick up a development task and implement it efficiently.
+You're working on **StackrTrackr v3.04.40+**, a client-side precious metals inventory web app. Your job is to pick up a development task and implement it efficiently.
 
 ## Quick Orientation (3 steps)
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,7 +1,7 @@
 # StackrTrackr Announcements
 
 ## What's New
-- **{{VERSION_WITH_V}} – Fuzzy search engine**: Introduced standalone fuzzy search module with typo-tolerant matching.
+- **v3.04.40 – Fuzzy search engine**: Introduced standalone fuzzy search module with typo-tolerant matching.
 - **v3.04.36 – Dynamic summary bubbles**: Added color-coded counts for type, metal, purchase location, and storage location, and preserved link colors for URL purchases.
 - **v3.04.35 – JSON import options**: Split JSON import into Import and Merge buttons and removed Excel support.
 - **v3.04.34 – Streamlined Numista imports**: Removed stored Numista CSV cache and associated clear-cache button.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,15 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.39**
+> **Latest release: v3.04.40**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.40 – Pagination Section Reorder (2025-08-12)
+- **UI Layout**: Moved pagination controls above table controls with Change Log button
+- **Styling**: Added horizontal padding so pagination buttons no longer touch container edges
 
 ### Version 3.04.39 – Template Variable Fix (2025-08-12)
 - **Template Resolution**: Fixed unreplaced template variables in documentation files

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: {{VERSION_WITH_V}}**
+> **Latest release: v3.04.40**
 
 
 | File | Function | Description |

--- a/docs/human_workflow.md
+++ b/docs/human_workflow.md
@@ -2,7 +2,7 @@
 
 This guide summarizes the typical tools and branch strategy for human contributors to StackrTrackr.
 
-**Current Release:** {{VERSION_WITH_V}}
+**Current Release:** v3.04.40
 
 ## Tools
 

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,6 +1,6 @@
 # Implementation Summary: Dynamic Summary Bubbles
 
-> **Latest release: {{VERSION_WITH_V}}**
+> **Latest release: v3.04.40**
 
 ## Version Update: 3.04.35 → 3.04.36
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,7 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - _No active patch goals at this time._
 
 ## Completed Patch Goals (v3.04.xx)
+- ✅ **Pagination section reorder** - Moved pagination above Change Log with edge padding (v3.04.40)
 - ✅ **Template Variable Resolution** - Fixed unreplaced template variables in documentation (v3.04.39)
 - Align inventory action buttons and theme controls
 - Enforce Metals.dev 30-day history limit and record daily price history
@@ -22,7 +23,7 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - Added standalone fuzzy search engine module (v3.04.37)
 - ✅ **Documentation Template System** - Created comprehensive template replacement system for version management (v3.04.38)
   - Audited all .md files and identified 16 files with hardcoded version references
-  - Implemented template variables: {{VERSION}}, {{VERSION_WITH_V}}, {{VERSION_TITLE}}, {{VERSION_BRANCH}}, {{BRANDING_NAME}}
+  - Implemented template variables: 3.04.40, v3.04.40, StackrTrackr v3.04.40, 3.04.x, StackrTrackr
   - Created automated build script for template processing
   - Replaced hardcoded versions across documentation with template variables
   - Established single-source-of-truth version management system

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,13 +2,13 @@
 
 
 
-> **Latest release: {{VERSION_WITH_V}}**
+> **Latest release: v3.04.40**
 
 See [announcements](announcements.md) for recent changes and upcoming milestones.
 
-## 🎯 Current State: **BETA {{VERSION_WITH_V}}** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.40** ✅ MAINTAINED & OPTIMIZED
 
-**{{VERSION_TITLE}}** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.40** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -28,6 +28,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.04.40 - Pagination controls reposition**: moved pagination above Change Log and added edge padding
 - **v3.04.25 - Unified logo**: single SVG logo across themes, removed theme-specific assets
 - **v3.04.24 - Backup warning theming**: local storage warning uses theme colors with centered type summary and backup link
 - **v3.04.23 - Inventory actions alignment**: row icons reordered and theme-aware controls
@@ -183,7 +184,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: {{VERSION}} (managed in `js/constants.js`)
+1. **Current Version**: 3.04.40 (managed in `js/constants.js`)
 2. **Last Change**: Simplified archive workflow
 3. **Last Documentation Update**: August 11, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: {{VERSION_WITH_V}}**
+> **Latest release: v3.04.40**
 
 
 The repository is organized as follows:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: {{VERSION_WITH_V}}**
+> **Latest release: v3.04.40**
 
 ## Overview 
 
@@ -9,7 +9,7 @@ The StackrTrackr now uses a dynamic version management system that automatically
 ## How It Works
 
 ### Single Source of Truth
- - Version is defined once in `js/constants.js` as `APP_VERSION = '{{VERSION}}'`
+ - Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.40'`
   - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation
@@ -19,7 +19,7 @@ The StackrTrackr now uses a dynamic version management system that automatically
 
 ### Utility Functions
 - `js/constants.js` provides:
-- `getVersionString(prefix)`: Returns formatted version (e.g., "{{VERSION_WITH_V}}")
+- `getVersionString(prefix)`: Returns formatted version (e.g., "v3.04.40")
   - `injectVersionString(elementId, prefix)`: Inserts formatted version into a target element
 - `js/utils.js` provides:
   - `getAppTitle(baseTitle)`: Returns full app title with version
@@ -31,14 +31,14 @@ To release a new version:
 1. **Update ONLY the constants file:**
    ```javascript
    // In js/constants.js
-    const APP_VERSION = '{{VERSION}}';  // Change this line only
+    const APP_VERSION = '3.04.40';  // Change this line only
    ```
 
 2. **All these will automatically update:**
-  - Page title: "{{VERSION_TITLE}}"
-  - Page heading: "{{VERSION_TITLE}}"
-  - Browser tab title: "{{VERSION_TITLE}}"
-   - App header: "{{VERSION_TITLE}}"
+  - Page title: "StackrTrackr v3.04.40"
+  - Page heading: "StackrTrackr v3.04.40"
+  - Browser tab title: "StackrTrackr v3.04.40"
+   - App header: "StackrTrackr v3.04.40"
 
 3. **Update changelog:** Add entry to `/docs/changelog.md` for documentation
 

--- a/index.html
+++ b/index.html
@@ -640,28 +640,6 @@
           <tbody></tbody>
         </table>
       </section>
-      <section class="table-controls-section">
-        <div class="table-controls">
-          <button type="button" id="changeLogBtn" class="btn">Change Log</button>
-          <div class="disclaimer-wrapper">
-            <span class="table-disclaimer">
-              All data is stored locally. 
-              <span id="backupReminder" class="backup-link">Back up often.</span>
-            </span>
-            <div id="typeSummary"></div>
-          </div>
-          <div class="items-per-page">
-            <span class="items-label">Items:</span>
-            <select class="pagination-select" id="itemsPerPage">
-              <option vaue="10">10</option>
-              <option value="15">15</option>
-              <option selected value="25">25</option>
-              <option value="50">50</option>
-              <option value="100">100</option>
-            </select>
-          </div>
-        </div>
-      </section>
       <!-- Pagination Controls -->
       <section class="pagination-section">
           <div class="pagination-container">
@@ -695,6 +673,28 @@
               </div>
             </div>
           </div>
+      </section>
+      <section class="table-controls-section">
+        <div class="table-controls">
+          <button type="button" id="changeLogBtn" class="btn">Change Log</button>
+          <div class="disclaimer-wrapper">
+            <span class="table-disclaimer">
+              All data is stored locally.
+              <span id="backupReminder" class="backup-link">Back up often.</span>
+            </span>
+            <div id="typeSummary"></div>
+          </div>
+          <div class="items-per-page">
+            <span class="items-label">Items:</span>
+            <select class="pagination-select" id="itemsPerPage">
+              <option vaue="10">10</option>
+              <option value="15">15</option>
+              <option selected value="25">25</option>
+              <option value="50">50</option>
+              <option value="100">100</option>
+            </select>
+          </div>
+        </div>
       </section>
     </section>
     <!-- =============================================================================

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.39";
+const APP_VERSION = "3.04.40";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting


### PR DESCRIPTION
## Summary
- Move pagination controls above Change Log section
- Pad pagination buttons away from container edges
- Bump version to 3.04.40 and refresh docs

## Testing
- `for f in tests/*.test.js; do node "$f"; done`
- `node scripts/update-templates.js`


------
https://chatgpt.com/codex/tasks/task_e_689bc5bf20cc832e82f5c6145420e4cf