### PR TITLE
feat: add section titles and update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# StackrTrackr v3.04.40
+# StackrTrackr v3.04.41
 
 
 StackrTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -9,6 +9,7 @@ The public hosted version of the app is available at [stackrtrackr.com](https://
 See [docs/announcements.md](docs/announcements.md) for the latest release notes and upcoming milestones.
 
 ## Recent Updates
+- **v3.04.41 - Section titles**: added centered titles for Spot Prices, Inventory, Filters, and Information Cards
 - **v3.04.40 - Pagination reposition & padding**: pagination controls now appear above the Change Log section with added edge spacing
 - **v3.04.34 - Streamlined Numista imports**: Removed stored Numista CSV cache and clear-cache button
 - **v3.04.31 - Streamlined API history**: Removed charts and expanded API history table to fill modal
@@ -358,8 +359,8 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: 3.04.40
-**Last Updated**: August 12, 2025
+**Current Version**: 3.04.41
+**Last Updated**: August 17, 2025
 **Status**: Feature complete release candidate
 
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -236,6 +236,22 @@ h2 {
   margin-bottom: var(--spacing-sm);
 }
 
+.section-title {
+  text-align: center;
+  font-family:
+    "Inter",
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  margin: var(--spacing-lg) 0;
+}
+
+.modal-header .section-title {
+  margin: 0;
+}
+
 label {
   display: block;
   font-weight: 500;
@@ -2851,12 +2867,6 @@ input:disabled + .slider {
   position: relative;
   border-radius: var(--radius-lg) var(--radius-lg) 0 0;
   box-shadow: var(--shadow);
-}
-
-#filtersModal .modal-header h2 {
-  margin: 0;
-  color: var(--text-primary);
-  text-align: center;
 }
 
 #filtersModal .modal-body {

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.40
+# Multi-Agent Development Workflow - StackrTrackr v3.04.41
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.40**
+> **Latest release: v3.04.41**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.40**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.41**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: 3.04.40 (stable)
+**Current Status**: 3.04.41 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/agents/prompt.md
+++ b/docs/agents/prompt.md
@@ -1,6 +1,6 @@
 # StackrTrackr Development Prompt
 
-You're working on **StackrTrackr v3.04.40+**, a client-side precious metals inventory web app. Your job is to pick up a development task and implement it efficiently.
+You're working on **StackrTrackr v3.04.41+**, a client-side precious metals inventory web app. Your job is to pick up a development task and implement it efficiently.
 
 ## Quick Orientation (3 steps)
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,6 +1,7 @@
 # StackrTrackr Announcements
 
 ## What's New
+- **v3.04.41 – Section titles**: Added centered titles for Spot Prices, Inventory, Filters, and Information Cards.
 - **v3.04.40 – Fuzzy search engine**: Introduced standalone fuzzy search module with typo-tolerant matching.
 - **v3.04.36 – Dynamic summary bubbles**: Added color-coded counts for type, metal, purchase location, and storage location, and preserved link colors for URL purchases.
 - **v3.04.35 – JSON import options**: Split JSON import into Import and Merge buttons and removed Excel support.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,14 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.40**
+> **Latest release: v3.04.41**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.41 – Section Titles Enhancement (2025-08-17)
+- **UI**: Added centered section titles for Spot Prices, Inventory, Filters, and Information Cards using modern fonts.
 
 ### Version 3.04.40 – Pagination Section Reorder (2025-08-12)
 - **UI Layout**: Moved pagination controls above table controls with Change Log button

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.40**
+> **Latest release: v3.04.41**
 
 
 | File | Function | Description |

--- a/docs/human_workflow.md
+++ b/docs/human_workflow.md
@@ -2,7 +2,7 @@
 
 This guide summarizes the typical tools and branch strategy for human contributors to StackrTrackr.
 
-**Current Release:** v3.04.40
+**Current Release:** v3.04.41
 
 ## Tools
 

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,6 +1,6 @@
 # Implementation Summary: Dynamic Summary Bubbles
 
-> **Latest release: v3.04.40**
+> **Latest release: v3.04.41**
 
 ## Version Update: 3.04.35 → 3.04.36
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,7 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - _No active patch goals at this time._
 
 ## Completed Patch Goals (v3.04.xx)
+- ✅ **Section titles for main UI** - Added centered titles to Spot Prices, Inventory, Filters, and Information Cards (v3.04.41)
 - ✅ **Pagination section reorder** - Moved pagination above Change Log with edge padding (v3.04.40)
 - ✅ **Template Variable Resolution** - Fixed unreplaced template variables in documentation (v3.04.39)
 - Align inventory action buttons and theme controls

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,13 +2,13 @@
 
 
 
-> **Latest release: v3.04.40**
+> **Latest release: v3.04.41**
 
 See [announcements](announcements.md) for recent changes and upcoming milestones.
 
-## 🎯 Current State: **BETA v3.04.40** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.41** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.40** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.41** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -28,6 +28,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.04.41 - Section titles**: added centered titles for Spot Prices, Inventory, Filters, and Information Cards
 - **v3.04.40 - Pagination controls reposition**: moved pagination above Change Log and added edge padding
 - **v3.04.25 - Unified logo**: single SVG logo across themes, removed theme-specific assets
 - **v3.04.24 - Backup warning theming**: local storage warning uses theme colors with centered type summary and backup link
@@ -184,7 +185,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.04.40 (managed in `js/constants.js`)
+1. **Current Version**: 3.04.41 (managed in `js/constants.js`)
 2. **Last Change**: Simplified archive workflow
 3. **Last Documentation Update**: August 11, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.04.40**
+> **Latest release: v3.04.41**
 
 
 The repository is organized as follows:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.04.40**
+> **Latest release: v3.04.41**
 
 ## Overview 
 
@@ -9,7 +9,7 @@ The StackrTrackr now uses a dynamic version management system that automatically
 ## How It Works
 
 ### Single Source of Truth
- - Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.40'`
+ - Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.41'`
   - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation
@@ -19,7 +19,7 @@ The StackrTrackr now uses a dynamic version management system that automatically
 
 ### Utility Functions
 - `js/constants.js` provides:
-- `getVersionString(prefix)`: Returns formatted version (e.g., "v3.04.40")
+- `getVersionString(prefix)`: Returns formatted version (e.g., "v3.04.41")
   - `injectVersionString(elementId, prefix)`: Inserts formatted version into a target element
 - `js/utils.js` provides:
   - `getAppTitle(baseTitle)`: Returns full app title with version
@@ -31,14 +31,14 @@ To release a new version:
 1. **Update ONLY the constants file:**
    ```javascript
    // In js/constants.js
-    const APP_VERSION = '3.04.40';  // Change this line only
+    const APP_VERSION = '3.04.41';  // Change this line only
    ```
 
 2. **All these will automatically update:**
-  - Page title: "StackrTrackr v3.04.40"
-  - Page heading: "StackrTrackr v3.04.40"
-  - Browser tab title: "StackrTrackr v3.04.40"
-   - App header: "StackrTrackr v3.04.40"
+  - Page title: "StackrTrackr v3.04.41"
+  - Page heading: "StackrTrackr v3.04.41"
+  - Browser tab title: "StackrTrackr v3.04.41"
+   - App header: "StackrTrackr v3.04.41"
 
 3. **Update changelog:** Add entry to `/docs/changelog.md` for documentation
 

--- a/index.html
+++ b/index.html
@@ -216,6 +216,7 @@
          Spot prices are used for premium calculations and profit/loss analysis
          ============================================================================= -->
       <section class="spot-prices">
+        <h2 class="section-title">Spot Prices</h2>
         <div
           class="grid"
           style="
@@ -464,6 +465,7 @@
          Wrapper containing search and inventory table
          ============================================================================= -->
       <section class="inventory-section">
+        <h2 class="section-title">Inventory</h2>
         <!-- =============================================================================
            SEARCH FUNCTIONALITY
 
@@ -711,6 +713,7 @@
          Values are updated automatically when inventory changes
          ============================================================================= -->
       <section class="totals-section">
+        <h2 class="section-title">Information Cards</h2>
         <div class="totals">
           <!-- Silver totals card -->
           <div class="total-card silver">
@@ -1299,7 +1302,7 @@
     <div class="modal" id="filtersModal" style="display: none">
       <div class="modal-content">
         <div class="modal-header">
-          <h2>Advanced Filters</h2>
+          <h2 class="section-title">Filters</h2>
           <button aria-label="Close modal" class="modal-close" id="filtersCloseBtn">×</button>
         </div>
         <div class="modal-body">
@@ -2426,7 +2429,7 @@
     <div class="modal" id="filtersModal" style="display: none">
       <div class="modal-content">
         <div class="modal-header">
-          <h2>Filters</h2>
+          <h2 class="section-title">Filters</h2>
           <button aria-label="Close modal" class="modal-close" id="filtersCloseBtn">×</button>
         </div>
         <div class="modal-body">

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.40";
+const APP_VERSION = "3.04.41";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting


### PR DESCRIPTION
## Summary
- add centered titles for Spot Prices, Inventory, Filters, and Information Cards sections
- style titles with a reusable section-title class using modern fonts
- bump app version to v3.04.41 and update documentation

## Testing
- `for f in tests/*.test.js; do node $f; done`


------
https://chatgpt.com/codex/tasks/task_e_689bc83e89bc832eb02f83b8bcbb3904