### PR TITLE
feat: limit filter chips to frequent values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# StackrTrackr v3.04.41
+# StackrTrackr v3.04.43
 
 
 StackrTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -9,6 +9,8 @@ The public hosted version of the app is available at [stackrtrackr.com](https://
 See [docs/announcements.md](docs/announcements.md) for the latest release notes and upcoming milestones.
 
 ## Recent Updates
+- **v3.04.43 - Filter chip threshold**: summary chips only display values with more than two items
+- **v3.04.42 - Filter chip expansion**: added Filters subtitle and dynamic Name/Date chips that filter the table and update counts
 - **v3.04.41 - Section titles**: added centered titles for Spot Prices, Inventory, Filters, and Information Cards
 - **v3.04.40 - Pagination reposition & padding**: pagination controls now appear above the Change Log section with added edge spacing
 - **v3.04.34 - Streamlined Numista imports**: Removed stored Numista CSV cache and clear-cache button
@@ -359,7 +361,7 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: 3.04.41
+**Current Version**: 3.04.43
 **Last Updated**: August 17, 2025
 **Status**: Feature complete release candidate
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -2539,6 +2539,13 @@ td input:checked + .slider:before {
   text-align: center;
 }
 
+.table-subtitle {
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-align: center;
+  margin-bottom: 0.25rem;
+}
+
 .backup-link {
   text-decoration: underline;
   cursor: pointer;

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.41
+# Multi-Agent Development Workflow - StackrTrackr v3.04.43
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.41**
+> **Latest release: v3.04.43**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.41**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.43**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: 3.04.41 (stable)
+**Current Status**: 3.04.43 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/agents/prompt.md
+++ b/docs/agents/prompt.md
@@ -1,6 +1,6 @@
 # StackrTrackr Development Prompt
 
-You're working on **StackrTrackr v3.04.41+**, a client-side precious metals inventory web app. Your job is to pick up a development task and implement it efficiently.
+You're working on **StackrTrackr v3.04.43+**, a client-side precious metals inventory web app. Your job is to pick up a development task and implement it efficiently.
 
 ## Quick Orientation (3 steps)
 

--- a/docs/announcements.md
+++ b/docs/announcements.md
@@ -1,6 +1,8 @@
 # StackrTrackr Announcements
 
 ## What's New
+- **v3.04.43 – Filter chip threshold**: Summary chips now show only values with more than two items to reduce clutter.
+- **v3.04.42 – Filter chip expansion**: Added Filters subtitle and summary chips for Name and Date with dynamic counts and filtering.
 - **v3.04.41 – Section titles**: Added centered titles for Spot Prices, Inventory, Filters, and Information Cards.
 - **v3.04.40 – Fuzzy search engine**: Introduced standalone fuzzy search module with typo-tolerant matching.
 - **v3.04.36 – Dynamic summary bubbles**: Added color-coded counts for type, metal, purchase location, and storage location, and preserved link colors for URL purchases.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,17 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.41**
+> **Latest release: v3.04.43**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.43 – Filter Chip Threshold (2025-08-19)
+- **Filters**: Summary chips only render for values with more than two items.
+
+### Version 3.04.42 – Filter Chip Expansion (2025-08-18)
+- **Filters**: Added Filters subtitle and summary chips for Name and Date with dynamic counts and clickable filtering.
 
 ### Version 3.04.41 – Section Titles Enhancement (2025-08-17)
 - **UI**: Added centered section titles for Spot Prices, Inventory, Filters, and Information Cards using modern fonts.

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.41**
+> **Latest release: v3.04.43**
 
 
 | File | Function | Description |
@@ -107,7 +107,7 @@
 | inventory.js | filterLink | Builds clickable filter span with optional HTML content |
 | inventory.js | formatPurchaseLocation | Detects URLs and wraps Purchase Location in a hyperlink |
 | inventory.js | renderTable |  |
-| inventory.js | updateTypeSummary | Shows color-coded counts for type, metal, purchase location, and storage location |
+| inventory.js | updateTypeSummary | Renders clickable summary chips for type, metal, purchase location, storage location, name, and date when count > 2 |
 | inventory.js | updateSummary | Calculates and updates all financial summary displays across the application |
 | inventory.js | calculateTotals | Calculates financial metrics for specified metal type |
 | inventory.js | deleteItem | Deletes inventory item at specified index after confirmation |

--- a/docs/human_workflow.md
+++ b/docs/human_workflow.md
@@ -2,7 +2,7 @@
 
 This guide summarizes the typical tools and branch strategy for human contributors to StackrTrackr.
 
-**Current Release:** v3.04.41
+**Current Release:** v3.04.43
 
 ## Tools
 

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,18 +1,16 @@
-# Implementation Summary: Dynamic Summary Bubbles
+# Implementation Summary: Filter Chip Threshold
 
-> **Latest release: v3.04.41**
+> **Latest release: v3.04.43**
 
-## Version Update: 3.04.35 → 3.04.36
+## Version Update: 3.04.42 → 3.04.43
 
 ## User Requirements Implemented
 
-- Summary bubbles now include Type, Metal, Purchase Location, and Storage Location with color-coded counts.
-- Purchase Location URLs preserve their assigned colors when rendered as hyperlinks.
+- Summary chips now display only values with more than two items to reduce clutter.
 
 ## Technical Changes Made
 
 ### Files Modified:
-1. **`css/styles.css`**: Ensured filter link anchors inherit color and generalized chip styling.
-2. **`js/inventory.js`**: Expanded summary chip generation across multiple fields.
-3. **`js/constants.js`**: Bumped `APP_VERSION` to 3.04.36.
-4. **Documentation**: Updated announcements, changelog, function table, status, versioning, and workflow references.
+1. **`js/inventory.js`**: Skips rendering summary chips for counts below three.
+2. **`js/constants.js`**: Bumped `APP_VERSION` to 3.04.43.
+3. **Documentation**: Updated README, announcements, changelog, roadmap, status, versioning, workflow references, and function table.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,8 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - _No active patch goals at this time._
 
 ## Completed Patch Goals (v3.04.xx)
+- ✅ **Filter chip threshold** - Summary chips only show values with more than two items (v3.04.43)
+- ✅ **Expanded filter chips** - Added Name/Date chips with dynamic filtering and counts, replaced backup notice with Filters subtitle (v3.04.42)
 - ✅ **Section titles for main UI** - Added centered titles to Spot Prices, Inventory, Filters, and Information Cards (v3.04.41)
 - ✅ **Pagination section reorder** - Moved pagination above Change Log with edge padding (v3.04.40)
 - ✅ **Template Variable Resolution** - Fixed unreplaced template variables in documentation (v3.04.39)

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,13 +2,13 @@
 
 
 
-> **Latest release: v3.04.41**
+> **Latest release: v3.04.43**
 
 See [announcements](announcements.md) for recent changes and upcoming milestones.
 
-## 🎯 Current State: **BETA v3.04.41** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.43** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.41** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.43** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -28,6 +28,8 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.04.43 - Filter chip threshold**: summary chips only show values with more than two items
+- **v3.04.42 - Expanded filter chips**: replaced backup reminder with Filters subtitle and added Name/Date chips with dynamic filtering and counts
 - **v3.04.41 - Section titles**: added centered titles for Spot Prices, Inventory, Filters, and Information Cards
 - **v3.04.40 - Pagination controls reposition**: moved pagination above Change Log and added edge padding
 - **v3.04.25 - Unified logo**: single SVG logo across themes, removed theme-specific assets
@@ -185,7 +187,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.04.41 (managed in `js/constants.js`)
+1. **Current Version**: 3.04.43 (managed in `js/constants.js`)
 2. **Last Change**: Simplified archive workflow
 3. **Last Documentation Update**: August 11, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.04.41**
+> **Latest release: v3.04.43**
 
 
 The repository is organized as follows:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.04.41**
+> **Latest release: v3.04.43**
 
 ## Overview 
 
@@ -9,7 +9,7 @@ The StackrTrackr now uses a dynamic version management system that automatically
 ## How It Works
 
 ### Single Source of Truth
- - Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.41'`
+ - Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.43'`
   - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation
@@ -19,7 +19,7 @@ The StackrTrackr now uses a dynamic version management system that automatically
 
 ### Utility Functions
 - `js/constants.js` provides:
-- `getVersionString(prefix)`: Returns formatted version (e.g., "v3.04.41")
+ - `getVersionString(prefix)`: Returns formatted version (e.g., "v3.04.43")
   - `injectVersionString(elementId, prefix)`: Inserts formatted version into a target element
 - `js/utils.js` provides:
   - `getAppTitle(baseTitle)`: Returns full app title with version
@@ -31,14 +31,14 @@ To release a new version:
 1. **Update ONLY the constants file:**
    ```javascript
    // In js/constants.js
-    const APP_VERSION = '3.04.41';  // Change this line only
+    const APP_VERSION = '3.04.43';  // Change this line only
    ```
 
 2. **All these will automatically update:**
-  - Page title: "StackrTrackr v3.04.41"
-  - Page heading: "StackrTrackr v3.04.41"
-  - Browser tab title: "StackrTrackr v3.04.41"
-   - App header: "StackrTrackr v3.04.41"
+  - Page title: "StackrTrackr v3.04.43"
+  - Page heading: "StackrTrackr v3.04.43"
+  - Browser tab title: "StackrTrackr v3.04.43"
+  - App header: "StackrTrackr v3.04.43"
 
 3. **Update changelog:** Add entry to `/docs/changelog.md` for documentation
 

--- a/index.html
+++ b/index.html
@@ -680,10 +680,11 @@
         <div class="table-controls">
           <button type="button" id="changeLogBtn" class="btn">Change Log</button>
           <div class="disclaimer-wrapper">
-            <span class="table-disclaimer">
+            <!-- <span class="table-disclaimer">
               All data is stored locally.
               <span id="backupReminder" class="backup-link">Back up often.</span>
-            </span>
+            </span> -->
+            <h3 class="table-subtitle">Filters</h3>
             <div id="typeSummary"></div>
           </div>
           <div class="items-per-page">

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.41";
+const APP_VERSION = "3.04.43";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -524,6 +524,8 @@ const typeColors = {
 };
 const purchaseLocationColors = {};
 const storageLocationColors = {};
+const nameColors = {};
+const dateColors = {};
 
 const getColor = (map, key) => {
   if (!(key in map)) {
@@ -755,7 +757,8 @@ const startCellEdit = (idx, field, icon) => {
 
 window.startCellEdit = startCellEdit;
 
-const updateTypeSummary = () => {
+
+const updateTypeSummary = (items = inventory) => {
   const el = elements.typeSummary || document.getElementById('typeSummary');
   if (!el) return;
 
@@ -782,24 +785,44 @@ const updateTypeSummary = () => {
     {
       field: 'storageLocation',
       getColors: (val) => ({ bg: getStorageLocationColor(val), text: textColor })
+    },
+    {
+      field: 'name',
+      getColors: (val) => ({ bg: getColor(nameColors, val), text: textColor })
+    },
+    {
+      field: 'date',
+      getColors: (val) => ({ bg: getColor(dateColors, val), text: textColor }),
+      format: (val) => formatDisplayDate(val)
     }
   ];
 
-  const html = categories
-    .map(cat => {
-      const counts = inventory.reduce((acc, item) => {
-        const key = item[cat.field] || (cat.field === 'purchaseLocation' ? 'Numista Import' : 'Unknown');
-        acc[key] = (acc[key] || 0) + 1;
-        return acc;
-      }, {});
-      return Object.entries(counts)
-        .map(([val, count]) => {
-          const safeVal = sanitizeHtml(val);
-          const colors = cat.getColors(val);
-          const cls = cat.getClass ? ` ${cat.getClass(val)}` : '';
-          return `<span class="summary-chip${cls}" style="background-color: ${colors.bg}; color: ${colors.text};">${safeVal}: ${count}</span>`;
-        })
-        .join('');
+  const chips = [];
+  categories.forEach(cat => {
+    const counts = items.reduce((acc, item) => {
+      const key = item[cat.field] || (cat.field === 'purchaseLocation' ? 'Numista Import' : 'Unknown');
+      acc[key] = (acc[key] || 0) + 1;
+      return acc;
+    }, {});
+
+    Object.entries(counts).forEach(([val, count]) => {
+      if (count > 2) {
+        const colors = cat.getColors(val);
+        const cls = cat.getClass ? ` ${cat.getClass(val)}` : '';
+        const display = cat.format ? cat.format(val) : val;
+        chips.push({ field: cat.field, value: val, display, count, colors, cls });
+      }
+    });
+  });
+
+  chips.sort((a, b) => b.count - a.count);
+
+  const html = chips
+    .map(chip => {
+      const safeVal = sanitizeHtml(String(chip.display));
+      const handler = `applyQuickFilter('${chip.field}', ${JSON.stringify(chip.value)})`;
+      const escaped = escapeAttribute(handler);
+      return `<span class="summary-chip${chip.cls}" style="background-color: ${chip.colors.bg}; color: ${chip.colors.text};" onclick="${escaped}" tabindex="0" role="button" onkeydown="if(event.key==='Enter'||event.key===' ')${escaped}">${safeVal}: ${chip.count}</span>`;
     })
     .join('');
 
@@ -888,7 +911,7 @@ const renderTable = () => {
     );
 
     elements.inventoryTable.innerHTML = rows.concat(placeholders).join('');
-    updateTypeSummary();
+    updateTypeSummary(filteredInventory);
 
     // Update sort indicators
     const headers = document.querySelectorAll('#inventoryTable th');


### PR DESCRIPTION
## Summary
- show summary filter chips only when a value appears more than twice
- bump version to 3.04.43 and update documentation

## Testing
- `for f in tests/*.test.js; do echo "Running $f"; node $f; done`


------
https://chatgpt.com/codex/tasks/task_e_689bcb786bec832ea0a423722eabef0f