### PR TITLE
style: center filters card and anchor items dropdown

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2497,11 +2497,17 @@ td input:checked + .slider:before {
 
 .table-controls {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: space-between;
   gap: var(--spacing);
   margin: 0;
-  flex-wrap: wrap;
+}
+
+.top-controls {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
 }
 
 .items-label {
@@ -2523,13 +2529,6 @@ td input:checked + .slider:before {
 
 .btn.silver:hover {
   background: #9ca3af;
-}
-
-.disclaimer-wrapper {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
 }
 
 .table-disclaimer {
@@ -2631,9 +2630,22 @@ td input:checked + .slider:before {
   background: var(--secondary-hover);
 }
 
+.filters-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  padding: var(--spacing);
+  flex: 0 1 600px;
+  margin: var(--spacing) auto 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .filter-info {
   display: flex;
-  justify-content: space-between;
+  justify-content: center;
   align-items: center;
   margin-top: var(--spacing-sm);
   flex-wrap: wrap;
@@ -2651,9 +2663,10 @@ td input:checked + .slider:before {
   align-items: center;
   gap: var(--spacing-xs);
   color: #f8fafc;
-  padding: 0.25rem 0.5rem;
+  padding: 0 0.5rem;
   border-radius: var(--radius);
   font-size: 0.75rem;
+  line-height: 1;
   cursor: pointer;
 }
 

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.43
+# Multi-Agent Development Workflow - StackrTrackr v3.04.45
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.43**
+> **Latest release: v3.04.45**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.43**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.45**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: 3.04.43 (stable)
+**Current Status**: 3.04.45 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,19 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.43**
+> **Latest release: v3.04.45**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.45 – Centered Filters Card Refinements (2025-08-20)
+- **UI**: Filters card centered with top-anchored items dropdown and Change Log button.
+- **Filters**: Active filter chips reduced to single-line height.
+
+### Version 3.04.44 – Filters Card & Anchored Controls (2025-08-20)
+- **Filters**: Active filter chips hidden when no filters applied and moved into centered card.
+- **UI**: Change Log button and items dropdown anchored to top of Filters block.
 
 ### Version 3.04.43 – Filter Chip Totals & Tooltip Links (2025-08-19)
 - **Filters**: Summary chips show filtered/total counts and display only active categories.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,8 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - _No active patch goals at this time._
 
 ## Completed Patch Goals (v3.04.xx)
+- ✅ **Centered filters card refinements** - Items dropdown anchored left, chips single-line height, filters card centered (v3.04.45)
+- ✅ **Filters card and anchored controls** - Filters moved to centered card; controls anchored top; chips hidden when none (v3.04.44)
 - ✅ **Expanded filter chips** - Added Name/Date chips with dynamic filtering and counts, replaced backup notice with Filters subtitle (v3.04.42)
 - ✅ **Filter chip totals and purchase tooltips** - Chips show filtered/total counts, purchase links moved to info icons, table cells centered (v3.04.43)
 - ✅ **Section titles for main UI** - Added centered titles to Spot Prices, Inventory, Filters, and Information Cards (v3.04.41)

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,13 +2,13 @@
 
 
 
-> **Latest release: v3.04.43**
+> **Latest release: v3.04.45**
 
 See [announcements](announcements.md) for recent changes and upcoming milestones.
 
-## 🎯 Current State: **BETA v3.04.43** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.45** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.43** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.44** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -28,6 +28,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.04.44 - Filters card and anchored controls**: centered card for filters, chips hidden when none, controls pinned to top
 - **v3.04.43 - Filter chip totals and purchase link tooltips**: summary chips show filtered/total counts, purchase locations include informational links, and table cells are centered
 - **v3.04.42 - Expanded filter chips**: replaced backup reminder with Filters subtitle and added Name/Date chips with dynamic filtering and counts
 - **v3.04.41 - Section titles**: added centered titles for Spot Prices, Inventory, Filters, and Information Cards

--- a/index.html
+++ b/index.html
@@ -489,10 +489,6 @@
             <button class="btn" id="clearSearchBtn">Clear</button>
             <button class="btn success" id="newItemBtn">New Item</button>
           </div>
-          <div class="filter-info">
-            <div class="active-filters" id="activeFilters"></div>
-            <div class="search-results-info" id="searchResultsInfo"></div>
-          </div>
         </section>
         <!-- =============================================================================
            INVENTORY TABLE SECTION
@@ -678,24 +674,26 @@
       </section>
       <section class="table-controls-section">
         <div class="table-controls">
-          <button type="button" id="changeLogBtn" class="btn">Change Log</button>
-          <div class="disclaimer-wrapper">
-            <!-- <span class="table-disclaimer">
-              All data is stored locally.
-              <span id="backupReminder" class="backup-link">Back up often.</span>
-            </span> -->
+          <div class="top-controls">
+            <div class="items-per-page">
+              <span class="items-label">Items:</span>
+              <select class="pagination-select" id="itemsPerPage">
+                <option vaue="10">10</option>
+                <option value="15">15</option>
+                <option selected value="25">25</option>
+                <option value="50">50</option>
+                <option value="100">100</option>
+              </select>
+            </div>
+            <button type="button" id="changeLogBtn" class="btn">Change Log</button>
+          </div>
+          <div class="filters-card" id="filtersCard">
             <h3 class="table-subtitle">Filters</h3>
             <div id="typeSummary"></div>
-          </div>
-          <div class="items-per-page">
-            <span class="items-label">Items:</span>
-            <select class="pagination-select" id="itemsPerPage">
-              <option vaue="10">10</option>
-              <option value="15">15</option>
-              <option selected value="25">25</option>
-              <option value="50">50</option>
-              <option value="100">100</option>
-            </select>
+            <div class="filter-info">
+              <div class="active-filters" id="activeFilters"></div>
+              <div class="search-results-info" id="searchResultsInfo"></div>
+            </div>
           </div>
         </div>
       </section>

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.43";
+const APP_VERSION = "3.04.45";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/filters.js
+++ b/js/filters.js
@@ -258,6 +258,12 @@ const renderActiveFilters = () => {
     filters.push({ field: 'search', value: searchQuery });
   }
 
+  if (filters.length === 0) {
+    container.style.display = 'none';
+    return;
+  }
+  container.style.display = '';
+
   const colors = ['var(--primary)', 'var(--secondary)', 'var(--success)', 'var(--warning)', 'var(--danger)', 'var(--info)'];
   const labels = {
     metal: 'Metal',


### PR DESCRIPTION
## Summary
- center filters card beneath top-anchored Items dropdown and Change Log button
- reduce filter chips to a single-line height
- bump version to v3.04.45 and update docs

## Testing
- `node tests/quick-filter-generic.test.js`
- `node tests/export-numista-comments.test.js`
- `node tests/display-composition.test.js`
- `node tests/collectable-weight-numista.test.js`
- `node tests/estimate-numista.test.js`
- `node tests/search-numista.test.js`
- `node tests/totals-numista.test.js`
- `node tests/purchase-location-url.test.js`
- `node scripts/test-templates.js`


------
https://chatgpt.com/codex/tasks/task_e_689bd63c8c14832e895ab633f71e1961