### PR TITLE
Reorder filter controls and enforce single-line chips

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -2508,6 +2508,7 @@ td input:checked + .slider:before {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
+  gap: var(--spacing);
 }
 
 .items-label {
@@ -2636,8 +2637,8 @@ td input:checked + .slider:before {
   border-radius: var(--radius-lg);
   box-shadow: var(--shadow);
   padding: var(--spacing);
-  flex: 0 1 600px;
-  margin: var(--spacing) auto 0;
+  flex: 1;
+  margin: 0 var(--spacing);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -2654,8 +2655,9 @@ td input:checked + .slider:before {
 
 .active-filters {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   gap: var(--spacing-xs);
+  overflow-x: auto;
 }
 
 .filter-chip {

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.46
+# Multi-Agent Development Workflow - StackrTrackr v3.04.47
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.46**
+> **Latest release: v3.04.47**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.46**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.47**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: 3.04.46 (stable)
+**Current Status**: 3.04.47 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,15 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.46**
+> **Latest release: v3.04.47**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.47 – Filter Controls Reorder (2025-08-20)
+- **UI**: Filters card moved between Change Log and Items dropdown with controls repositioned.
+- **Filters**: Active filter chips stay on a single line with horizontal scrolling.
 
 ### Version 3.04.46 – Filter Card Layout Stabilization (2025-08-20)
 - **Filters**: Ensured active chips hide when no filters and enforced single-line height.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,7 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - _No active patch goals at this time._
 
 ## Completed Patch Goals (v3.04.xx)
+- ✅ **Filter controls reorder** - Filters card nested between Change Log and items dropdown with chips constrained to one line (v3.04.47)
 - ✅ **Filter card layout stabilization** - Reapplied centered filters card with top-anchored controls and hidden chips when inactive (v3.04.46)
 - ✅ **Centered filters card refinements** - Items dropdown anchored left, chips single-line height, filters card centered (v3.04.45)
 - ✅ **Filters card and anchored controls** - Filters moved to centered card; controls anchored top; chips hidden when none (v3.04.44)

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,13 +2,13 @@
 
 
 
-> **Latest release: v3.04.46**
+> **Latest release: v3.04.47**
 
 See [announcements](announcements.md) for recent changes and upcoming milestones.
 
-## 🎯 Current State: **BETA v3.04.46** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.47** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.46** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.47** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -28,6 +28,7 @@ The tool features a **modular JavaScript architecture** with separate files for 
 
 ## ✨ Latest Changes
 
+- **v3.04.47 - Filter controls reorder**: filters card positioned between Change Log and Items dropdown with single-line chips
 - **v3.04.46 - Filter card layout stabilization**: controls anchored top-left, chips hidden when none, single-line chip height
 - **v3.04.45 - Centered filters card refinements**: Items dropdown anchored left, chips single-line height, filters card centered
 - **v3.04.44 - Filters card and anchored controls**: centered card for filters, chips hidden when none, controls pinned to top
@@ -190,7 +191,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.04.46 (managed in `js/constants.js`)
+1. **Current Version**: 3.04.47 (managed in `js/constants.js`)
 2. **Last Change**: Simplified archive workflow
 3. **Last Documentation Update**: August 11, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns

--- a/index.html
+++ b/index.html
@@ -675,6 +675,15 @@
       <section class="table-controls-section">
         <div class="table-controls">
           <div class="top-controls">
+            <button type="button" id="changeLogBtn" class="btn">Change Log</button>
+            <div class="filters-card" id="filtersCard">
+              <h3 class="table-subtitle">Filters</h3>
+              <div id="typeSummary"></div>
+              <div class="filter-info">
+                <div class="active-filters" id="activeFilters"></div>
+                <div class="search-results-info" id="searchResultsInfo"></div>
+              </div>
+            </div>
             <div class="items-per-page">
               <span class="items-label">Items:</span>
               <select class="pagination-select" id="itemsPerPage">
@@ -684,15 +693,6 @@
                 <option value="50">50</option>
                 <option value="100">100</option>
               </select>
-            </div>
-            <button type="button" id="changeLogBtn" class="btn">Change Log</button>
-          </div>
-          <div class="filters-card" id="filtersCard">
-            <h3 class="table-subtitle">Filters</h3>
-            <div id="typeSummary"></div>
-            <div class="filter-info">
-              <div class="active-filters" id="activeFilters"></div>
-              <div class="search-results-info" id="searchResultsInfo"></div>
             </div>
           </div>
         </div>

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.46";
+const APP_VERSION = "3.04.47";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting


### PR DESCRIPTION
## Summary
- Place filters card between Change Log button and Items dropdown while swapping control positions.
- Ensure filter chips remain a single row with horizontal scrolling and make the card flex to available space.
- Bump version to 3.04.47 with corresponding documentation updates.

## Testing
- `for f in tests/*.test.js; do echo "Running $f"; node $f; echo; done`


------
https://chatgpt.com/codex/tasks/task_e_689bf1a709dc832ea7b41f2adf65ebc6