### PR TITLE
feat: update file menu colors and data wipe warning

### DIFF
--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.47
+# Multi-Agent Development Workflow - StackrTrackr v3.04.51
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.47**
+> **Latest release: v3.04.51**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.47**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.51**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: 3.04.47 (stable)
+**Current Status**: 3.04.51 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,15 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.50**
+> **Latest release: v3.04.51**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.51 – File Menu Color Updates (2025-08-13)
+- **File menu clarity**: Import buttons are now orange, merge buttons green, and export buttons remain blue
+- **Data wipe warning**: “Boating Accident?” button renamed to “Wipe All Data” with a cautionary notice
 
 ### Version 3.04.50 – Standardized Filter Chip Sizing (2025-08-12)
 - **Filter Chip Standardization**: Unified chip sizing across all filter types for consistent appearance

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,7 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - _No active patch goals at this time._
 
 ## Completed Patch Goals (v3.04.xx)
+- ✅ **File menu color coding and data wipe notice** - Import buttons orange, merge buttons green, Boating Accident renamed (v3.04.51)
 - ✅ **Filter controls reorder** - Filters card nested between Change Log and items dropdown with chips constrained to one line (v3.04.47)
 - ✅ **Filter card layout stabilization** - Reapplied centered filters card with top-anchored controls and hidden chips when inactive (v3.04.46)
 - ✅ **Centered filters card refinements** - Items dropdown anchored left, chips single-line height, filters card centered (v3.04.45)

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,13 +2,13 @@
 
 
 
-> **Latest release: v3.04.47**
+> **Latest release: v3.04.51**
 
 See [announcements](announcements.md) for recent changes and upcoming milestones.
 
-## 🎯 Current State: **BETA v3.04.47** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.51** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.47** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.51** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -191,7 +191,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.04.47 (managed in `js/constants.js`)
+1. **Current Version**: 3.04.51 (managed in `js/constants.js`)
 2. **Last Change**: Simplified archive workflow
 3. **Last Documentation Update**: August 11, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns

--- a/index.html
+++ b/index.html
@@ -1743,12 +1743,12 @@
               <div class="import-block">
                 <div class="import-export-grid">
                   <div class="import-csv-grid">
-                    <button class="btn danger" id="importCsvOverride">Import CSV</button>
+                    <button class="btn warning" id="importCsvOverride">Import CSV</button>
                     <button class="btn success" id="importCsvMerge">Merge CSV</button>
                     <input accept=".csv" hidden id="importCsvFile" type="file" />
                   </div>
                   <div class="import-json-grid">
-                    <button class="btn danger" id="importJsonOverride">Import JSON</button>
+                    <button class="btn warning" id="importJsonOverride">Import JSON</button>
                     <button class="btn success" id="importJsonMerge">Merge JSON</button>
                     <input accept=".json" hidden id="importJsonFile" type="file" />
                   </div>
@@ -1788,8 +1788,8 @@
                 <div class="third-party-block">
                   <div class="import-export-grid">
                     <div class="grid grid-2">
-                      <button class="btn danger" id="importNumistaBtn">Import Numista CSV</button>
-                      <button class="btn secondary" id="mergeNumistaBtn">Merge Numista CSV</button>
+                      <button class="btn warning" id="importNumistaBtn">Import Numista CSV</button>
+                      <button class="btn success" id="mergeNumistaBtn">Merge Numista CSV</button>
                     </div>
                     <input type="file" id="numistaImportFile" accept=".csv" hidden />
                     <div class="beta-warning">⚠️ Numista import is a beta feature</div>
@@ -1805,8 +1805,9 @@
                   Remove Inventory Data
                 </button>
                 <button class="btn danger" id="boatingAccidentBtn">
-                  Boating Accident?
+                  Wipe All Data
                 </button>
+                <div class="beta-warning">⚠️ have you or someone you know been involved in a 🚤 accident?</div>
               </div>
             </div>
           </div>

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.50";
+const APP_VERSION = "3.04.51";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting


### PR DESCRIPTION
## Summary
- color-code file menu imports and merges for clearer actions
- rename "Boating Accident?" to "Wipe All Data" with playful caution notice
- bump app version to 3.04.51 and document the change

## Testing
- `node scripts/update-templates.js`
- `for f in tests/*.test.js; do echo "Running $f"; node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_689bff906534832e943283a92292348b