### PR TITLE
Remove section titles and move filter controls above inventory table

### DIFF
--- a/docs/agents/agents.ai
+++ b/docs/agents/agents.ai
@@ -1,7 +1,7 @@
 # StackTrackr Project Instructions
 
 ## CONTEXT
-Precious metals inventory app (v3.04.39+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
+Precious metals inventory app (v3.04.52+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
 
 ## FILES
 - `index.html` - main UI
@@ -94,7 +94,7 @@ AUTO_WARN: "⚠️ Chat approaching limit. Start new conversation soon and refer
 `index.html` `events.js` `styles.css` - coordinate changes, minimal edits
 
 ## NOTES
-- Current version: 3.04.39 (template variable fixes in documentation)
+- Current version: 3.04.52
 - **THEME TOGGLE FIXED**: Button now shows current theme color/icon, removed system mode
 - **THEME ROTATION**: dark → light → sepia → dark (no system mode)
 - **BUTTON STYLING**: Shows current theme with matching background color

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.51
+# Multi-Agent Development Workflow - StackrTrackr v3.04.52
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.51**
+> **Latest release: v3.04.52**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.51**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.52**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: 3.04.51 (stable)
+**Current Status**: 3.04.52 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,15 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.51**
+> **Latest release: v3.04.52**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.52 – Layout Refinements (2025-08-13)
+- Removed section titles from Spot Prices, Inventory, and Information Cards
+- Moved filter controls and Change Log button above the inventory table
 
 ### Version 3.04.51 – File Menu Color Updates (2025-08-13)
 - **File menu clarity**: Import buttons are now orange, merge buttons green, and export buttons remain blue

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,7 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - _No active patch goals at this time._
 
 ## Completed Patch Goals (v3.04.xx)
+- ✅ **Titleless sections with repositioned controls** - Removed Spot Prices/Inventory/Information Cards headers and moved filter card with Change Log above table (v3.04.52)
 - ✅ **File menu color coding and data wipe notice** - Import buttons orange, merge buttons green, Boating Accident renamed (v3.04.51)
 - ✅ **Filter controls reorder** - Filters card nested between Change Log and items dropdown with chips constrained to one line (v3.04.47)
 - ✅ **Filter card layout stabilization** - Reapplied centered filters card with top-anchored controls and hidden chips when inactive (v3.04.46)

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,13 +2,13 @@
 
 
 
-> **Latest release: v3.04.51**
+> **Latest release: v3.04.52**
 
 See [announcements](announcements.md) for recent changes and upcoming milestones.
 
-## 🎯 Current State: **BETA v3.04.51** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.52** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.51** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.52** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -191,7 +191,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.04.51 (managed in `js/constants.js`)
+1. **Current Version**: 3.04.52 (managed in `js/constants.js`)
 2. **Last Change**: Simplified archive workflow
 3. **Last Documentation Update**: August 11, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns

--- a/index.html
+++ b/index.html
@@ -216,7 +216,6 @@
          Spot prices are used for premium calculations and profit/loss analysis
          ============================================================================= -->
       <section class="spot-prices">
-        <h2 class="section-title">Spot Prices</h2>
         <div
           class="grid"
           style="
@@ -465,7 +464,6 @@
          Wrapper containing search and inventory table
          ============================================================================= -->
       <section class="inventory-section">
-        <h2 class="section-title">Inventory</h2>
         <!-- =============================================================================
            SEARCH FUNCTIONALITY
 
@@ -488,6 +486,41 @@
             />
             <button class="btn" id="clearSearchBtn">Clear</button>
             <button class="btn success" id="newItemBtn">New Item</button>
+          </div>
+        </section>
+        <section class="table-controls-section">
+          <div class="table-controls">
+            <div class="top-controls">
+              <button type="button" id="changeLogBtn" class="btn">Change Log</button>
+              <div class="filters-card" id="filtersCard">
+                <h3 class="table-subtitle">Filters</h3>
+                <div class="filter-controls">
+                  <label for="chipMinCount" class="chip-min-label">Min items for chip:</label>
+                  <select id="chipMinCount" class="chip-min-select" title="Minimum number of items before showing a chip">
+                    <option value="1">1+</option>
+                    <option value="2">2+</option>
+                    <option value="3">3+</option>
+                    <option value="5">5+</option>
+                    <option value="10">10+</option>
+                  </select>
+                </div>
+                <div id="typeSummary"></div>
+                <div class="filter-info">
+                  <div class="active-filters" id="activeFilters"></div>
+                  <div class="search-results-info" id="searchResultsInfo"></div>
+                </div>
+              </div>
+              <div class="items-per-page">
+                <span class="items-label">Items:</span>
+                <select class="pagination-select" id="itemsPerPage">
+                  <option vaue="10">10</option>
+                  <option value="15">15</option>
+                  <option selected value="25">25</option>
+                  <option value="50">50</option>
+                  <option value="100">100</option>
+                </select>
+              </div>
+            </div>
           </div>
         </section>
         <!-- =============================================================================
@@ -672,41 +705,6 @@
             </div>
           </div>
       </section>
-      <section class="table-controls-section">
-        <div class="table-controls">
-          <div class="top-controls">
-            <button type="button" id="changeLogBtn" class="btn">Change Log</button>
-            <div class="filters-card" id="filtersCard">
-              <h3 class="table-subtitle">Filters</h3>
-              <div class="filter-controls">
-                <label for="chipMinCount" class="chip-min-label">Min items for chip:</label>
-                <select id="chipMinCount" class="chip-min-select" title="Minimum number of items before showing a chip">
-                  <option value="1">1+</option>
-                  <option value="2">2+</option>
-                  <option value="3">3+</option>
-                  <option value="5">5+</option>
-                  <option value="10">10+</option>
-                </select>
-              </div>
-              <div id="typeSummary"></div>
-              <div class="filter-info">
-                <div class="active-filters" id="activeFilters"></div>
-                <div class="search-results-info" id="searchResultsInfo"></div>
-              </div>
-            </div>
-            <div class="items-per-page">
-              <span class="items-label">Items:</span>
-              <select class="pagination-select" id="itemsPerPage">
-                <option vaue="10">10</option>
-                <option value="15">15</option>
-                <option selected value="25">25</option>
-                <option value="50">50</option>
-                <option value="100">100</option>
-              </select>
-            </div>
-          </div>
-        </div>
-      </section>
     </section>
     <!-- =============================================================================
        TOTALS SECTION
@@ -722,7 +720,6 @@
          Values are updated automatically when inventory changes
          ============================================================================= -->
       <section class="totals-section">
-        <h2 class="section-title">Information Cards</h2>
         <div class="totals">
           <!-- Silver totals card -->
           <div class="total-card silver">

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.51";
+const APP_VERSION = "3.04.52";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting


### PR DESCRIPTION
## Summary
- remove Spot Prices, Inventory, and Information Cards headers
- move filter card and change log button above inventory table
- bump version to 3.04.52 and update docs

## Testing
- `for f in tests/*.test.js; do echo "Running $f"; node "$f"; done`

------
https://chatgpt.com/codex/tasks/task_e_689c02387bfc832e8d4a5a59fa668e22