### PR TITLE
Rename API Configuration to Metals API Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ See [docs/announcements.md](docs/announcements.md) for the latest release notes 
 - Marked as **feature complete** for the 3.2.x series
 
 ## 🆕 What's New in v3.2.0
-- Appearance settings now appear before API configuration for quicker access
+- Appearance settings now appear before Metals API configuration for quicker access
 - Sync All displays a confirmation dialog showing how many records were updated
 - API price history modal matches other modals and includes a Clear Filter button
 
@@ -208,7 +208,7 @@ See [docs/announcements.md](docs/announcements.md) for the latest release notes 
   - Clicking "Reset" restores the price to default or API cached value.
   - Price history updates accordingly with source tracking.
 - **API Integration**:
-  - Sync buttons are enabled/disabled based on API configuration.
+  - Sync buttons are enabled/disabled based on Metals API configuration.
   - All metal prices sync simultaneously from configured provider.
   - Button states show loading status during syncing.
 - **Backwards Compatibility and Stability**: Maintained all existing workflows and data integrity during fixes.

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -412,7 +412,7 @@ For upcoming work, see [announcements](announcements.md).
 - Cloud Sync placeholder modal now uses standard themed header with internal close button
 
 ### Version 3.2.0 – Settings & History Polish (2025-08-08)
-- Appearance section moved above API configuration in Settings
+- Appearance section moved above Metals API configuration in Settings
 - Sync All displays confirmation with records updated
 - API price history modal restyled with Clear Filter button and header close
 

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -18,9 +18,9 @@
 | about.js | setupAboutModalEvents | Sets up event listeners for about modal elements |
 | about.js | setupAckModalEvents | Sets up event listeners for acknowledgment modal elements |
 | api.js | renderApiStatusSummary |  |
-| api.js | loadApiConfig | Loads API configuration from localStorage |
-| api.js | saveApiConfig | Saves API configuration to localStorage |
-| api.js | clearApiConfig | Clears API configuration |
+| api.js | loadApiConfig | Loads Metals API configuration from localStorage |
+| api.js | saveApiConfig | Saves Metals API configuration to localStorage |
+| api.js | clearApiConfig | Clears Metals API configuration |
 | api.js | clearApiCache | Clears only the API cache, keeping the configuration |
 | api.js | getCacheDurationMs | Gets cache duration in milliseconds |
 | api.js | setProviderStatus | Sets connection status for a provider in the settings UI |
@@ -53,8 +53,8 @@
 | api.js | showManualInput | Shows manual price input for a specific metal |
 | api.js | hideManualInput | Hides manual price input for a specific metal |
 | api.js | resetSpotPrice | Resets spot price to default or API cached value |
-| api.js | createBackupData | Exports backup data including API configuration |
-| api.js | downloadCompleteBackup | Downloads complete backup files including inventory and API configuration |
+| api.js | createBackupData | Exports backup data including Metals API configuration |
+| api.js | downloadCompleteBackup | Downloads complete backup files including inventory and Metals API configuration |
 | filters.js | populateFilterDropdowns | Populates filter modal dropdowns and exclude toggles |
 | filters.js | applyFilters | Applies modal filters with multi-select and exclusion options |
 | filters.js | applyQuickFilter | Adds or toggles a filter for a specific field value |

--- a/docs/future/cloudflare/cloudflare-analytics-integration.md
+++ b/docs/future/cloudflare/cloudflare-analytics-integration.md
@@ -74,7 +74,7 @@ const CF_ANALYTICS_CACHE_DURATION = 30 * 60 * 1000; // 30 minutes
 /**
  * Fetches analytics data from Cloudflare API
  * @param {string} endpoint - Analytics endpoint to call
- * @param {Object} config - API configuration
+ * @param {Object} config - Metals API configuration
  * @returns {Promise<Object|null>} Analytics data or null
  */
 const fetchCloudflareAnalytics = async (endpoint, config) => {
@@ -229,7 +229,7 @@ const refreshWebsiteStats = async () => {
     if (stats) {
       updateStatsDisplay(stats);
     } else {
-      alert('Failed to fetch website statistics. Check your API configuration.');
+      alert('Failed to fetch website statistics. Check your Metals API configuration.');
     }
   } catch (error) {
     console.error('Error refreshing stats:', error);
@@ -408,7 +408,7 @@ Add to existing settings modal in `index.html`:
 - [ ] Add Cloudflare provider to API_PROVIDERS
 - [ ] Create cloudflare-analytics.js module
 - [ ] Basic UI for page views and visitors
-- [ ] Settings integration for API configuration
+- [ ] Settings integration for Metals API configuration
 - [ ] Cache management
 
 ### Phase 2: Enhanced Metrics (v3.4.1)

--- a/index.html
+++ b/index.html
@@ -1698,7 +1698,7 @@
         </div>
         <div class="modal-body">
           <div class="settings-section">
-            <h3 style="margin-bottom: 1rem">API Configuration</h3>
+            <h3 style="margin-bottom: 1rem">Metals API Configuration</h3>
             <p class="settings-subtext">Manage API cache, history, and providers.</p>
 
 

--- a/js/api.js
+++ b/js/api.js
@@ -38,8 +38,8 @@ let apiHistorySortAsc = true;
 let apiHistoryFilterText = "";
 
 /**
- * Loads API configuration from localStorage
- * @returns {Object|null} API configuration or null if not set
+ * Loads Metals API configuration from localStorage
+ * @returns {Object|null} Metals API configuration or null if not set
  */
 const loadApiConfig = () => {
   try {
@@ -137,8 +137,8 @@ const loadApiConfig = () => {
 };
 
 /**
- * Saves API configuration to localStorage
- * @param {Object} config - API configuration object
+ * Saves Metals API configuration to localStorage
+ * @param {Object} config - Metals API configuration object
  */
 const saveApiConfig = (config) => {
   try {
@@ -177,7 +177,7 @@ const saveApiConfig = (config) => {
 };
 
 /**
- * Clears API configuration
+ * Clears Metals API configuration
  */
 const clearApiConfig = () => {
   localStorage.removeItem(API_KEY_STORAGE_KEY);
@@ -1083,7 +1083,7 @@ const syncSpotPricesFromApi = async (
     !apiConfig.keys[apiConfig.provider]
   ) {
     alert(
-      "No API configuration found. Please configure an API provider first.",
+      "No Metals API configuration found. Please configure an API provider first.",
     );
     return false;
   }
@@ -1106,7 +1106,7 @@ const syncSpotPricesFromApi = async (
               : `${minutesAgo} minutes ago`;
 
           alert(
-            `Using cached prices from ${timeText}. To pull fresh data from the API, go to the API configuration and clear the cache first.`,
+            `Using cached prices from ${timeText}. To pull fresh data from the API, go to the Metals API configuration and clear the cache first.`,
           );
         }
 
@@ -1593,7 +1593,7 @@ const resetSpotPrice = (metal) => {
 };
 
 /**
- * Exports backup data including API configuration
+ * Exports backup data including Metals API configuration
  * @returns {Object} Complete backup data object
  */
 const createBackupData = () => {
@@ -1621,7 +1621,7 @@ const createBackupData = () => {
 };
 
 /**
- * Downloads complete backup files including inventory and API configuration
+ * Downloads complete backup files including inventory and Metals API configuration
  */
 const downloadCompleteBackup = async () => {
   try {
@@ -1745,7 +1745,7 @@ Application Version: ${APP_VERSION}
 3. **complete-backup-${timestamp}.json** - Full application backup
 4. **backup-info-${timestamp}.md** - This documentation file
 
-## API Configuration
+## Metals API Configuration
 ${
   backupData.apiConfig
     ? `
@@ -1768,7 +1768,7 @@ ${
     : ""
 }
 `
-    : "No API configuration found."
+    : "No Metals API configuration found."
 }
 
 ## Current Data Summary

--- a/js/events.js
+++ b/js/events.js
@@ -858,7 +858,7 @@ const setupEventListeners = () => {
               syncSpotPricesFromApi(true);
             } else {
               alert(
-                "API sync functionality requires API configuration. Please configure an API provider first.",
+                "API sync functionality requires Metals API configuration. Please configure an API provider first.",
               );
             }
           },

--- a/js/state.js
+++ b/js/state.js
@@ -262,7 +262,7 @@ let spotPrices = {
 /** @type {Array} Historical spot price records */
 let spotHistory = [];
 
-/** @type {Object|null} Current API configuration */
+/** @type {Object|null} Current Metals API configuration */
 let apiConfig = null;
 
 /** @type {Object|null} Cached API data with timestamp */

--- a/js/utils.js
+++ b/js/utils.js
@@ -1152,7 +1152,7 @@ const getStorageItemDisplayName = (key) => {
   const names = {
     'precious-metals-inventory': 'Inventory Data',
     'spot-price-history': 'Spot Price History',
-    'api-config': 'API Configuration',
+    'api-config': 'Metals API Configuration',
     'api-cache': 'API Cache',
     'spotPriceSilver': 'Silver Spot Price',
     'spotPriceGold': 'Gold Spot Price',
@@ -1172,7 +1172,7 @@ const getStorageItemDescription = (key) => {
   const descriptions = {
     'precious-metals-inventory': 'Your complete inventory of precious metals items with all details',
     'spot-price-history': 'Historical spot price data from API providers and manual entries',
-    'api-config': 'API provider configurations and usage statistics',
+    'api-config': 'Metals API provider configurations and usage statistics',
     'api-cache': 'Cached spot price data to reduce API calls',
     'spotPriceSilver': 'Current spot price setting for silver',
     'spotPriceGold': 'Current spot price setting for gold', 
@@ -2231,7 +2231,7 @@ const getStorageReportJS = () => {
         const names = {
             'precious-metals-inventory': 'Inventory Data',
             'spot-price-history': 'Spot Price History',
-            'api-config': 'API Configuration',
+            'api-config': 'Metals API Configuration',
             'api-cache': 'API Cache',
             'spotPriceSilver': 'Silver Spot Price',
             'spotPriceGold': 'Gold Spot Price',


### PR DESCRIPTION
## Summary
- Rename API settings heading to "Metals API Configuration" and update related display/description mappings
- Update API module comments and alerts to reference Metals API configuration
- Refresh documentation to use new Metals API configuration terminology

## Testing
- `for f in tests/*.test.js; do echo "Running $f"; node $f; done`


------
https://chatgpt.com/codex/tasks/task_e_689c0a25fd68832ebc46079cd6c0a234