### PR TITLE
Add Numista API placeholder in settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -1720,6 +1720,19 @@
               </button>
             </div>
           </div>
+          <div class="settings-section">
+            <h3 style="margin-bottom: 1rem">Numista API</h3>
+            <div class="api-key-row">
+              <label for="numistaApiKey">API Key:</label>
+              <input
+                type="password"
+                id="numistaApiKey"
+                placeholder="Coming soon"
+                disabled
+              />
+            </div>
+            <div class="api-key-note">Numista API integration coming soon.</div>
+          </div>
         </div>
       </div>
     </div>

--- a/js/init.js
+++ b/js/init.js
@@ -104,6 +104,7 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.exportPdfBtn = safeGetElement("exportPdfBtn");
     elements.cloudSyncBtn = safeGetElement("cloudSyncBtn");
     elements.syncAllBtn = safeGetElement("syncAllBtn");
+    elements.numistaApiKey = safeGetElement("numistaApiKey");
     elements.removeInventoryDataBtn = safeGetElement("removeInventoryDataBtn");
     elements.boatingAccidentBtn = safeGetElement("boatingAccidentBtn");
 


### PR DESCRIPTION
## Summary
- Add Numista API section in API modal with disabled key field and upcoming integration notice
- Register `numistaApiKey` in initialization to enable future DOM references

## Testing
- `for f in tests/*.test.js; do echo "Running $f"; node "$f"; echo; done`


------
https://chatgpt.com/codex/tasks/task_e_689c0e051644832eabbc28263fcc5720