### PR TITLE
Fix items-per-page persistence and default to 25

### DIFF
--- a/index.html
+++ b/index.html
@@ -513,7 +513,7 @@
               <div class="items-per-page">
                 <span class="items-label">Items:</span>
                 <select class="pagination-select" id="itemsPerPage">
-                  <option vaue="10">10</option>
+                  <option value="10">10</option>
                   <option value="15">15</option>
                   <option selected value="25">25</option>
                   <option value="50">50</option>

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1011,23 +1011,6 @@ const renderTable = () => {
   return monitorPerformance(() => {
     const filteredInventory = filterInventory();
 
-    // Automatically adjust items-per-page dropdown when filtered results
-    // are fewer than the currently selected page length. This ensures the
-    // table length always displays a sensible value (minimum of the smallest
-    // dropdown option) while still allowing larger result sets to use
-    // pagination.
-    if (filteredInventory.length < itemsPerPage && elements.itemsPerPage) {
-      const options = Array.from(elements.itemsPerPage.options).map(o => parseInt(o.value));
-      const minOption = Math.min(...options);
-      const target = Math.max(filteredInventory.length, minOption);
-      const newValue = options.find(opt => opt >= target) || options[options.length - 1];
-      if (newValue !== itemsPerPage) {
-        itemsPerPage = newValue;
-        elements.itemsPerPage.value = String(newValue);
-        currentPage = 1;
-      }
-    }
-
     const sortedInventory = sortInventory(filteredInventory);
     const totalPages = calculateTotalPages(sortedInventory);
     const startIndex = (currentPage - 1) * itemsPerPage;

--- a/js/state.js
+++ b/js/state.js
@@ -14,7 +14,7 @@ let editingChangeLogIndex = null;
 
 /** @type {Object} Pagination state */
 let currentPage = 1; // Current page number (1-based)
-let itemsPerPage = 10; // Number of items to display per page
+let itemsPerPage = 25; // Number of items to display per page
 
 /** @type {string} Current search query */
 let searchQuery = "";

--- a/tests/items-per-page-persistence.test.js
+++ b/tests/items-per-page-persistence.test.js
@@ -1,0 +1,100 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+// Minimal DOM and environment stubs
+global.localStorage = { getItem: () => null, setItem: () => {} };
+global.window = global;
+global.document = {
+  documentElement: { getAttribute: () => 'light' },
+  querySelectorAll: () => [],
+  getElementById: id => {
+    if (id === 'inventoryTable') return { innerHTML: '' };
+    if (id === 'itemsPerPage') {
+      return {
+        value: '25',
+        options: [
+          { value: '10' },
+          { value: '15' },
+          { value: '25' },
+          { value: '50' },
+          { value: '100' },
+        ],
+      };
+    }
+    return null;
+  },
+};
+
+// Required global variables/functions
+global.elements = { inventoryTable: null, itemsPerPage: null };
+global.monitorPerformance = fn => fn();
+global.filterInventory = () => inventory;
+global.sortInventory = arr => arr;
+global.calculateTotalPages = arr => Math.max(1, Math.ceil(arr.length / itemsPerPage));
+global.formatCurrency = v => v;
+global.formatDisplayDate = v => v;
+global.getTypeColor = () => '';
+global.getDisplayComposition = s => s;
+global.formatWeight = v => v;
+global.formatPurchaseLocation = v => v;
+global.getStorageLocationColor = () => '';
+global.filterLink = () => '';
+global.escapeAttribute = s => s;
+global.sanitizeHtml = s => s;
+global.toggleCollectable = () => {};
+global.showNotes = () => {};
+global.editItem = () => {};
+global.deleteItem = () => {};
+global.updateTypeSummary = () => {};
+global.setupColumnResizing = () => {};
+global.renderPagination = () => {};
+global.updateColumnVisibility = () => {};
+global.METAL_COLORS = {};
+
+// Load modules
+vm.runInThisContext(fs.readFileSync('js/state.js', 'utf8'));
+elements.inventoryTable = document.getElementById('inventoryTable');
+elements.itemsPerPage = document.getElementById('itemsPerPage');
+let inventoryCode = fs.readFileSync('js/inventory.js', 'utf8');
+inventoryCode = inventoryCode.replace(/\n\s*updateSummary\(\);\n/, '\n');
+vm.runInThisContext(inventoryCode);
+
+// Create sample inventory with 30 entries
+inventory = Array.from({ length: 30 }, (_, i) => ({
+  metal: 'Silver',
+  composition: 'Silver',
+  name: 'Item' + i,
+  qty: 1,
+  type: 'Coin',
+  weight: 1,
+  price: 1,
+  spotPriceAtPurchase: 1,
+  isCollectable: false,
+  totalPremium: 0,
+  purchaseLocation: '',
+  storageLocation: '',
+  numistaId: '',
+  notes: '',
+  date: '2024-01-01',
+}));
+
+// Initial render should use default 25 items per page
+renderTable();
+let rows = (elements.inventoryTable.innerHTML.match(/<tr>/g) || []).length;
+assert.strictEqual(itemsPerPage, 25);
+assert.strictEqual(rows, 25);
+
+// Change to 50 items per page and render
+itemsPerPage = 50;
+renderTable();
+rows = (elements.inventoryTable.innerHTML.match(/<tr>/g) || []).length;
+assert.strictEqual(rows, 50);
+
+// Filter inventory down to 5 items and ensure selection persists
+inventory = inventory.slice(0, 5);
+renderTable();
+assert.strictEqual(itemsPerPage, 50);
+
+console.log('items-per-page persistence test passed');
+


### PR DESCRIPTION
## Summary
- default to 25 items per page in state and UI
- remove auto-adjust that reset user choice when filtering
- add regression test ensuring items-per-page selection persists

## Testing
- `node tests/items-per-page-persistence.test.js`
- `for f in tests/*.test.js; do node "$f"; done`
- `node -e "global.localStorage={getItem:()=>null};const fs=require('fs'),vm=require('vm');vm.runInThisContext(fs.readFileSync('js/state.js','utf8'));console.log('itemsPerPage default:',itemsPerPage);"`
- `node -e "const fs=require('fs');const html=fs.readFileSync('index.html','utf8');const selectHtml=html.match(/<select[^>]*id=\"itemsPerPage\"[\s\S]*?<\/select>/)[0];const firstOpt=selectHtml.match(/<option[^>]*>(\d+)<\/option>/)[0];const firstVal=/value=\"(\d+)\"/.exec(firstOpt)[1];const selected=/selected value=\"(\d+)\"/.exec(selectHtml)[1];console.log('default value:',selected);console.log('first option value:',firstVal);"`


------
https://chatgpt.com/codex/tasks/task_e_689c14c6c960832e80849b7e8f97b998