### PR TITLE
Render Unknown storage locations

### DIFF
--- a/js/inventory.js
+++ b/js/inventory.js
@@ -566,7 +566,8 @@ const filterLink = (field, value, color, displayValue = value, title, allowHtml 
 
 const getTypeColor = type => typeColors[type] || 'var(--type-other-bg)';
 const getPurchaseLocationColor = loc => getColor(purchaseLocationColors, loc);
-const getStorageLocationColor = loc => getColor(storageLocationColors, loc);
+const getStorageLocationColor = loc =>
+  loc === 'Unknown' ? 'var(--text-muted)' : getColor(storageLocationColors, loc);
 
 /**
  * Formats Purchase Location for table display, wrapping URLs in hyperlinks
@@ -1052,7 +1053,7 @@ const renderTable = () => {
         ${formatPurchaseLocation(item.purchaseLocation)}
       </td>
       <td class="shrink" data-column="storageLocation">
-        ${item.storageLocation === 'Unknown' ? '' : filterLink('storageLocation', item.storageLocation || 'Numista Import', getStorageLocationColor(item.storageLocation || 'Numista Import'))}
+        ${filterLink('storageLocation', item.storageLocation || 'Unknown', getStorageLocationColor(item.storageLocation || 'Unknown'))}
       </td>
       <td class="shrink" data-column="numista">${item.numistaId ? `<a href="https://en.numista.com/catalogue/pieces${item.numistaId}.html" target="_blank" rel="noopener" title="View on Numista">N# ${sanitizeHtml(item.numistaId)}</a>` : ''}</td>
       <td class="icon-col" data-column="collectable"><span class="collectable-status" role="button" tabindex="0" onclick="toggleCollectable(${originalIdx})" onkeydown="if(event.key==='Enter'||event.key===' ') toggleCollectable(${originalIdx})" aria-label="Toggle collectable status for ${sanitizeHtml(item.name)}" title="Toggle collectable status">${item.isCollectable ? '<svg class=\"collectable-icon icon-copper\" xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><circle cx=\"12\" cy=\"12\" r=\"10\"/></svg>' : '<svg class=\"collectable-icon icon-gold\" xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"M3 3h18v18H3V3zm2 2v14h14V5H5zm5 10h6v2H10v-2zm2-8a2 2 0 100 4 2 2 0 000-4z\"/></svg>'}</span></td>

--- a/tests/storage-location-display.test.js
+++ b/tests/storage-location-display.test.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+// Minimal DOM stubs for sanitizeHtml and theming
+global.document = {
+  createElement: () => ({
+    textContent: '',
+    get innerHTML() {
+      return this.textContent
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+  }),
+  documentElement: { getAttribute: () => 'light' },
+  getElementById: () => null
+};
+
+global.window = global;
+
+// Load utilities and inventory code
+vm.runInThisContext(fs.readFileSync('js/utils.js', 'utf8'));
+vm.runInThisContext(fs.readFileSync('js/inventory.js', 'utf8'));
+
+// No storage location should display "Unknown" without color style
+const htmlUnknown = filterLink(
+  'storageLocation',
+  '' || 'Unknown',
+  getStorageLocationColor('Unknown')
+);
+assert(htmlUnknown.includes('>Unknown</span>'), 'Unknown location should display text');
+assert(!htmlUnknown.includes('style="color'), 'Unknown location should have no color style');
+
+// Existing storage location should be filterable with color style
+const htmlLoc = filterLink(
+  'storageLocation',
+  'Vault A',
+  getStorageLocationColor('Vault A')
+);
+assert(htmlLoc.includes('>Vault A</span>'), 'Storage location should display text');
+assert(htmlLoc.includes('style="color'), 'Storage location should have color style');
+console.log('Storage location display tests passed');


### PR DESCRIPTION
## Summary
- Always show storage location links, defaulting to **Unknown** when missing
- Handle `Unknown` storage locations with neutral color assignment
- Add tests to verify `Unknown` displays without color and real locations retain color

## Testing
- `node tests/storage-location-display.test.js`
- `for f in tests/*.test.js; do node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_689c1caaf5ac832e9ad9d88d88938a4b