### PR TITLE
Add option to clear change log

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1544,6 +1544,17 @@ input[type="submit"] {
   flex: 1;
 }
 
+#changeLogModal .modal-footer {
+  padding: var(--spacing);
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: flex-end;
+}
+
+#changeLogClearBtn {
+  font-size: 1.25rem;
+}
+
 #detailsModal .modal-body {
   padding: var(--spacing-xl);
   flex: 1;

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.54
+# Multi-Agent Development Workflow - StackrTrackr v3.04.55
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.54**
+> **Latest release: v3.04.55**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.54**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.55**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: 3.04.54 (stable)
+**Current Status**: 3.04.55 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,14 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.54**
+> **Latest release: v3.04.55**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.55 – Change Log Clearing (2025-08-16)
+- Added Clear Log button with confirmation to Change Log modal
 
 ### Version 3.04.54 – Search Controls Rework (2025-08-15)
 - Reordered search controls with icon buttons and integrated Change Log

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.42**
+> **Latest release: v3.04.55**
 
 
 | File | Function | Description |
@@ -64,6 +64,7 @@
 | changeLog.js | logItemChanges | Compares two item objects and logs any differences |
 | changeLog.js | renderChangeLog | Renders the change log table with all entries |
 | changeLog.js | toggleChange | Toggles a logged change between undone and redone states |
+| changeLog.js | clearChangeLog | Clears all change log entries after confirmation |
 | charts.js | generateColors | Generates a color palette for pie chart segments |
 | charts.js | getChartBackgroundColor | Gets appropriate background color for charts based on current theme |
 | charts.js | getChartTextColor | Gets appropriate text color for charts based on current theme |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,6 +1,6 @@
 # Implementation Summary: Filter Chip Expansion
 
-> **Latest release: v3.04.42**
+> **Latest release: v3.04.55**
 
 ## Version Update: 3.04.41 → 3.04.42
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,7 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - _No active patch goals at this time._
 
 ## Completed Patch Goals (v3.04.xx)
+- ✅ **Change log clearing option** - Added Clear Log button with confirmation in Change Log modal (v3.04.55)
 - ✅ **Search control consolidation** - New item icon, Change Log in search bar, and clear button redesign (v3.04.54)
 - ✅ **Clickable logo reloads application** - App logo refreshes the page when clicked (v3.04.53)
 - ✅ **Titleless sections with repositioned controls** - Removed Spot Prices/Inventory/Information Cards headers and moved filter card with Change Log above table (v3.04.52)

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,13 +2,13 @@
 
 
 
-> **Latest release: v3.04.52**
+> **Latest release: v3.04.55**
 
 See [announcements](announcements.md) for recent changes and upcoming milestones.
 
-## 🎯 Current State: **BETA v3.04.52** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.55** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.52** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.55** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -191,7 +191,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.04.52 (managed in `js/constants.js`)
+1. **Current Version**: 3.04.55 (managed in `js/constants.js`)
 2. **Last Change**: Simplified archive workflow
 3. **Last Documentation Update**: August 11, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.04.42**
+> **Latest release: v3.04.55**
 
 
 The repository is organized as follows:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.04.42**
+> **Latest release: v3.04.55**
 
 ## Overview 
 

--- a/index.html
+++ b/index.html
@@ -1294,6 +1294,15 @@
             </thead>
             <tbody></tbody>
           </table>
+        </div>
+        <div class="modal-footer">
+          <button
+            class="btn secondary icon-btn"
+            id="changeLogClearBtn"
+            title="Clear log"
+            aria-label="Clear log"
+          >↺</button>
+        </div>
       </div>
     </div>
   </div>

--- a/js/changeLog.js
+++ b/js/changeLog.js
@@ -123,10 +123,21 @@ const toggleChange = (logIdx) => {
   localStorage.setItem('changeLog', JSON.stringify(changeLog));
 };
 
+/**
+ * Clears all change log entries after confirmation
+ */
+const clearChangeLog = () => {
+  if (!confirm('Clear change log?')) return;
+  changeLog = [];
+  localStorage.setItem('changeLog', JSON.stringify(changeLog));
+  renderChangeLog();
+};
+
 window.logChange = logChange;
 window.logItemChanges = logItemChanges;
 window.renderChangeLog = renderChangeLog;
 window.toggleChange = toggleChange;
+window.clearChangeLog = clearChangeLog;
 window.editFromChangeLog = (idx, logIdx) => {
   const modal = document.getElementById('changeLogModal');
   if (modal) {

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.54";
+const APP_VERSION = "3.04.55";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/events.js
+++ b/js/events.js
@@ -783,6 +783,19 @@ const setupEventListeners = () => {
       );
     }
 
+    if (elements.changeLogClearBtn) {
+      safeAttachListener(
+        elements.changeLogClearBtn,
+        "click",
+        () => {
+          if (typeof clearChangeLog === "function") {
+            clearChangeLog();
+          }
+        },
+        "Change log clear button",
+      );
+    }
+
     // SPOT PRICE EVENT LISTENERS
     debugLog("Setting up spot price listeners...");
     Object.values(METALS).forEach((metalConfig) => {

--- a/js/init.js
+++ b/js/init.js
@@ -173,6 +173,7 @@ document.addEventListener("DOMContentLoaded", () => {
       elements.typeSummary = safeGetElement("typeSummary");
       elements.changeLogModal = safeGetElement("changeLogModal");
       elements.changeLogCloseBtn = safeGetElement("changeLogCloseBtn");
+      elements.changeLogClearBtn = safeGetElement("changeLogClearBtn");
       elements.changeLogTable = safeGetElement("changeLogTable");
       elements.storageUsage = safeGetElement("storageUsage");
       elements.storageReportLink = safeGetElement("storageReportLink");

--- a/js/state.js
+++ b/js/state.js
@@ -138,6 +138,7 @@ const elements = {
     typeSummary: null,
   changeLogModal: null,
   changeLogCloseBtn: null,
+  changeLogClearBtn: null,
   changeLogTable: null,
   storageUsage: null,
   storageReportLink: null,

--- a/tests/change-log-clear.test.js
+++ b/tests/change-log-clear.test.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+// Stub localStorage
+const storage = {};
+global.localStorage = {
+  getItem: (k) => (k in storage ? storage[k] : null),
+  setItem: (k, v) => { storage[k] = v; },
+};
+
+// Stub environment
+global.changeLog = [{ timestamp: Date.now(), itemName: 'Item', field: 'name', oldValue: 'a', newValue: 'b', idx: 0, undone: false }];
+
+global.confirm = () => true;
+global.window = global;
+global.document = { querySelector: () => ({ innerHTML: '' }) };
+
+vm.runInThisContext(fs.readFileSync('js/changeLog.js', 'utf8'));
+
+clearChangeLog();
+
+assert.strictEqual(changeLog.length, 0, 'Change log should be cleared');
+assert.strictEqual(storage.changeLog, '[]', 'LocalStorage should contain empty array');
+
+console.log('Change log clear tests passed');


### PR DESCRIPTION
## Summary
- Add Clear Log button to Change Log modal with reset icon
- Implement confirmation-based handler to wipe stored change log data
- Style modal footer and update documentation for v3.04.55

## Testing
- `node tests/change-log-clear.test.js`
- `for f in tests/*.test.js; do node "$f"; echo "ran $f"; done`
- `node tests/purchase-location-url.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689c20a62e68832e957459a48f0be3d8