### PR TITLE
Align filters card with spot price card and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# StackrTrackr v3.04.52
+# StackrTrackr v3.04.57
 
 
 StackrTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -9,6 +9,7 @@ The public hosted version of the app is available at [stackrtrackr.com](https://
 See [docs/announcements.md](docs/announcements.md) for the latest release notes and upcoming milestones.
 
 ## Recent Updates
+- **v3.04.57 - Filters card edge alignment**: filters card extends left to align with spot price card
 - **v3.04.42 - Filter chip expansion**: added Filters subtitle and dynamic Name/Date chips that filter the table and update counts
 - **v3.04.41 - Section titles**: added centered titles for Spot Prices, Inventory, Filters, and Information Cards
 - **v3.04.40 - Pagination reposition & padding**: pagination controls now appear above the Change Log section with added edge spacing
@@ -360,7 +361,7 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: v3.04.52
+**Current Version**: v3.04.57
 **Last Updated**: August 13, 2025
 **Status**: Feature complete release candidate
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -2646,7 +2646,7 @@ td input:checked + .slider:before {
   box-shadow: var(--shadow);
   padding: var(--spacing);
   flex: 1;
-  margin: 0 var(--spacing);
+  margin: 0;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/docs/agents/agents.ai
+++ b/docs/agents/agents.ai
@@ -1,7 +1,7 @@
 # StackTrackr Project Instructions
 
 ## CONTEXT
-Precious metals inventory app (v3.04.54+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
+Precious metals inventory app (v3.04.57+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
 
 ## FILES
 - `index.html` - main UI
@@ -94,7 +94,7 @@ AUTO_WARN: "⚠️ Chat approaching limit. Start new conversation soon and refer
 `index.html` `events.js` `styles.css` - coordinate changes, minimal edits
 
 ## NOTES
-- Current version: 3.04.52
+- Current version: 3.04.57
 - **THEME TOGGLE FIXED**: Button now shows current theme color/icon, removed system mode
 - **THEME ROTATION**: dark → light → sepia → dark (no system mode)
 - **BUTTON STYLING**: Shows current theme with matching background color

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.56
+# Multi-Agent Development Workflow - StackrTrackr v3.04.57
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.56**
+> **Latest release: v3.04.57**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.56**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.57**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: 3.04.56 (stable)
+**Current Status**: 3.04.57 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,14 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.56**
+> **Latest release: v3.04.57**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.57 – Filters Card Edge Alignment (2025-08-18)
+- Removed left margin from Filters card for alignment with spot price card
 
 ### Version 3.04.56 – Filters Modal Removal (2025-08-17)
 - Removed legacy Filters modal, button, and related code

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.56**
+> **Latest release: v3.04.57**
 
 
 | File | Function | Description |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,6 +1,6 @@
 # Implementation Summary: Filter Chip Expansion
 
-> **Latest release: v3.04.56**
+> **Latest release: v3.04.57**
 
 ## Version Update: 3.04.41 → 3.04.42
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,7 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - _No active patch goals at this time._
 
 ## Completed Patch Goals (v3.04.xx)
+- ✅ **Filters card edge alignment** - Filters card extends left to align with spot price card (v3.04.57)
 - ✅ **Filters modal removal** - Eliminated legacy filters modal and cleanup (v3.04.56)
 - ✅ **Change log clearing option** - Added Clear Log button with confirmation in Change Log modal (v3.04.55)
 - ✅ **Search control consolidation** - New item icon, Change Log in search bar, and clear button redesign (v3.04.54)

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,13 +2,13 @@
 
 
 
-> **Latest release: v3.04.56**
+> **Latest release: v3.04.57**
 
 See [announcements](announcements.md) for recent changes and upcoming milestones.
 
-## 🎯 Current State: **BETA v3.04.56** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.57** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.56** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.57** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -191,7 +191,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.04.56 (managed in `js/constants.js`)
+1. **Current Version**: 3.04.57 (managed in `js/constants.js`)
 2. **Last Change**: Simplified archive workflow
 3. **Last Documentation Update**: August 11, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.04.56**
+> **Latest release: v3.04.57**
 
 
 The repository is organized as follows:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.04.56**
+> **Latest release: v3.04.57**
 
 ## Overview 
 

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.56";
+const APP_VERSION = "3.04.57";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting


### PR DESCRIPTION
## Summary
- Remove horizontal margin from Filters card so it aligns with the first spot price card
- Bump application version to 3.04.57 and update documentation

## Testing
- `node scripts/update-templates.js`
- `for f in tests/*.test.js; do node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_689c283afab4832e95c44c309be159ab