### PR TITLE
Hide empty columns after filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# StackrTrackr v3.04.58
+# StackrTrackr v3.04.59
 
 
 StackrTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -9,6 +9,7 @@ The public hosted version of the app is available at [stackrtrackr.com](https://
 See [docs/announcements.md](docs/announcements.md) for the latest release notes and upcoming milestones.
 
 ## Recent Updates
+- **v3.04.59 - Hidden empty columns**: automatically hide columns with no data after filtering
 - **v3.04.58 - Cache refresh timestamp toggle**: display togglable cache refresh and API sync times
 - **v3.04.57 - Filters card edge alignment**: filters card extends left to align with spot price card
 - **v3.04.42 - Filter chip expansion**: added Filters subtitle and dynamic Name/Date chips that filter the table and update counts
@@ -362,7 +363,7 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: v3.04.58
+**Current Version**: v3.04.59
 **Last Updated**: August 13, 2025
 **Status**: Feature complete release candidate
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -1776,7 +1776,8 @@ td {
   vertical-align: middle;
 }
 
-[data-column].hidden {
+[data-column].hidden,
+[data-column].hidden-empty {
   display: none;
 }
 

--- a/docs/agents/agents.ai
+++ b/docs/agents/agents.ai
@@ -1,7 +1,7 @@
 # StackTrackr Project Instructions
 
 ## CONTEXT
-Precious metals inventory app (v3.04.58+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
+Precious metals inventory app (v3.04.59+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
 
 ## FILES
 - `index.html` - main UI
@@ -94,7 +94,7 @@ AUTO_WARN: "⚠️ Chat approaching limit. Start new conversation soon and refer
 `index.html` `events.js` `styles.css` - coordinate changes, minimal edits
 
 ## NOTES
-- Current version: 3.04.58
+- Current version: 3.04.59
 - **THEME TOGGLE FIXED**: Button now shows current theme color/icon, removed system mode
 - **THEME ROTATION**: dark → light → sepia → dark (no system mode)
 - **BUTTON STYLING**: Shows current theme with matching background color

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.58
+# Multi-Agent Development Workflow - StackrTrackr v3.04.59
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.58**
+> **Latest release: v3.04.59**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.58**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.59**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: 3.04.58 (stable)
+**Current Status**: 3.04.59 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,14 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.58**
+> **Latest release: v3.04.59**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.59 – Hidden Empty Columns (2025-08-20)
+- Columns with no data after filtering are automatically hidden
 
 ### Version 3.04.58 – Cache Refresh Timestamp Toggle (2025-08-19)
 - Renamed “Last sync” to “Last Cache Refresh”

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.58**
+> **Latest release: v3.04.59**
 
 
 | File | Function | Description |
@@ -105,6 +105,7 @@
 | inventory.js | escapeAttribute | Escapes text for safe use in HTML attributes |
 | inventory.js | filterLink | Builds clickable filter span with optional HTML content |
 | inventory.js | formatPurchaseLocation | Detects URLs and appends info tooltip link while keeping text filterable |
+| inventory.js | hideEmptyColumns | Hides table columns that contain no data after filtering |
 | inventory.js | renderTable |  |
 | inventory.js | updateTypeSummary | Renders single-row chips for type, metal, purchase location, storage location with filtered/total counts |
 | inventory.js | updateSummary | Calculates and updates all financial summary displays across the application |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,6 +1,6 @@
 # Implementation Summary: Filter Chip Expansion
 
-> **Latest release: v3.04.58**
+> **Latest release: v3.04.59**
 
 ## Version Update: 3.04.41 → 3.04.42
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,7 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - _No active patch goals at this time._
 
 ## Completed Patch Goals (v3.04.xx)
+- ✅ **Hidden empty columns after filtering** - Automatically hide columns with no data after filtering (v3.04.59)
 - ✅ **Cache refresh timestamp toggle** - Display togglable cache refresh and API sync times (v3.04.58)
 - ✅ **Filters card edge alignment** - Filters card extends left to align with spot price card (v3.04.57)
 - ✅ **Filters modal removal** - Eliminated legacy filters modal and cleanup (v3.04.56)

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,13 +2,13 @@
 
 
 
-> **Latest release: v3.04.58**
+> **Latest release: v3.04.59**
 
 See [announcements](announcements.md) for recent changes and upcoming milestones.
 
-## 🎯 Current State: **BETA v3.04.58** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.59** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.58** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.59** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -191,7 +191,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.04.58 (managed in `js/constants.js`)
+1. **Current Version**: 3.04.59 (managed in `js/constants.js`)
 2. **Last Change**: Simplified archive workflow
 3. **Last Documentation Update**: August 11, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.04.58**
+> **Latest release: v3.04.59**
 
 
 The repository is organized as follows:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.04.58**
+> **Latest release: v3.04.59**
 
 ## Overview 
 
@@ -9,7 +9,7 @@ The StackrTrackr now uses a dynamic version management system that automatically
 ## How It Works
 
 ### Single Source of Truth
- - Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.42'`
+ - Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.59'`
   - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.58";
+const APP_VERSION = "3.04.59";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1007,6 +1007,21 @@ const updateTypeSummary = (items = inventory) => {
 };
 window.updateTypeSummary = updateTypeSummary;
 
+/**
+ * Hides table columns that contain no data after filtering.
+ */
+const hideEmptyColumns = () => {
+  if (typeof document === 'undefined') return;
+  const headers = document.querySelectorAll('#inventoryTable thead th[data-column]');
+  headers.forEach(header => {
+    const col = header.getAttribute('data-column');
+    const cells = document.querySelectorAll(`#inventoryTable tbody [data-column="${col}"]`);
+    const allEmpty = cells.length > 0 && Array.from(cells).every(cell => cell.textContent.trim() === '');
+    document.querySelectorAll(`#inventoryTable [data-column="${col}"]`).forEach(el => {
+      el.classList.toggle('hidden-empty', allEmpty);
+    });
+  });
+};
 
 const renderTable = () => {
   return monitorPerformance(() => {
@@ -1071,6 +1086,7 @@ const renderTable = () => {
     );
 
     elements.inventoryTable.innerHTML = rows.concat(placeholders).join('');
+    hideEmptyColumns();
     updateTypeSummary(filteredInventory);
 
     // Update sort indicators


### PR DESCRIPTION
## Summary
- Hide table columns with no data after filters by scanning each column and toggling `hidden-empty`.
- Recalculate column visibility on every table render and add supporting CSS.
- Bump version to v3.04.59 and document the change.

## Testing
- `for f in tests/*.test.js; do node "$f"; done`


------
https://chatgpt.com/codex/tasks/task_e_689c3ced4d90832e88e20b4501e7dcb2