### PR TITLE
feat: prioritize columns for small viewports

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# StackrTrackr v3.04.59
+# StackrTrackr v3.04.60
 
 
 StackrTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -9,6 +9,7 @@ The public hosted version of the app is available at [stackrtrackr.com](https://
 See [docs/announcements.md](docs/announcements.md) for the latest release notes and upcoming milestones.
 
 ## Recent Updates
+- **v3.04.60 - Responsive column prioritization**: hides lower-priority columns and enlarges edit pencil
 - **v3.04.59 - Hidden empty columns**: automatically hide columns with no data after filtering
 - **v3.04.58 - Cache refresh timestamp toggle**: display togglable cache refresh and API sync times
 - **v3.04.57 - Filters card edge alignment**: filters card extends left to align with spot price card
@@ -363,7 +364,7 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: v3.04.59
+**Current Version**: v3.04.60
 **Last Updated**: August 13, 2025
 **Status**: Feature complete release candidate
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -1737,6 +1737,16 @@ table {
   table-layout: auto; /* Allow columns to size based on content */
 }
 
+.table-section {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+#inventoryTable {
+  width: max-content;
+  min-width: 100%;
+}
+
 #inventoryTable tbody {
   min-height: calc(10 * 2.2rem);
 }
@@ -1898,6 +1908,8 @@ td .cancel-inline {
 
 td .inline-edit-icon {
   margin-right: 0.25rem;
+  font-size: 1.1rem;
+  display: inline-block;
 }
 
 td.editing {

--- a/docs/agents/agents.ai
+++ b/docs/agents/agents.ai
@@ -1,7 +1,7 @@
 # StackTrackr Project Instructions
 
 ## CONTEXT
-Precious metals inventory app (v3.04.59+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
+Precious metals inventory app (v3.04.60+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
 
 ## FILES
 - `index.html` - main UI
@@ -94,7 +94,7 @@ AUTO_WARN: "⚠️ Chat approaching limit. Start new conversation soon and refer
 `index.html` `events.js` `styles.css` - coordinate changes, minimal edits
 
 ## NOTES
-- Current version: 3.04.59
+- Current version: 3.04.60
 - **THEME TOGGLE FIXED**: Button now shows current theme color/icon, removed system mode
 - **THEME ROTATION**: dark → light → sepia → dark (no system mode)
 - **BUTTON STYLING**: Shows current theme with matching background color

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.59
+# Multi-Agent Development Workflow - StackrTrackr v3.04.60
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.59**
+> **Latest release: v3.04.60**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.59**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.60**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: 3.04.59 (stable)
+**Current Status**: 3.04.60 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,15 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.59**
+> **Latest release: v3.04.60**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.60 – Responsive Column Priority (2025-08-21)
+- Columns hide by priority for small viewports with horizontal scrolling
+- Enlarged pencil icon opens edit modal directly
 
 ### Version 3.04.59 – Hidden Empty Columns (2025-08-20)
 - Columns with no data after filtering are automatically hidden

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.59**
+> **Latest release: v3.04.60**
 
 
 | File | Function | Description |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,6 +1,6 @@
 # Implementation Summary: Filter Chip Expansion
 
-> **Latest release: v3.04.59**
+> **Latest release: v3.04.60**
 
 ## Version Update: 3.04.41 → 3.04.42
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,7 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - _No active patch goals at this time._
 
 ## Completed Patch Goals (v3.04.xx)
+- ✅ **Responsive column prioritization** - Progressive column hiding with scroll and modal edit icon (v3.04.60)
 - ✅ **Hidden empty columns after filtering** - Automatically hide columns with no data after filtering (v3.04.59)
 - ✅ **Cache refresh timestamp toggle** - Display togglable cache refresh and API sync times (v3.04.58)
 - ✅ **Filters card edge alignment** - Filters card extends left to align with spot price card (v3.04.57)

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,13 +2,13 @@
 
 
 
-> **Latest release: v3.04.59**
+> **Latest release: v3.04.60**
 
 See [announcements](announcements.md) for recent changes and upcoming milestones.
 
-## 🎯 Current State: **BETA v3.04.59** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.60** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.59** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.60** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -191,7 +191,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.04.59 (managed in `js/constants.js`)
+1. **Current Version**: 3.04.60 (managed in `js/constants.js`)
 2. **Last Change**: Simplified archive workflow
 3. **Last Documentation Update**: August 11, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.04.59**
+> **Latest release: v3.04.60**
 
 
 The repository is organized as follows:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.04.59**
+> **Latest release: v3.04.60**
 
 ## Overview 
 
@@ -9,7 +9,7 @@ The StackrTrackr now uses a dynamic version management system that automatically
 ## How It Works
 
 ### Single Source of Truth
- - Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.59'`
+ - Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.60'`
   - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation

--- a/index.html
+++ b/index.html
@@ -670,13 +670,6 @@
                 </svg>
                 <span class="header-text">Notes</span>
               </th>
-              <th class="icon-col" data-column="edit" aria-label="Edit" title="Edit">
-                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
-                  <circle cx="12" cy="12" r="3"/>
-                  <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>
-                </svg>
-                <span class="header-text">Edit</span>
-              </th>
               <th class="icon-col" data-column="delete" aria-label="Delete" title="Delete">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">
                   <polyline points="3,6 5,6 21,6"/>

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.59";
+const APP_VERSION = "3.04.60";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/events.js
+++ b/js/events.js
@@ -157,43 +157,28 @@ const updateColumnVisibility = () => {
   const hidden = new Set();
 
   const breakpoints = [
-    { width: 1200, hide: ["purchaseLocation", "storageLocation", "collectable"] },
+    { width: 1400, hide: ["collectable"] },
+    { width: 1200, hide: ["collectable", "notes"] },
+    { width: 992, hide: ["collectable", "notes", "premium"] },
+    { width: 768, hide: ["collectable", "notes", "premium", "spot"] },
     {
-      width: 992,
-      hide: [
-        "purchaseLocation",
-        "storageLocation",
-        "collectable",
-        "premium",
-        "spot",
-        "weight",
-      ],
-    },
-    {
-      width: 768,
-      hide: [
-        "purchaseLocation",
-        "storageLocation",
-        "collectable",
-        "premium",
-        "spot",
-        "weight",
-        "qty",
-        "metal",
-      ],
+      width: 640,
+      hide: ["collectable", "notes", "premium", "spot", "weight"],
     },
     {
       width: 576,
       hide: [
-        "purchaseLocation",
-        "storageLocation",
         "collectable",
+        "notes",
         "premium",
         "spot",
         "weight",
-        "qty",
-        "metal",
+        "purchaseLocation",
+        "storageLocation",
+        "numista",
         "type",
+        "metal",
+        "delete",
       ],
     },
   ];

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1051,7 +1051,7 @@ const renderTable = () => {
         ${filterLink('qty', item.qty, 'var(--text-primary)')}
       </td>
       <td class="expand" data-column="name" style="text-align: left;">
-        <span class="inline-edit-icon" role="button" tabindex="0" onclick="startCellEdit(${originalIdx}, 'name', this)" aria-label="Edit name" title="Edit name">✎</span>
+        <span class="inline-edit-icon" role="button" tabindex="0" onclick="editItem(${originalIdx})" aria-label="Edit ${sanitizeHtml(item.name)}" title="Edit ${sanitizeHtml(item.name)}">✎</span>
         ${filterLink('name', item.name, 'var(--text-primary)')}
       </td>
       <td class="shrink" data-column="weight">
@@ -1073,7 +1073,6 @@ const renderTable = () => {
       <td class="shrink" data-column="numista">${item.numistaId ? `<a href="https://en.numista.com/catalogue/pieces${item.numistaId}.html" target="_blank" rel="noopener" title="View on Numista">N# ${sanitizeHtml(item.numistaId)}</a>` : ''}</td>
       <td class="icon-col" data-column="collectable"><span class="collectable-status" role="button" tabindex="0" onclick="toggleCollectable(${originalIdx})" onkeydown="if(event.key==='Enter'||event.key===' ') toggleCollectable(${originalIdx})" aria-label="Toggle collectable status for ${sanitizeHtml(item.name)}" title="Toggle collectable status">${item.isCollectable ? '<svg class=\"collectable-icon icon-copper\" xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><circle cx=\"12\" cy=\"12\" r=\"10\"/></svg>' : '<svg class=\"collectable-icon icon-gold\" xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\"><path d=\"M3 3h18v18H3V3zm2 2v14h14V5H5zm5 10h6v2H10v-2zm2-8a2 2 0 100 4 2 2 0 000-4z\"/></svg>'}</span></td>
       <td class="icon-col" data-column="notes"><span class="action-icon ${item.notes && item.notes.trim() ? 'success' : ''}" role="button" tabindex="0" onclick="showNotes(${originalIdx})" aria-label="View notes" title="View notes">📓</span></td>
-      <td class="icon-col" data-column="edit"><span class="action-icon" role="button" tabindex="0" onclick="editItem(${originalIdx})" aria-label="Edit ${sanitizeHtml(item.name)}" title="Edit ${sanitizeHtml(item.name)}">⚙️</span></td>
       <td class="icon-col" data-column="delete"><span class="action-icon danger" role="button" tabindex="0" onclick="deleteItem(${originalIdx})" aria-label="Delete item" title="Delete item">🗑️</span></td>
       </tr>
       `);
@@ -1082,7 +1081,7 @@ const renderTable = () => {
     const visibleCount = endIndex - startIndex;
     const placeholders = Array.from(
       { length: Math.max(0, itemsPerPage - visibleCount) },
-      () => '<tr><td class="shrink" colspan="16">&nbsp;</td></tr>'
+      () => '<tr><td class="shrink" colspan="15">&nbsp;</td></tr>'
     );
 
     elements.inventoryTable.innerHTML = rows.concat(placeholders).join('');


### PR DESCRIPTION
## Summary
- Hide low-priority columns as the viewport shrinks, keeping Date, Qty, Name and Price visible
- Repurpose and enlarge the pencil icon to open the edit modal directly
- Enable horizontal scrolling for the inventory table and bump version to 3.04.60

## Testing
- `for f in tests/*.test.js; do node $f > /tmp/test.log && tail -n 1 /tmp/test.log; done`


------
https://chatgpt.com/codex/tasks/task_e_689c40757318832eb75627ae9f586e1e