### PR TITLE
feat: add fuzzy autocomplete for item names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# StackrTrackr v3.04.60
+# StackrTrackr v3.04.61
 
 
 StackrTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -9,6 +9,7 @@ The public hosted version of the app is available at [stackrtrackr.com](https://
 See [docs/announcements.md](docs/announcements.md) for the latest release notes and upcoming milestones.
 
 ## Recent Updates
+- **v3.04.61 - Autocomplete for item names**: localStorage-backed suggestions with fuzzy matching
 - **v3.04.60 - Responsive column prioritization**: hides lower-priority columns and enlarges edit pencil
 - **v3.04.59 - Hidden empty columns**: automatically hide columns with no data after filtering
 - **v3.04.58 - Cache refresh timestamp toggle**: display togglable cache refresh and API sync times
@@ -364,7 +365,7 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: v3.04.60
+**Current Version**: v3.04.61
 **Last Updated**: August 13, 2025
 **Status**: Feature complete release candidate
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -2640,6 +2640,31 @@ td input:checked + .slider:before {
   flex: 1;
 }
 
+.autocomplete-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow);
+  z-index: 1000;
+  max-height: 12rem;
+  overflow-y: auto;
+}
+
+.autocomplete-item {
+  padding: var(--spacing-sm) var(--spacing);
+  cursor: pointer;
+}
+
+.autocomplete-item.active,
+.autocomplete-item:hover {
+  background: var(--bg-secondary);
+}
+
+
 .filter-select {
   width: 8rem;
   height: 1.375rem;

--- a/docs/agents/agents.ai
+++ b/docs/agents/agents.ai
@@ -1,7 +1,7 @@
 # StackTrackr Project Instructions
 
 ## CONTEXT
-Precious metals inventory app (v3.04.60+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
+Precious metals inventory app (v3.04.61+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
 
 ## FILES
 - `index.html` - main UI
@@ -94,7 +94,7 @@ AUTO_WARN: "⚠️ Chat approaching limit. Start new conversation soon and refer
 `index.html` `events.js` `styles.css` - coordinate changes, minimal edits
 
 ## NOTES
-- Current version: 3.04.60
+- Current version: 3.04.61
 - **THEME TOGGLE FIXED**: Button now shows current theme color/icon, removed system mode
 - **THEME ROTATION**: dark → light → sepia → dark (no system mode)
 - **BUTTON STYLING**: Shows current theme with matching background color

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.60
+# Multi-Agent Development Workflow - StackrTrackr v3.04.61
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.60**
+> **Latest release: v3.04.61**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.60**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.61**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: 3.04.60 (stable)
+**Current Status**: 3.04.61 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,15 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.60**
+> **Latest release: v3.04.61**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.61 – Autocomplete Suggestions (2025-08-22)
+- Added localStorage-backed autocomplete with 100 bullion names
+- Suggestions integrate fuzzy search and persist new entries
 
 ### Version 3.04.60 – Responsive Column Priority (2025-08-21)
 - Columns hide by priority for small viewports with horizontal scrolling

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.60**
+> **Latest release: v3.04.61**
 
 
 | File | Function | Description |
@@ -17,6 +17,8 @@
 | about.js | showFullChangelog | Shows full changelog in a new window or navigates to documentation |
 | about.js | setupAboutModalEvents | Sets up event listeners for about modal elements |
 | about.js | setupAckModalEvents | Sets up event listeners for acknowledgment modal elements |
+| autocomplete.js | registerName | Adds a new name to the autocomplete store |
+| autocomplete.js | getSuggestions | Returns name suggestions using fuzzy or substring matching |
 | api.js | renderApiStatusSummary |  |
 | api.js | loadApiConfig | Loads Metals API configuration from localStorage |
 | api.js | saveApiConfig | Saves Metals API configuration to localStorage |

--- a/docs/implementation_summary.md
+++ b/docs/implementation_summary.md
@@ -1,6 +1,6 @@
 # Implementation Summary: Filter Chip Expansion
 
-> **Latest release: v3.04.60**
+> **Latest release: v3.04.61**
 
 ## Version Update: 3.04.41 → 3.04.42
 

--- a/docs/notes/fuzzy-autocomplete-implementation-plan.md
+++ b/docs/notes/fuzzy-autocomplete-implementation-plan.md
@@ -117,3 +117,9 @@ const FEATURES = {
 **Created**: August 12, 2025  
 **Status**: Planning Phase  
 **Next**: Create feature checklist and begin Phase 1 implementation
+
+## Phase 2 Update (v3.04.61)
+- Added `js/autocomplete.js` with 100 predefined bullion names.
+- Names stored in a Set persisted to `localStorage` (`autocompleteNames`).
+- Implemented `registerName()` to add new entries and `getSuggestions()` to surface matches using `fuzzySearch` when available.
+- Integrated module with item form, search box, and import workflows.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,7 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - _No active patch goals at this time._
 
 ## Completed Patch Goals (v3.04.xx)
+- ✅ **Autocomplete for item names** - LocalStorage-backed suggestions with fuzzy matching (v3.04.61)
 - ✅ **Responsive column prioritization** - Progressive column hiding with scroll and modal edit icon (v3.04.60)
 - ✅ **Hidden empty columns after filtering** - Automatically hide columns with no data after filtering (v3.04.59)
 - ✅ **Cache refresh timestamp toggle** - Display togglable cache refresh and API sync times (v3.04.58)

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,13 +2,13 @@
 
 
 
-> **Latest release: v3.04.60**
+> **Latest release: v3.04.61**
 
 See [announcements](announcements.md) for recent changes and upcoming milestones.
 
-## 🎯 Current State: **BETA v3.04.60** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.61** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.60** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.61** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -191,7 +191,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.04.60 (managed in `js/constants.js`)
+1. **Current Version**: 3.04.61 (managed in `js/constants.js`)
 2. **Last Change**: Simplified archive workflow
 3. **Last Documentation Update**: August 11, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -1,7 +1,7 @@
 # Project Structure
 
 
-> **Latest release: v3.04.60**
+> **Latest release: v3.04.61**
 
 
 The repository is organized as follows:

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Dynamic Version Management System
 
-> **Latest release: v3.04.60**
+> **Latest release: v3.04.61**
 
 ## Overview 
 
@@ -9,7 +9,7 @@ The StackrTrackr now uses a dynamic version management system that automatically
 ## How It Works
 
 ### Single Source of Truth
- - Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.60'`
+ - Version is defined once in `js/constants.js` as `APP_VERSION = '3.04.61'`
   - This is the ONLY place you need to update the version number
 
 ### Automatic Propagation

--- a/index.html
+++ b/index.html
@@ -2411,6 +2411,8 @@
   <script defer src="./js/constants.js"></script>
   <script defer src="./js/state.js"></script>
   <script defer src="./js/utils.js"></script>
+  <script defer src="./js/fuzzy-search.js"></script>
+  <script defer src="./js/autocomplete.js"></script>
   <script defer src="./js/versionCheck.js"></script>
   <script defer src="./js/changeLog.js"></script>
     <script defer src="./js/charts.js"></script>

--- a/js/autocomplete.js
+++ b/js/autocomplete.js
@@ -1,0 +1,267 @@
+// Autocomplete module for StackrTrackr
+// Maintains a set of known bullion/coin names persisted to localStorage
+
+/** Predefined bullion and coin names */
+const DEFAULT_AUTOCOMPLETE_NAMES = [
+  "Silver American Eagle",
+  "Gold American Eagle",
+  "Platinum American Eagle",
+  "Palladium American Eagle",
+  "Silver Canadian Maple Leaf",
+  "Gold Canadian Maple Leaf",
+  "Platinum Canadian Maple Leaf",
+  "Palladium Canadian Maple Leaf",
+  "Silver South African Krugerrand",
+  "Gold South African Krugerrand",
+  "Platinum South African Krugerrand",
+  "Palladium South African Krugerrand",
+  "Silver Austrian Philharmonic",
+  "Gold Austrian Philharmonic",
+  "Platinum Austrian Philharmonic",
+  "Palladium Austrian Philharmonic",
+  "Silver British Britannia",
+  "Gold British Britannia",
+  "Platinum British Britannia",
+  "Palladium British Britannia",
+  "Silver Chinese Panda",
+  "Gold Chinese Panda",
+  "Platinum Chinese Panda",
+  "Palladium Chinese Panda",
+  "Silver Mexican Libertad",
+  "Gold Mexican Libertad",
+  "Platinum Mexican Libertad",
+  "Palladium Mexican Libertad",
+  "Silver Australian Kangaroo",
+  "Gold Australian Kangaroo",
+  "Platinum Australian Kangaroo",
+  "Palladium Australian Kangaroo",
+  "Silver Australian Koala",
+  "Gold Australian Koala",
+  "Platinum Australian Koala",
+  "Palladium Australian Koala",
+  "Silver Australian Kookaburra",
+  "Gold Australian Kookaburra",
+  "Platinum Australian Kookaburra",
+  "Palladium Australian Kookaburra",
+  "Silver Australian Lunar",
+  "Gold Australian Lunar",
+  "Platinum Australian Lunar",
+  "Palladium Australian Lunar",
+  "Silver Somali Elephant",
+  "Gold Somali Elephant",
+  "Platinum Somali Elephant",
+  "Palladium Somali Elephant",
+  "Silver Armenian Noah's Ark",
+  "Gold Armenian Noah's Ark",
+  "Platinum Armenian Noah's Ark",
+  "Palladium Armenian Noah's Ark",
+  "Silver Russian Ballerina",
+  "Gold Russian Ballerina",
+  "Platinum Russian Ballerina",
+  "Palladium Russian Ballerina",
+  "Silver French Rooster",
+  "Gold French Rooster",
+  "Platinum French Rooster",
+  "Palladium French Rooster",
+  "Silver Swiss Vreneli",
+  "Gold Swiss Vreneli",
+  "Platinum Swiss Vreneli",
+  "Palladium Swiss Vreneli",
+  "Silver Indian Mohur",
+  "Gold Indian Mohur",
+  "Platinum Indian Mohur",
+  "Palladium Indian Mohur",
+  "Silver Austrian Ducat",
+  "Gold Austrian Ducat",
+  "Platinum Austrian Ducat",
+  "Palladium Austrian Ducat",
+  "Silver British Sovereign",
+  "Gold British Sovereign",
+  "Platinum British Sovereign",
+  "Palladium British Sovereign",
+  "Silver Saint-Gaudens",
+  "Gold Saint-Gaudens",
+  "Platinum Saint-Gaudens",
+  "Palladium Saint-Gaudens",
+  "Silver Walking Liberty Half Dollar",
+  "Gold Walking Liberty Half Dollar",
+  "Platinum Walking Liberty Half Dollar",
+  "Palladium Walking Liberty Half Dollar",
+  "Silver Morgan Dollar",
+  "Gold Morgan Dollar",
+  "Platinum Morgan Dollar",
+  "Palladium Morgan Dollar",
+  "Silver Peace Dollar",
+  "Gold Peace Dollar",
+  "Platinum Peace Dollar",
+  "Palladium Peace Dollar",
+  "Silver Engelhard Bar",
+  "Gold Engelhard Bar",
+  "Platinum Engelhard Bar",
+  "Palladium Engelhard Bar",
+  "Silver Johnson Matthey Bar",
+  "Gold Johnson Matthey Bar",
+  "Platinum Johnson Matthey Bar",
+  "Palladium Johnson Matthey Bar"
+];
+
+const AUTOCOMPLETE_KEY = "autocompleteNames";
+
+const loadNames = () => {
+  try {
+    const stored = JSON.parse(localStorage.getItem(AUTOCOMPLETE_KEY));
+    if (Array.isArray(stored) && stored.length) {
+      const merged = new Set([...DEFAULT_AUTOCOMPLETE_NAMES, ...stored]);
+      localStorage.setItem(AUTOCOMPLETE_KEY, JSON.stringify([...merged]));
+      return merged;
+    }
+  } catch (err) {
+    console.warn("Failed to parse stored autocomplete names", err);
+  }
+  localStorage.setItem(AUTOCOMPLETE_KEY, JSON.stringify(DEFAULT_AUTOCOMPLETE_NAMES));
+  return new Set(DEFAULT_AUTOCOMPLETE_NAMES);
+};
+
+const namesSet = loadNames();
+
+const saveNames = () => {
+  try {
+    localStorage.setItem(AUTOCOMPLETE_KEY, JSON.stringify([...namesSet]));
+  } catch (err) {
+    console.warn("Failed to save autocomplete names", err);
+  }
+};
+
+/**
+ * Registers a new name into the autocomplete store
+ * @param {string} name - Name to register
+ */
+const registerName = (name) => {
+  if (typeof name !== "string") return;
+  const cleaned = name.trim();
+  if (!cleaned) return;
+  if (!namesSet.has(cleaned)) {
+    namesSet.add(cleaned);
+    saveNames();
+  }
+};
+
+/**
+ * Retrieves autocomplete suggestions for a query
+ * @param {string} query - Search text
+ * @param {Object} [options]
+ * @param {number} [options.max=5] - Maximum suggestions
+ * @returns {string[]} Array of suggestion strings
+ */
+const getSuggestions = (query, { max = 5 } = {}) => {
+  if (typeof query !== "string" || !query.trim()) return [];
+  const names = [...namesSet];
+  if (
+    typeof window !== "undefined" &&
+    window.fuzzySearch &&
+    typeof window.fuzzySearch.fuzzySearch === "function"
+  ) {
+    return window.fuzzySearch.fuzzySearch(query, names, { maxResults: max }).map(
+      (r) => r.text
+    );
+  }
+  const q = query.toLowerCase();
+  return names
+    .filter((n) => n.toLowerCase().includes(q))
+    .slice(0, max);
+};
+
+const attachAutocomplete = (input) => {
+  if (!input) return;
+  const parent = input.parentNode;
+  if (parent) {
+    const computed = window.getComputedStyle(parent);
+    if (computed.position === "static") parent.style.position = "relative";
+  }
+  const dropdown = document.createElement("div");
+  dropdown.className = "autocomplete-dropdown";
+  dropdown.style.display = "none";
+  input.after(dropdown);
+
+  let activeIndex = -1;
+  const hide = () => {
+    dropdown.style.display = "none";
+    dropdown.innerHTML = "";
+    activeIndex = -1;
+  };
+
+  const show = (items) => {
+    dropdown.innerHTML = "";
+    items.forEach((text) => {
+      const div = document.createElement("div");
+      div.className = "autocomplete-item";
+      div.textContent = text;
+      div.addEventListener("mousedown", (e) => {
+        e.preventDefault();
+        input.value = text;
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+        hide();
+      });
+      dropdown.appendChild(div);
+    });
+    dropdown.style.display = items.length ? "block" : "none";
+  };
+
+  const updateActive = (items) => {
+    items.forEach((item, idx) => {
+      item.classList.toggle("active", idx === activeIndex);
+    });
+  };
+
+  input.addEventListener("input", () => {
+    const suggestions = getSuggestions(input.value, { max: 8 });
+    show(suggestions);
+  });
+
+  input.addEventListener("keydown", (e) => {
+    const items = Array.from(dropdown.children);
+    if (e.key === "ArrowDown" && items.length) {
+      activeIndex = (activeIndex + 1) % items.length;
+      updateActive(items);
+      e.preventDefault();
+    } else if (e.key === "ArrowUp" && items.length) {
+      activeIndex = (activeIndex - 1 + items.length) % items.length;
+      updateActive(items);
+      e.preventDefault();
+    } else if (e.key === "Enter" && activeIndex >= 0) {
+      e.preventDefault();
+      const item = items[activeIndex];
+      if (item) {
+        input.value = item.textContent;
+        input.dispatchEvent(new Event("input", { bubbles: true }));
+        hide();
+      }
+    } else if (e.key === "Escape") {
+      hide();
+    }
+  });
+
+  input.addEventListener("blur", () => setTimeout(hide, 100));
+};
+
+const setupAutocomplete = () => {
+  attachAutocomplete(document.getElementById("itemName"));
+  attachAutocomplete(document.getElementById("searchInput"));
+};
+
+if (typeof document !== "undefined") {
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", setupAutocomplete);
+  } else {
+    setupAutocomplete();
+  }
+}
+
+if (typeof window !== "undefined") {
+  window.registerName = registerName;
+  window.getSuggestions = getSuggestions;
+}
+
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = { DEFAULT_AUTOCOMPLETE_NAMES, registerName, getSuggestions };
+}

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.60";
+const APP_VERSION = "3.04.61";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/events.js
+++ b/js/events.js
@@ -460,6 +460,7 @@ const setupEventListeners = () => {
             numistaId: catalog,
           });
 
+          typeof registerName === "function" && registerName(name);
           addCompositionOption(composition);
 
           catalogMap[serial] = catalog;

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1564,6 +1564,12 @@ const importCsv = (file, override = false) => {
 
         if (deduped.length === 0) return alert('No items to import.');
 
+        for (const item of deduped) {
+          if (typeof registerName === "function") {
+            registerName(item.name);
+          }
+        }
+
         if (override) {
           inventory = deduped;
         } else {
@@ -1760,6 +1766,12 @@ const importNumistaCsv = (file, override = false) => {
         }
 
         if (deduped.length === 0) return alert('No items to import.');
+
+        for (const item of deduped) {
+          if (typeof registerName === "function") {
+            registerName(item.name);
+          }
+        }
 
         if (override) {
           inventory = deduped;
@@ -2076,6 +2088,12 @@ const importJson = (file, override = false) => {
 
       if (deduped.length === 0) {
         return alert('No items to import.');
+      }
+
+      for (const item of deduped) {
+        if (typeof registerName === "function") {
+          registerName(item.name);
+        }
       }
 
       if (override) {

--- a/tests/autocomplete.test.js
+++ b/tests/autocomplete.test.js
@@ -1,0 +1,33 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+// Stub browser environment
+const localStore = {};
+global.localStorage = {
+  getItem: (k) => (k in localStore ? localStore[k] : null),
+  setItem: (k, v) => { localStore[k] = v; },
+};
+global.document = { getElementById: () => null, addEventListener: () => {} };
+global.window = global;
+
+// Load module
+vm.runInThisContext(fs.readFileSync('js/autocomplete.js', 'utf8'));
+
+// Test base list loads
+const base = JSON.parse(localStore.autocompleteNames);
+assert.strictEqual(base.length, 100, 'should load 100 default names');
+
+// Test registerName persistence
+registerName('Test Coin');
+const stored = JSON.parse(localStore.autocompleteNames);
+assert(stored.includes('Test Coin'), 'new name should persist');
+assert(getSuggestions('Test').includes('Test Coin'), 'should suggest newly registered name');
+
+// Test fuzzy search integration
+window.fuzzySearch = {
+  fuzzySearch: () => [{ text: 'Fuzzy Coin', score: 1 }],
+};
+assert.deepStrictEqual(getSuggestions('Whatever', { max: 1 }), ['Fuzzy Coin'], 'should use fuzzySearch when available');
+
+console.log('Autocomplete tests passed');


### PR DESCRIPTION
## Summary
- add localStorage-backed autocomplete module with fuzzy suggestions for item names
- track new names during manual entry and imports to enrich suggestions
- document feature rollout and version bump to v3.04.61

## Testing
- `for f in tests/*.test.js; do echo "Running $f"; node $f; done`

------
https://chatgpt.com/codex/tasks/task_e_689c43e86eec832eadca03f8be40ccc5