### PR TITLE
Ensure price defaults and append Numista import markdown

### DIFF
--- a/docs/agents/agents.ai
+++ b/docs/agents/agents.ai
@@ -1,7 +1,7 @@
 # StackTrackr Project Instructions
 
 ## CONTEXT
-Precious metals inventory app (v3.04.61+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
+Precious metals inventory app (v3.04.65+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
 
 ## FILES
 - `index.html` - main UI
@@ -97,7 +97,7 @@ AUTO_WARN: "⚠️ Chat approaching limit. Start new conversation soon and refer
 `index.html` `events.js` `styles.css` - coordinate changes, minimal edits
 
 ## NOTES
-- Current version: 3.04.64
+ - Current version: 3.04.65
 - **THEME TOGGLE FIXED**: Button now shows current theme color/icon, removed system mode
 - **THEME ROTATION**: dark → light → sepia → dark (no system mode)
 - **BUTTON STYLING**: Shows current theme with matching background color

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.62
+# Multi-Agent Development Workflow - StackrTrackr v3.04.65
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.61**
+> **Latest release: v3.04.65**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.62**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.65**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: 3.04.62 (stable)
+**Current Status**: 3.04.65 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,17 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.64**
+> **Latest release: v3.04.65**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.65 – Import Price Defaults & Numista Markdown (2025-08-13)
+- **Data Integrity**: Missing price fields now default to 0 during all import types.
+- **Numista Enhancements**:
+  - Buying price and Estimate columns detect currency in values and convert to USD.
+  - Full Numista row data appended to item notes as a concise Markdown list.
 
 ### Version 3.04.64 – Feature Flag System (2025-08-13)
 - **Feature Development**: Completed Task 2A - Feature Flag System for Phase 2 of fuzzy autocomplete

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.63**
+> **Latest release: v3.04.65**
 
 
 | File | Function | Description |
@@ -184,6 +184,7 @@
 | utils.js | oztToGrams | Converts troy ounces to grams |
 | utils.js | formatWeight | Formats a weight in ozt to grams or ounces |
 | utils.js | convertToUsd | Converts amount from specified currency to USD using static rates |
+| utils.js | detectCurrency | Detects currency code from a value string |
 | utils.js | stripNonAlphanumeric | Removes all characters except letters, numbers, and spaces |
 | utils.js | cleanString | Removes HTML tags and control characters while preserving punctuation |
 | utils.js | sanitizeObjectFields | Strips non-alphanumeric characters from string fields except purchaseLocation, which uses cleanString |
@@ -196,7 +197,7 @@
 | utils.js | loadData | Loads data from localStorage with error handling |
 | utils.js | sortInventoryByDateNewestFirst | Sorts inventory by date (newest first) |
 | utils.js | validateInventoryItem | Validates inventory item data |
-| utils.js | sanitizeImportedItem | Coerces invalid imported fields to safe defaults and strips HTML, diacritics, and non-alphanumeric characters |
+| utils.js | sanitizeImportedItem | Coerces invalid imported fields to safe defaults (price defaults to 0) and strips HTML, diacritics, and non-alphanumeric characters |
 | utils.js | handleError | Handles errors with user-friendly messaging |
 | utils.js | getUserFriendlyMessage | Converts technical error messages to user-friendly ones |
 | utils.js | downloadFile | Downloads a file with the specified content and filename |

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,13 +2,13 @@
 
 
 
-> **Latest release: v3.04.61**
+> **Latest release: v3.04.65**
 
 See [announcements](announcements.md) for recent changes and upcoming milestones.
 
-## 🎯 Current State: **BETA v3.04.61** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.65** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.61** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.65** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -191,7 +191,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.04.61 (managed in `js/constants.js`)
+1. **Current Version**: 3.04.65 (managed in `js/constants.js`)
 2. **Last Change**: Simplified archive workflow
 3. **Last Documentation Update**: August 11, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.64";
+const APP_VERSION = "3.04.65";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1520,7 +1520,7 @@ const importCsv = (file, override = false) => {
             date,
             purchaseLocation,
             storageLocation,
-            notes,
+            notes: finalNotes,
             spotPriceAtPurchase,
             premiumPerOz,
             totalPremium,
@@ -1669,17 +1669,20 @@ const importNumistaCsv = (file, override = false) => {
 
           const priceKey = Object.keys(row).find(k => /^(buying price|purchase price|price paid)/i.test(k));
           const estimateKey = Object.keys(row).find(k => /^estimate/i.test(k));
+          const parsePriceField = (key) => {
+            const rawVal = String(row[key] ?? '').trim();
+            const valueCurrency = detectCurrency(rawVal);
+            const headerCurrencyMatch = key.match(/\(([^)]+)\)/);
+            const headerCurrency = headerCurrencyMatch ? headerCurrencyMatch[1] : 'USD';
+            const currency = valueCurrency || headerCurrency;
+            const amount = parseFloat(rawVal.replace(/[^0-9.\-]/g, ''));
+            return isNaN(amount) ? 0 : convertToUsd(amount, currency);
+          };
           let purchasePrice = 0;
           if (priceKey) {
-            const currencyMatch = priceKey.match(/\(([^)]+)\)/);
-            const currency = currencyMatch ? currencyMatch[1] : 'USD';
-            const amount = parseFloat(String(row[priceKey]).replace(/[^0-9.\-]/g, ''));
-            purchasePrice = convertToUsd(amount, currency);
+            purchasePrice = parsePriceField(priceKey);
           } else if (estimateKey) {
-            const currencyMatch = estimateKey.match(/\(([^)]+)\)/);
-            const currency = currencyMatch ? currencyMatch[1] : 'USD';
-            const amount = parseFloat(String(row[estimateKey]).replace(/[^0-9.\-]/g, ''));
-            purchasePrice = convertToUsd(amount, currency);
+            purchasePrice = parsePriceField(estimateKey);
           }
 
           const purchaseLocRaw = getValue(row, ['Acquisition place', 'Acquired from', 'Purchase place']);
@@ -1702,6 +1705,16 @@ const importNumistaCsv = (file, override = false) => {
           if (otherComment) noteParts.push(`Comment: ${otherComment}`);
           const notes = noteParts.join('\n');
 
+          const markdownLines = Object.entries(row)
+            .filter(([, v]) => v && String(v).trim())
+            .map(([k, v]) => `- **${k.trim()}**: ${String(v).trim()}`);
+          const markdownNote = markdownLines.length
+            ? `### Numista Import Data\n${markdownLines.join('\n')}`
+            : '';
+          const finalNotes = markdownNote
+            ? notes ? `${notes}\n\n${markdownNote}` : markdownNote
+            : notes;
+
           if (type === 'Bar' || type === 'Round') {
             isCollectable = false;
           }
@@ -1722,7 +1735,7 @@ const importNumistaCsv = (file, override = false) => {
             date,
             purchaseLocation,
             storageLocation,
-            notes,
+            notes: finalNotes,
             spotPriceAtPurchase,
             premiumPerOz,
             totalPremium,

--- a/js/utils.js
+++ b/js/utils.js
@@ -505,6 +505,21 @@ const convertToUsd = (amount, currency = "USD") => {
 };
 
 /**
+ * Detects currency code from a value string containing symbols or codes
+ *
+ * @param {string} str - Value containing currency information
+ * @returns {string|null} Detected currency code or null if not found
+ */
+const detectCurrency = (str = "") => {
+  const s = str.toUpperCase();
+  if (/[€]|EUR/.test(s)) return "EUR";
+  if (/[£]|GBP/.test(s)) return "GBP";
+  if (/CAD|C\$|CA\$/.test(s)) return "CAD";
+  if (/USD|US\$/.test(s)) return "USD";
+  return null;
+};
+
+/**
  * Removes all non-alphanumeric characters from a string, preserving spaces.
  *
  * @param {string} str - Input string
@@ -713,8 +728,12 @@ const sanitizeImportedItem = (item) => {
     sanitized.composition = sanitized.metal;
   }
 
-  // Ensure numeric fields parse correctly
-  const numFields = ['qty', 'weight', 'price', 'spotPriceAtPurchase'];
+  // Ensure price always has a numeric value
+  const parsedPrice = parseFloat(sanitized.price);
+  sanitized.price = isNaN(parsedPrice) ? 0 : parsedPrice;
+
+  // Ensure other numeric fields parse correctly
+  const numFields = ['qty', 'weight', 'spotPriceAtPurchase'];
   for (const field of numFields) {
     if (sanitized[field] !== undefined) {
       const parsed = parseFloat(sanitized[field]);

--- a/tests/estimate-numista.test.js
+++ b/tests/estimate-numista.test.js
@@ -92,10 +92,32 @@ const csv2 = 'Numista #,Title,Year,Composition,Type,Weight,Note,Private comment,
 const file2 = { content: csv2 };
 global.inventory = [];
 importNumistaCsv(file2);
-assert.strictEqual(
-  inventory[0].notes,
-  'Base note\nPrivate Comment: Private text\nPublic Comment: Public text\nComment: Other text',
-  'all comment fields should appear in notes'
+const expectedPrefix = 'Base note\nPrivate Comment: Private text\nPublic Comment: Public text\nComment: Other text';
+assert.ok(
+  inventory[0].notes.startsWith(expectedPrefix),
+  'all comment fields should appear at start of notes'
+);
+assert.ok(
+  inventory[0].notes.includes('### Numista Import Data'),
+  'notes should include markdown representation'
 );
 console.log('Numista comment import test passed');
+
+// Test currency detection from value string
+const csv3 = 'Numista #,Title,Year,Composition,Type,Weight,Buying price (USD)\n' +
+  '123,Test Coin,2024,Silver 0.999,Coin,31.103,10 EUR';
+const file3 = { content: csv3 };
+global.inventory = [];
+importNumistaCsv(file3);
+assert.strictEqual(
+  inventory[0].purchasePrice,
+  convertToUsd(10, 'EUR'),
+  'should detect EUR currency in value and convert to USD'
+);
+console.log('Numista currency detection test passed');
+
+// Test default price when missing
+const sanitized = sanitizeImportedItem({});
+assert.strictEqual(sanitized.price, 0, 'missing price should default to 0');
+console.log('Price default test passed');
 

--- a/tests/export-numista-comments.test.js
+++ b/tests/export-numista-comments.test.js
@@ -98,18 +98,18 @@ importNumistaCsv(file);
 capturedCsv = '';
 exportNumistaCsv();
 
-const lines = capturedCsv.trim().split(/\r?\n/);
-const headers = lines[0].split(',');
-const row = lines[1].split(',');
-
+const [headerLine] = capturedCsv.split(/\r?\n/);
+const headers = headerLine.split(',');
 assert.deepStrictEqual(
   headers.slice(11),
   ['Note','Private comment','Public comment','Comment'],
   'header columns should include note and comment fields'
 );
-assert.strictEqual(row[11], 'Base note');
-assert.strictEqual(row[12], 'Private text');
-assert.strictEqual(row[13], 'Public text');
-assert.strictEqual(row[14], 'Other text');
+const noteMatch = capturedCsv.match(/"([^"]*)",Private text/);
+assert.ok(noteMatch && noteMatch[1].startsWith('Base note'), 'note column should start with original base note');
+assert.ok(noteMatch && noteMatch[1].includes('Numista Import Data'), 'note column should include markdown data');
+assert.ok(capturedCsv.includes(',Private text,'));
+assert.ok(capturedCsv.includes(',Public text,'));
+assert.ok(capturedCsv.includes(',Other text')); // last field may not have trailing comma
 
 console.log('Numista comment export test passed');


### PR DESCRIPTION
## Summary
- Default missing prices to 0 during import to avoid null values
- Detect non-USD currencies in Numista imports and convert to USD
- Attach Markdown-formatted raw Numista row data to each item's notes

## Testing
- `for f in tests/*.test.js; do node "$f"; done` *(autocomplete.test.js: "undefined" is not valid JSON)*

------
https://chatgpt.com/codex/tasks/task_e_689c542c2dcc832ea5768d888c657697