### PR TITLE
feat: purge stray storage keys on startup

### DIFF
--- a/docs/agents/agents.ai
+++ b/docs/agents/agents.ai
@@ -1,7 +1,7 @@
 # StackTrackr Project Instructions
 
 ## CONTEXT
-Precious metals inventory app (v3.04.65+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
+Precious metals inventory app (v3.04.66+). Client-side: JS modules + localStorage + CSS. Tracks Au/Ag/Pt/Pd.
 
 ## FILES
 - `index.html` - main UI
@@ -97,7 +97,7 @@ AUTO_WARN: "⚠️ Chat approaching limit. Start new conversation soon and refer
 `index.html` `events.js` `styles.css` - coordinate changes, minimal edits
 
 ## NOTES
- - Current version: 3.04.65
+ - Current version: 3.04.66
 - **THEME TOGGLE FIXED**: Button now shows current theme color/icon, removed system mode
 - **THEME ROTATION**: dark → light → sepia → dark (no system mode)
 - **BUTTON STYLING**: Shows current theme with matching background color

--- a/docs/agents/multi_agent_workflow.md
+++ b/docs/agents/multi_agent_workflow.md
@@ -1,14 +1,14 @@
-# Multi-Agent Development Workflow - StackrTrackr v3.04.65
+# Multi-Agent Development Workflow - StackrTrackr v3.04.66
 
 > **⚠️ NOTICE: `docs/agents/agents.ai` is the primary development reference for token efficiency. This file is maintained for consistency only.**
 
-> **Latest release: v3.04.65**
+> **Latest release: v3.04.66**
 
 ## 🎯 Project Overview
 
-You are contributing to **StackrTrackr v3.04.65**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
+You are contributing to **StackrTrackr v3.04.66**, a comprehensive client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium). The project uses a modular JavaScript architecture with local storage, responsive CSS theming, and advanced features like API integration, data visualization, and comprehensive import/export capabilities.
 
-**Current Status**: 3.04.65 (stable)
+**Current Status**: 3.04.66 (stable)
 **Your Role**: Complete focused v3.04.x patch tasks as part of a coordinated multi-agent development effort
 
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,15 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.65**
+> **Latest release: v3.04.66**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.66 – Storage Cleanup (2025-08-13)
+- **Data Hygiene**: Startup routine now purges unrecognized localStorage keys while preserving valid data.
+- **Maintenance**: Introduced centralized list of allowed localStorage keys.
 
 ### Version 3.04.65 – Import Price Defaults & Numista Markdown (2025-08-13)
 - **Data Integrity**: Missing price fields now default to 0 during all import types.

--- a/docs/functionstable.md
+++ b/docs/functionstable.md
@@ -1,7 +1,7 @@
 # Function Reference
 
 
-> **Latest release: v3.04.65**
+> **Latest release: v3.04.66**
 
 
 | File | Function | Description |
@@ -195,6 +195,7 @@
 | utils.js | getDisplayComposition | Returns "Alloy" when composition doesn't start with a primary metal |
 | utils.js | saveData | Saves data to localStorage with JSON serialization |
 | utils.js | loadData | Loads data from localStorage with error handling |
+| utils.js | cleanupStorage | Removes unknown localStorage keys to maintain a clean storage state |
 | utils.js | sortInventoryByDateNewestFirst | Sorts inventory by date (newest first) |
 | utils.js | validateInventoryItem | Validates inventory item data |
 | utils.js | sanitizeImportedItem | Coerces invalid imported fields to safe defaults (price defaults to 0) and strips HTML, diacritics, and non-alphanumeric characters |

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,6 +6,7 @@ This roadmap tracks upcoming goals without committing to specific patch numbers.
 - _No active patch goals at this time._
 
 ## Completed Patch Goals (v3.04.xx)
+- ✅ **LocalStorage cleanup** - Startup routine removes unknown keys (v3.04.66)
 - ✅ **Autocomplete for item names** - LocalStorage-backed suggestions with fuzzy matching (v3.04.61)
 - ✅ **Responsive column prioritization** - Progressive column hiding with scroll and modal edit icon (v3.04.60)
 - ✅ **Hidden empty columns after filtering** - Automatically hide columns with no data after filtering (v3.04.59)

--- a/docs/status.md
+++ b/docs/status.md
@@ -2,13 +2,13 @@
 
 
 
-> **Latest release: v3.04.65**
+> **Latest release: v3.04.66**
 
 See [announcements](announcements.md) for recent changes and upcoming milestones.
 
-## 🎯 Current State: **BETA v3.04.65** ✅ MAINTAINED & OPTIMIZED
+## 🎯 Current State: **BETA v3.04.66** ✅ MAINTAINED & OPTIMIZED
 
-**StackrTrackr v3.04.65** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
+**StackrTrackr v3.04.66** is a fully-featured, client-side web application for tracking precious metal investments (Silver, Gold, Platinum, Palladium) with comprehensive inventory management, API integration, and complete backup capabilities. The 3.04.x series focuses on polish, maintenance, and optimization.
 
 
 ## 🏗️ Architecture Overview
@@ -191,7 +191,7 @@ All data is stored locally in the browser using localStorage with:
 
 If continuing development in a new chat session:
 
-1. **Current Version**: 3.04.65 (managed in `js/constants.js`)
+1. **Current Version**: 3.04.66 (managed in `js/constants.js`)
 2. **Last Change**: Simplified archive workflow
 3. **Last Documentation Update**: August 11, 2025 - All docs synchronized
 4. **Architecture**: Fully modular with proper separation of concerns

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.65";
+const APP_VERSION = "3.04.66";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting
@@ -398,6 +398,35 @@ const VERSION_ACK_KEY = "ackVersion";
 
 /** @constant {string} FEATURE_FLAGS_KEY - LocalStorage key for feature flags */
 const FEATURE_FLAGS_KEY = "featureFlags";
+
+/**
+ * List of recognized localStorage keys for cleanup validation
+ * @constant {string[]}
+ */
+const ALLOWED_STORAGE_KEYS = [
+  LS_KEY,
+  SERIAL_KEY,
+  CATALOG_MAP_KEY,
+  SPOT_HISTORY_KEY,
+  THEME_KEY,
+  ACK_DISMISSED_KEY,
+  API_KEY_STORAGE_KEY,
+  API_CACHE_KEY,
+  LAST_CACHE_REFRESH_KEY,
+  LAST_API_SYNC_KEY,
+  APP_VERSION_KEY,
+  VERSION_ACK_KEY,
+  FEATURE_FLAGS_KEY,
+  "spotSilver",
+  "spotGold",
+  "spotPlatinum",
+  "spotPalladium",
+  "chipMinCount",
+  "changeLog",
+  "autocomplete_lookup_cache",
+  "autocomplete_cache_timestamp",
+  "stackrtrackr.debug",
+];
 
 // Persist current application version for comparison on future loads
 try {
@@ -836,4 +865,5 @@ if (typeof window !== "undefined") {
   window.enableFeature = enableFeature;
   window.disableFeature = disableFeature;
   window.toggleFeature = toggleFeature;
+  window.ALLOWED_STORAGE_KEYS = ALLOWED_STORAGE_KEYS;
 }

--- a/js/events.js
+++ b/js/events.js
@@ -1899,3 +1899,6 @@ const setupApiEvents = () => {
 };
 
 // =============================================================================
+
+// Early cleanup of stray localStorage entries before application initialization
+document.addEventListener('DOMContentLoaded', cleanupStorage);

--- a/js/utils.js
+++ b/js/utils.js
@@ -631,6 +631,23 @@ const saveData = (key, data) => { try { const raw = JSON.stringify(data); const 
 const loadData = (key, defaultValue = []) => { try { const raw = localStorage.getItem(key); if(raw == null) return defaultValue; const str = __decompressIfNeeded(raw); return JSON.parse(str); } catch(e) { return defaultValue; } };
 
 /**
+ * Removes unknown localStorage keys to maintain a clean storage state
+ *
+ * Iterates over all localStorage entries and deletes any keys not present in
+ * ALLOWED_STORAGE_KEYS.
+ */
+const cleanupStorage = () => {
+  if (typeof localStorage === 'undefined') return;
+  const allowed = new Set(ALLOWED_STORAGE_KEYS);
+  for (let i = localStorage.length - 1; i >= 0; i--) {
+    const key = localStorage.key(i);
+    if (!allowed.has(key)) {
+      localStorage.removeItem(key);
+    }
+  }
+};
+
+/**
  * Sorts inventory by date (newest first)
  *
  * @param {Array} [data=inventory] - Data to sort
@@ -2436,4 +2453,5 @@ function generateStorageReport(){
 if (typeof window !== 'undefined') {
   window.generateStorageReport = generateStorageReport;
   window.updateSpotTimestamp = updateSpotTimestamp;
+  window.cleanupStorage = cleanupStorage;
 }

--- a/tests/storage-cleanup.test.js
+++ b/tests/storage-cleanup.test.js
@@ -1,0 +1,32 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+
+// Stub full-featured localStorage
+const store = {};
+global.localStorage = {
+  _data: store,
+  setItem(key, value) { this._data[key] = String(value); },
+  getItem(key) { return this._data.hasOwnProperty(key) ? this._data[key] : null; },
+  removeItem(key) { delete this._data[key]; },
+  key(i) { return Object.keys(this._data)[i]; },
+  get length() { return Object.keys(this._data).length; }
+};
+
+global.window = global;
+global.window.location = { search: '' };
+
+// Load modules
+vm.runInThisContext(fs.readFileSync('js/constants.js', 'utf8'));
+vm.runInThisContext(fs.readFileSync('js/utils.js', 'utf8'));
+
+// Insert allowed and disallowed keys
+localStorage.setItem(LS_KEY, '[]');
+localStorage.setItem('randomKey', '123');
+
+cleanupStorage();
+
+assert.strictEqual(localStorage.getItem(LS_KEY), '[]', 'Allowed key should remain');
+assert.strictEqual(localStorage.getItem('randomKey'), null, 'Unknown key should be removed');
+
+console.log('storage cleanup tests passed');


### PR DESCRIPTION
## Summary
- maintain an ALLOWED_STORAGE_KEYS list for all supported localStorage entries
- add cleanupStorage utility and invoke it on DOMContentLoaded to drop unknown keys
- test that only approved keys persist after cleanup

## Testing
- `node tests/storage-cleanup.test.js`
- `node tests/change-log-clear.test.js`
- `node tests/autocomplete.test.js` *(fails: "undefined" is not valid JSON)*

------
https://chatgpt.com/codex/tasks/task_e_689c5937f2e4832eaef718a72152f08b