### PR TITLE
fix: restore csv import/export helpers

### DIFF
--- a/agents/gpt.ai
+++ b/agents/gpt.ai
@@ -22,3 +22,7 @@ Your primary role on the StackTrackr project is **Feature Implementation and Gen
 - Use backticks for code: `filename.js`, `function()`, `variable`
 - Use proper list formatting with hyphens (`-`)
 - Maintain consistent spacing and structure
+
+## Change Log
+
+- 2025-08-14: Restored global CSV import/export functions and corrected notes handling in `importCsv` (GPT)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,17 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.73**
+> **Latest release: v3.04.74**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.74 – CSV Import/Export Fixes (2025-08-14)
+- **Import Reliability**: Fixed undefined notes reference and removed unnecessary file input reset in `importCsv`
+- **Export Cleanup**: Released object URLs after CSV download to free resources
+- **Global Access**: Restored global exports for import/export functions and summary utilities
+- **Files Updated**: `js/inventory.js`, `js/constants.js`
 
 ### Version 3.04.73 – Changelog Loading Fix (2025-08-13)
 - **Hotfix**: Resolved "Unable to load changelog" error in version modal and about dialog

--- a/docs/patch/PATCH-3.04.74.ai
+++ b/docs/patch/PATCH-3.04.74.ai
@@ -1,0 +1,4 @@
+Version: 3.04.74
+Date: 2025-08-14
+Agent: GPT
+Summary: Restored global access for CSV import/export utilities and fixed CSV notes handling.

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.73";
+const APP_VERSION = "3.04.74";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1477,7 +1477,7 @@ const importCsv = (file, override = false) => {
             date,
             purchaseLocation,
             storageLocation,
-            notes: finalNotes,
+            notes,
             spotPriceAtPurchase,
             premiumPerOz,
             totalPremium,
@@ -1541,8 +1541,6 @@ const importCsv = (file, override = false) => {
         if (typeof updateStorageStats === 'function') {
           updateStorageStats();
         }
-
-        this.value = '';
       },
       error: function(error) {
         endImportProgress();
@@ -1916,6 +1914,7 @@ const exportCsv = () => {
   document.body.appendChild(a);
   a.click();
   a.remove();
+  URL.revokeObjectURL(url);
 };
 
 /**
@@ -2229,6 +2228,12 @@ const exportPdf = () => {
 };
 // =============================================================================
 // Expose inventory actions globally for inline event handlers
+window.importCsv = importCsv;
+window.exportCsv = exportCsv;
+window.importJson = importJson;
+window.exportJson = exportJson;
+window.exportPdf = exportPdf;
+window.updateSummary = updateSummary;
 window.toggleCollectable = toggleCollectable;
 window.editItem = editItem;
 window.deleteItem = deleteItem;


### PR DESCRIPTION
## Summary
- fix `importCsv` notes handling and remove stale input reset
- free blob URLs after CSV export
- expose import/export utilities globally and bump version to 3.04.74

## Testing
- `node scripts/test-templates.js` *(fails: ENOENT: no such file or directory, open '/workspace/StackTrackr/docs/status.md')*
- `node - <<'NODE'
const fs = require('fs');
const Papa = require('papaparse');
const path = require('path');
const samplePath = path.join(__dirname, 'sample.csv');
const data = fs.readFileSync(samplePath, 'utf8');
const result = Papa.parse(data, {header:true, skipEmptyLines:true});
console.log('Rows:', result.data.length);
console.log('First row keys:', Object.keys(result.data[0]));
// edge case: empty CSV
const empty = '';
const emptyResult = Papa.parse(empty, {header:true});
console.log('Empty rows:', emptyResult.data.length);
NODE`


------
https://chatgpt.com/codex/tasks/task_e_689e64aad890832e91367b99adb288e1