### PR TITLE
feat: add debug modal for import/export

### DIFF
--- a/agents/gpt.ai
+++ b/agents/gpt.ai
@@ -26,3 +26,4 @@ Your primary role on the StackTrackr project is **Feature Implementation and Gen
 ## Change Log
 
 - 2025-08-14: Restored global CSV import/export functions and corrected notes handling in `importCsv` (GPT)
+- 2025-08-14: Added debug modal and enhanced import/export/table logging (GPT)

--- a/css/styles.css
+++ b/css/styles.css
@@ -4541,3 +4541,11 @@ th {
     width: 100%;
   }
 }
+
+/* Debug modal styling */
+#debugModalContent {
+  max-height: 60vh;
+  overflow-y: auto;
+  font-family: monospace;
+  white-space: pre-wrap;
+}

--- a/docs/patch/PATCH-3.04.75.ai
+++ b/docs/patch/PATCH-3.04.75.ai
@@ -1,0 +1,4 @@
+Version: 3.04.75
+Date: 2025-08-14
+Agent: GPT
+Summary: Added debug modal with log history and enhanced import/export debugging.

--- a/index.html
+++ b/index.html
@@ -2418,7 +2418,24 @@
         </div>
       </div>
     </div>
-    
+
+    <!-- =============================================================================
+       DEBUG LOG MODAL
+
+       Displays collected debug output when debug mode is enabled.
+       ============================================================================= -->
+    <div class="modal" id="debugModal" style="display: none">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h2>Debug Log</h2>
+          <button aria-label="Close modal" class="modal-close" id="debugCloseBtn">×</button>
+        </div>
+        <div class="modal-body">
+          <pre id="debugModalContent"></pre>
+        </div>
+      </div>
+    </div>
+
     <!-- =============================================================================
        JAVASCRIPT MODULE LOADING
        
@@ -2450,6 +2467,7 @@
     <script defer src="./js/sorting.js"></script>
     <script defer src="./js/pagination.js"></script>
     <script defer src="./js/detailsModal.js"></script>
+    <script defer src="./js/debugModal.js"></script>
     <script defer src="./js/numista-modal.js"></script>
     <script defer src="./js/spot.js"></script>
     <script defer src="./js/api.js"></script>

--- a/js/debug-log.js
+++ b/js/debug-log.js
@@ -2,19 +2,22 @@
 (function (global) {
   'use strict';
   if (typeof global.debugLog === 'function') return;
+  const history = [];
   function isEnabled() {
     try { return !!localStorage.getItem('stackrtrackr.debug'); } catch (_) { return true; }
   }
   function log(level,args){
     if(!isEnabled()) return;
     try{
-      const a = ['[StackrTrackr]', new Date().toISOString(), level+':'].concat([].slice.call(args));
-      if(level==='WARN') console.warn.apply(console,a);
-      else if(level==='ERROR') console.error.apply(console,a);
-      else console.log.apply(console,a);
+      const parts = ['[StackrTrackr]', new Date().toISOString(), level+':'].concat([].slice.call(args));
+      history.push(parts.join(' '));
+      if(level==='WARN') console.warn.apply(console,parts);
+      else if(level==='ERROR') console.error.apply(console,parts);
+      else console.log.apply(console,parts);
     }catch(e){}
   }
   global.debugLog=function(){log('INFO',arguments)};
   global.debugWarn=function(){log('WARN',arguments)};
   global.debugError=function(){log('ERROR',arguments)};
+  global.getDebugHistory=function(){return history.slice();};
 })(typeof window!=='undefined'?window:this);

--- a/js/debugModal.js
+++ b/js/debugModal.js
@@ -1,0 +1,24 @@
+const showDebugModal = () => {
+  const modal = document.getElementById('debugModal');
+  const content = document.getElementById('debugModalContent');
+  if (content && typeof window.getDebugHistory === 'function') {
+    content.textContent = window.getDebugHistory().join('\n');
+  }
+  if (window.openModalById) openModalById('debugModal');
+  else if (modal) {
+    modal.style.display = 'flex';
+    document.body.style.overflow = 'hidden';
+  }
+};
+
+const hideDebugModal = () => {
+  if (window.closeModalById) closeModalById('debugModal');
+  else {
+    const modal = document.getElementById('debugModal');
+    if (modal) modal.style.display = 'none';
+    try { document.body.style.overflow = ''; } catch (e) {}
+  }
+};
+
+window.showDebugModal = showDebugModal;
+window.hideDebugModal = hideDebugModal;

--- a/js/events.js
+++ b/js/events.js
@@ -824,6 +824,19 @@ const setupEventListeners = () => {
       );
     }
 
+    if (elements.debugCloseBtn) {
+      safeAttachListener(
+        elements.debugCloseBtn,
+        "click",
+        () => {
+          if (typeof hideDebugModal === "function") {
+            hideDebugModal();
+          }
+        },
+        "Debug modal close button",
+      );
+    }
+
       if (elements.changeLogBtn) {
         safeAttachListener(
           elements.changeLogBtn,

--- a/js/init.js
+++ b/js/init.js
@@ -161,6 +161,10 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.cancelNotesBtn = safeGetElement("cancelNotes");
     elements.notesCloseBtn = safeGetElement("notesCloseBtn");
 
+    // Debug modal elements
+    elements.debugModal = safeGetElement("debugModal");
+    elements.debugCloseBtn = safeGetElement("debugCloseBtn");
+
     // Pagination elements
     debugLog("Phase 5: Initializing pagination elements...");
     elements.itemsPerPage = safeGetElement("itemsPerPage");

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -974,8 +974,8 @@ const hideEmptyColumns = () => {
 const renderTable = () => {
   return monitorPerformance(() => {
     const filteredInventory = filterInventory();
-
     const sortedInventory = sortInventory(filteredInventory);
+    debugLog('renderTable start', sortedInventory.length, 'items');
     const totalPages = calculateTotalPages(sortedInventory);
     const startIndex = (currentPage - 1) * itemsPerPage;
     const endIndex = Math.min(startIndex + itemsPerPage, sortedInventory.length);
@@ -985,6 +985,7 @@ const renderTable = () => {
     for (let i = startIndex; i < endIndex; i++) {
       const item = sortedInventory[i];
       const originalIdx = inventory.indexOf(item);
+      debugLog('renderTable row', i, item.name);
   const spotDisplay = item.isCollectable ? '—' : (item.spotPriceAtPurchase > 0 ? formatCurrency(item.spotPriceAtPurchase) : '—');
   const spotValue = item.isCollectable ? '—' : (item.spotPriceAtPurchase > 0 ? item.spotPriceAtPurchase : '');
       const premiumDisplay = item.isCollectable ? '—' : formatCurrency(item.totalPremium);
@@ -1042,6 +1043,8 @@ const renderTable = () => {
     tbody.innerHTML = rows.concat(placeholders).join('');
     hideEmptyColumns();
     updateTypeSummary(filteredInventory);
+
+    debugLog('renderTable complete');
 
     // Update sort indicators
     const headers = document.querySelectorAll('#inventoryTable th');
@@ -1409,6 +1412,7 @@ const endImportProgress = () => {
  */
 const importCsv = (file, override = false) => {
   try {
+    debugLog('importCsv start', file.name);
     Papa.parse(file, {
       header: true,
       skipEmptyLines: true,
@@ -1421,6 +1425,7 @@ const importCsv = (file, override = false) => {
 
         for (const row of results.data) {
           processed++;
+          debugLog('importCsv row', processed, JSON.stringify(row));
           const compositionRaw = row['Composition'] || row['Metal'] || 'Silver';
           const composition = getCompositionFirstWords(compositionRaw);
           const metal = parseNumistaMetal(composition);
@@ -1540,6 +1545,10 @@ const importCsv = (file, override = false) => {
         renderTable();
         if (typeof updateStorageStats === 'function') {
           updateStorageStats();
+        }
+        debugLog('importCsv complete', deduped.length, 'items added');
+        if (localStorage.getItem('stackrtrackr.debug') && typeof window.showDebugModal === 'function') {
+          showDebugModal();
         }
       },
       error: function(error) {
@@ -1865,6 +1874,7 @@ const exportNumistaCsv = () => {
  * Exports current inventory to CSV format
  */
 const exportCsv = () => {
+  debugLog('exportCsv start', inventory.length, 'items');
   const timestamp = new Date().toISOString().slice(0,10).replace(/-/g,'');
   const headers = [
     "Metal","Name","Qty","Type","Weight(oz)","Purchase Price",
@@ -1915,6 +1925,10 @@ const exportCsv = () => {
   a.click();
   a.remove();
   URL.revokeObjectURL(url);
+  debugLog('exportCsv complete');
+  if (localStorage.getItem('stackrtrackr.debug') && typeof window.showDebugModal === 'function') {
+    showDebugModal();
+  }
 };
 
 /**
@@ -1925,6 +1939,7 @@ const exportCsv = () => {
  */
 const importJson = (file, override = false) => {
   const reader = new FileReader();
+  debugLog('importJson start', file.name);
 
   reader.onload = function(e) {
     try {
@@ -1945,6 +1960,7 @@ const importJson = (file, override = false) => {
 
       for (const [index, raw] of data.entries()) {
         processed++;
+        debugLog('importJson item', index + 1, JSON.stringify(raw));
 
         const compositionRaw = raw.composition || raw.metal || 'Silver';
         const composition = getCompositionFirstWords(compositionRaw);
@@ -2079,6 +2095,10 @@ const importJson = (file, override = false) => {
       if (typeof updateStorageStats === "function") {
         updateStorageStats();
       }
+      debugLog('importJson complete', deduped.length, 'items added');
+      if (localStorage.getItem('stackrtrackr.debug') && typeof window.showDebugModal === 'function') {
+        showDebugModal();
+      }
     } catch (error) {
       endImportProgress();
       alert("Error parsing JSON file: " + error.message);
@@ -2092,6 +2112,7 @@ const importJson = (file, override = false) => {
  * Exports current inventory to JSON format
  */
 const exportJson = () => {
+  debugLog('exportJson start', inventory.length, 'items');
   const timestamp = new Date().toISOString().slice(0,10).replace(/-/g,'');
 
   // Sort inventory by date (newest first) for export
@@ -2126,6 +2147,10 @@ const exportJson = () => {
   document.body.appendChild(a);
   a.click();
   a.remove();
+  debugLog('exportJson complete');
+  if (localStorage.getItem('stackrtrackr.debug') && typeof window.showDebugModal === 'function') {
+    showDebugModal();
+  }
 };
 
 /**

--- a/js/state.js
+++ b/js/state.js
@@ -113,6 +113,10 @@ const elements = {
   cancelNotesBtn: null,
   notesCloseBtn: null,
 
+  // Debug modal elements
+  debugModal: null,
+  debugCloseBtn: null,
+
   // Details modal elements
   detailsModal: null,
   detailsModalTitle: null,


### PR DESCRIPTION
## Summary
- add debug modal component to display collected log history
- log import/export and table rendering steps for easier troubleshooting

## Testing
- `node scripts/test-templates.js` *(fails: ENOENT: no such file or directory, open '/workspace/StackTrackr/docs/status.md')*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e6879703c832e9db2c3b2c6cdd483