### PR TITLE
Add item count container below inventory table

### DIFF
--- a/agents/gpt.ai
+++ b/agents/gpt.ai
@@ -27,3 +27,4 @@ Your primary role on the StackTrackr project is **Feature Implementation and Gen
 
 - 2025-08-14: Restored global CSV import/export functions and corrected notes handling in `importCsv` (GPT)
 - 2025-08-14: Added debug modal and enhanced import/export/table logging (GPT)
+- 2025-08-15: Inserted item count placeholder below inventory table and added styling (GPT)

--- a/css/styles.css
+++ b/css/styles.css
@@ -1779,6 +1779,13 @@ table {
   height: auto;
 }
 
+.table-item-count {
+  font-size: 0.875rem;
+  color: var(--text-muted);
+  text-align: right;
+  margin-top: 0.25rem;
+}
+
 th {
   background: var(--bg-tertiary);
   color: var(--text-primary);

--- a/docs/patch/PATCH-3.04.76.ai
+++ b/docs/patch/PATCH-3.04.76.ai
@@ -1,0 +1,4 @@
+Version: 3.04.76
+Date: 2025-08-15
+Agent: GPT
+Summary: Added item count element below inventory table and styling.

--- a/index.html
+++ b/index.html
@@ -691,6 +691,7 @@
           </thead>
           <tbody></tbody>
         </table>
+        <div id="itemCount" class="table-item-count"></div>
       </section>
       <!-- Pagination Controls -->
       <section class="pagination-section">


### PR DESCRIPTION
## Summary
- Display placeholder `<div>` for inventory item count beneath main table
- Style `.table-item-count` element for muted, right-aligned appearance

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e83447004832eaa5e6b17bafc6995