### PR TITLE
pagination: cache item count element

### DIFF
--- a/agents/gpt.ai
+++ b/agents/gpt.ai
@@ -28,3 +28,4 @@ Your primary role on the StackTrackr project is **Feature Implementation and Gen
 - 2025-08-14: Restored global CSV import/export functions and corrected notes handling in `importCsv` (GPT)
 - 2025-08-14: Added debug modal and enhanced import/export/table logging (GPT)
 - 2025-08-15: Inserted item count placeholder below inventory table and added styling (GPT)
+- 2025-08-15: Cached pagination item count element in state and init for global access (GPT)

--- a/docs/patch/PATCH-3.04.77.ai
+++ b/docs/patch/PATCH-3.04.77.ai
@@ -1,0 +1,4 @@
+Version: 3.04.77
+Date: 2025-08-15
+Agent: GPT
+Summary: Exposed item count element in pagination for global state access.

--- a/js/init.js
+++ b/js/init.js
@@ -173,6 +173,7 @@ document.addEventListener("DOMContentLoaded", () => {
     elements.firstPage = safeGetElement("firstPage");
     elements.lastPage = safeGetElement("lastPage");
     elements.pageNumbers = safeGetElement("pageNumbers");
+    elements.itemCount = safeGetElement("itemCount");
 
       elements.changeLogBtn = safeGetElement("changeLogBtn");
       elements.backupReminder = safeGetElement("backupReminder");

--- a/js/state.js
+++ b/js/state.js
@@ -136,6 +136,7 @@ const elements = {
   firstPage: null,
   lastPage: null,
   pageNumbers: null,
+  itemCount: null,
 
   // Change log elements
     changeLogBtn: null,


### PR DESCRIPTION
## Summary
- cache pagination item count element in state for global access
- add item count lookup in init
- document change in patch notes

## Testing
- `node scripts/test-templates.js`

------
https://chatgpt.com/codex/tasks/task_e_689e87482ec8832eb6cab28c55c70a18