### PR TITLE
Add dynamic item count refresh in inventory table

### DIFF
--- a/agents/gpt.ai
+++ b/agents/gpt.ai
@@ -29,3 +29,5 @@ Your primary role on the StackTrackr project is **Feature Implementation and Gen
 - 2025-08-14: Added debug modal and enhanced import/export/table logging (GPT)
 - 2025-08-15: Inserted item count placeholder below inventory table and added styling (GPT)
 - 2025-08-15: Cached pagination item count element in state and init for global access (GPT)
+- 2025-08-15: Started dynamic item counter implementation (GPT)
+- 2025-08-15: Implemented dynamic item count refresh in renderTable (GPT)

--- a/docs/patch/PATCH-3.04.78.ai
+++ b/docs/patch/PATCH-3.04.78.ai
@@ -1,0 +1,4 @@
+Version: 3.04.78
+Date: 2025-08-15
+Agent: GPT
+Summary: Implemented dynamic item count update and refresh in renderTable.

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -649,6 +649,20 @@ const persistInventoryAndRefresh = () => {
 };
 
 /**
+ * Updates the displayed inventory item count based on active filters
+ *
+ * @param {number} filteredCount - Items matching current filters
+ * @param {number} totalCount - Total items in inventory
+ */
+const updateItemCount = (filteredCount, totalCount) => {
+  if (!elements.itemCount) return;
+  elements.itemCount.textContent =
+    filteredCount === totalCount
+      ? `${totalCount} items`
+      : `${filteredCount} of ${totalCount} items`;
+};
+
+/**
  * Enhanced validation for inline edits with comprehensive field support
  * @param {string} field - Field being edited
  * @param {string} value - Proposed value
@@ -974,6 +988,7 @@ const hideEmptyColumns = () => {
 const renderTable = () => {
   return monitorPerformance(() => {
     const filteredInventory = filterInventory();
+    updateItemCount(filteredInventory.length, inventory.length);
     const sortedInventory = sortInventory(filteredInventory);
     debugLog('renderTable start', sortedInventory.length, 'items');
     const totalPages = calculateTotalPages(sortedInventory);


### PR DESCRIPTION
## Summary
- add `updateItemCount` helper to display total vs. filtered item counts
- refresh item count during `renderTable` to stay synchronized with filters and pagination
- record patch notes for version 3.04.78

## Testing
- `node --check js/inventory.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e89c17584832ea8fdede550071c95