### PR TITLE
docs: document table item counter

### DIFF
--- a/codex.ai
+++ b/codex.ai
@@ -1,0 +1,5 @@
+# Codex Agent Memory
+
+## Change Log
+- 2025-08-15: Started session to document table item counter and update documentation (GPT)
+- 2025-08-15: Added changelog entry and style guide notes for inventory table item counter (GPT)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,16 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.74**
+> **Latest release: v3.04.76**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.76 – Table Item Counter (2025-08-15)
+- **Inventory Insight**: Added dynamic item counter below the inventory table displaying the number of visible items.
+- **Styling**: Muted text, right-aligned using `.table-item-count` for a subtle appearance.
+- **Files Updated**: `index.html`, `css/styles.css`, `js/state.js`, `js/inventory.js`
 
 ### Version 3.04.74 – CSV Import/Export Fixes (2025-08-14)
 - **Import Reliability**: Fixed undefined notes reference and removed unnecessary file input reset in `importCsv`

--- a/docs/patch/PATCH-3.04.76.ai
+++ b/docs/patch/PATCH-3.04.76.ai
@@ -1,4 +1,4 @@
 Version: 3.04.76
 Date: 2025-08-15
 Agent: GPT
-Summary: Added item count element below inventory table and styling.
+Summary: Added inventory table item counter with muted styling and documented usage.

--- a/docs/ui_style_guide.md
+++ b/docs/ui_style_guide.md
@@ -79,3 +79,8 @@ The `.btn` class provides the base button style with variant modifiers:
 - Buttons include a subtle shine effect via the `::before` pseudo-element and use `var(--radius)` for rounded corners.
 
 Use these guidelines to keep new UI elements consistent with the existing design system.
+
+## Inventory Table Counter
+
+- The `#itemCount` element displays the number of visible inventory items.
+- Styled with `.table-item-count` using muted text (`var(--text-muted)`), `0.875rem` font size, right alignment, and a small top margin.


### PR DESCRIPTION
## Summary
- add changelog entry for new inventory table item counter feature
- note counter styling in UI style guide
- record patch details for version 3.04.76

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node scripts/test-templates.js` *(fails: ENOENT: no such file or directory, open '/workspace/StackTrackr/docs/status.md')*

------
https://chatgpt.com/codex/tasks/task_e_689e8ba9c178832eb0b396e176d78e54