### PR TITLE
guard fuzzy-search exports for browser compatibility

### DIFF
--- a/agents/gpt.ai
+++ b/agents/gpt.ai
@@ -31,3 +31,4 @@ Your primary role on the StackTrackr project is **Feature Implementation and Gen
 - 2025-08-15: Cached pagination item count element in state and init for global access (GPT)
 - 2025-08-15: Started dynamic item counter implementation (GPT)
 - 2025-08-15: Implemented dynamic item count refresh in renderTable (GPT)
+- 2025-08-15: Added browser-safe exports for fuzzy-search utilities (GPT)

--- a/codex.ai
+++ b/codex.ai
@@ -3,3 +3,4 @@
 ## Change Log
 - 2025-08-15: Started session to document table item counter and update documentation (GPT)
 - 2025-08-15: Added changelog entry and style guide notes for inventory table item counter (GPT)
+- 2025-08-15: Documented fuzzy-search global export safeguard (GPT)

--- a/docs/patch/PATCH-3.04.79.ai
+++ b/docs/patch/PATCH-3.04.79.ai
@@ -1,0 +1,4 @@
+Version: 3.04.79
+Date: 2025-08-15
+Agent: GPT
+Summary: Wrapped Node exports with environment check and exposed fuzzy-search utilities to browser.

--- a/js/fuzzy-search.js
+++ b/js/fuzzy-search.js
@@ -187,13 +187,25 @@ const fuzzySearch = (query, targets, options = {}) => {
   return results.slice(0, maxResults);
 };
 
-// Exporting functions for external use
-module.exports = {
-  normalizeString,
-  tokenizeWords,
-  generateNGrams,
-  calculateLevenshteinDistance,
-  fuzzyMatch,
-  fuzzySearch,
-};
+// Exporting functions for external use in Node.js
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = {
+    normalizeString,
+    tokenizeWords,
+    generateNGrams,
+    calculateLevenshteinDistance,
+    fuzzyMatch,
+    fuzzySearch,
+  };
+}
+
+// Expose functions to the browser global scope
+if (typeof window !== "undefined") {
+  window.normalizeString = normalizeString;
+  window.tokenizeWords = tokenizeWords;
+  window.generateNGrams = generateNGrams;
+  window.calculateLevenshteinDistance = calculateLevenshteinDistance;
+  window.fuzzyMatch = fuzzyMatch;
+  window.fuzzySearch = fuzzySearch;
+}
 


### PR DESCRIPTION
## Summary
- avoid ReferenceError in browser by wrapping `module.exports` in environment checks and exposing fuzzy-search utilities to `window`.
- record fuzzy-search export safeguard in agent logs and patch notes.

## Testing
- `node -e "const fs=require('fs');const vm=require('vm');const code=fs.readFileSync('./js/fuzzy-search.js','utf8');const context={window:{}};vm.createContext(context);try{vm.runInContext(code,context);console.log('load success');}catch(e){console.error('load error',e);process.exit(1);}"`
- `node -e "const f=require('./js/fuzzy-search.js');console.log(Object.keys(f));"`


------
https://chatgpt.com/codex/tasks/task_e_689ebe7928fc832e9378aef7e4d7a23a