### PR TITLE
docs: update fuzzy-search threshold defaults

### DIFF
--- a/agents/gpt.ai
+++ b/agents/gpt.ai
@@ -32,3 +32,4 @@ Your primary role on the StackTrackr project is **Feature Implementation and Gen
 - 2025-08-15: Started dynamic item counter implementation (GPT)
 - 2025-08-15: Implemented dynamic item count refresh in renderTable (GPT)
 - 2025-08-15: Added browser-safe exports for fuzzy-search utilities (GPT)
+- 2025-08-15: Standardized fuzzy-search threshold defaults and documentation (GPT)

--- a/codex.ai
+++ b/codex.ai
@@ -4,3 +4,4 @@
 - 2025-08-15: Started session to document table item counter and update documentation (GPT)
 - 2025-08-15: Added changelog entry and style guide notes for inventory table item counter (GPT)
 - 2025-08-15: Documented fuzzy-search global export safeguard (GPT)
+- 2025-08-15: Aligned fuzzy-search threshold defaults and documentation (GPT)

--- a/docs/patch/PATCH-3.04.80.ai
+++ b/docs/patch/PATCH-3.04.80.ai
@@ -1,0 +1,4 @@
+Version: 3.04.80
+Date: 2025-08-15
+Agent: GPT
+Summary: Aligned fuzzy-search threshold defaults and documentation.

--- a/js/fuzzy-search.js
+++ b/js/fuzzy-search.js
@@ -88,7 +88,7 @@ const calculateLevenshteinDistance = (str1, str2) => {
  * @param {string} query - User search input
  * @param {string} target - Inventory item name to match against
  * @param {Object} [options={}] - Configuration options
- * @param {number} [options.threshold=0.3] - Minimum similarity score
+ * @param {number} [options.threshold=0.5] - Minimum similarity score
  * @param {boolean} [options.caseSensitive=false] - Case sensitive matching
  * @returns {number} Similarity score between 0 and 1
  *
@@ -165,7 +165,7 @@ const fuzzyMatch = (query, target, options = {}) => {
  * @param {string} query - Search query
  * @param {string[]} targets - Array of strings to search
  * @param {Object} [options={}] - Configuration options
- * @param {number} [options.threshold=0.3] - Minimum similarity score
+ * @param {number} [options.threshold=0.5] - Minimum similarity score
  * @param {number} [options.maxResults=Infinity] - Maximum results to return
  * @param {boolean} [options.caseSensitive=false] - Case sensitive matching
  * @returns {{text: string, score: number}[]} Array of results
@@ -175,10 +175,10 @@ const fuzzySearch = (query, targets, options = {}) => {
     console.warn("fuzzySearch: targets must be an array");
     return [];
   }
-  const { maxResults = Infinity } = options;
+  const { threshold = 0.5, maxResults = Infinity, caseSensitive = false } = options;
   const results = [];
   targets.forEach((t) => {
-    const score = fuzzyMatch(query, t, options);
+    const score = fuzzyMatch(query, t, { threshold, caseSensitive });
     if (score > 0) {
       results.push({ text: t, score });
     }


### PR DESCRIPTION
## Summary
- document fuzzy-match default threshold of 0.5
- ensure fuzzySearch forwards a default threshold consistently
- record changes in agent memory and patch log

## Testing
- `node --check js/fuzzy-search.js`


------
https://chatgpt.com/codex/tasks/task_e_689ec040fd50832e9d67298fa2bdfb7b