### PR TITLE
fix: rely on CSS for logo height

### DIFF
--- a/agents/gpt-4o.ai
+++ b/agents/gpt-4o.ai
@@ -1,0 +1,6 @@
+# GPT-4o Agent Log
+
+## Change Log
+- 2025-08-15: Session start - plan to remove invalid `height="auto"` from SVG logo and verify no browser warnings.
+- 2025-08-15: Completed removal of `height="auto"` from Stackr logo, relying on CSS; attempted browser check (gpt-4o)
+

--- a/codex.ai
+++ b/codex.ai
@@ -7,3 +7,5 @@
 - 2025-08-15: Aligned fuzzy-search threshold defaults and documentation (GPT)
 - 2025-08-15: Exposed `checkFileSize` and `MAX_LOCAL_FILE_SIZE` to global window and added validation test (GPT)
 
+- 2025-08-15: Removed invalid height attribute from Stackr logo and attempted headless check for warnings (gpt-4o)
+

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,15 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.81**
+> **Latest release: v3.04.82**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.82 – Logo height via CSS (2025-08-15)
+- Removed invalid height attribute from Stackr logo SVG, relying on CSS for sizing.
+- Files Updated: `index.html`, `docs/changelog.md`
 
 ### Version 3.04.81 – Composition helper cleanup (2025-08-15)
 - Removed obsolete composition helper comment and synchronized documentation

--- a/docs/fixes/logo-height-fix.md
+++ b/docs/fixes/logo-height-fix.md
@@ -1,0 +1,12 @@
+# Logo Height Fix
+
+## Problem
+- `index.html` defined `height="auto"` on the Stackr logo SVG, which is not a valid attribute value and produced browser warnings.
+
+## Solution
+- Removed the `height` attribute from the `<svg>` and rely on the CSS rule `.stackr-logo { height: auto; }` for sizing.
+
+## Affected Files
+- `index.html`
+- `css/styles.css`
+

--- a/docs/patch/PATCH-3.04.82.ai
+++ b/docs/patch/PATCH-3.04.82.ai
@@ -1,0 +1,5 @@
+Version: 3.04.82
+Date: 2025-08-15
+Agent: GPT-4o
+Summary: Removed height attribute from Stackr logo SVG to rely on CSS sizing and prevent HTML warnings.
+

--- a/index.html
+++ b/index.html
@@ -65,7 +65,7 @@
     <div class="app-header">
       <div>
         <h1 class="app-logo" id="appLogo" aria-label="StackrTrackr">
-          <svg class="stackr-logo" viewBox="0 0 480 200" xmlns="http://www.w3.org/2000/svg" width="100%" height="auto" style="max-width: 666px;">
+          <svg class="stackr-logo" viewBox="0 0 480 200" xmlns="http://www.w3.org/2000/svg" width="100%" style="max-width: 666px;">
             <defs>
               <!-- Light Mode Gradients -->
               <linearGradient id="goldLight" x1="0%" y1="0%" x2="0%" y2="100%">

--- a/js/constants.js
+++ b/js/constants.js
@@ -257,7 +257,7 @@ const API_PROVIDERS = {
  * Example: 3.03.02a → branch 3, release 03, patch 02, alpha
  */
 
-const APP_VERSION = "3.04.81";
+const APP_VERSION = "3.04.82";
 
 /**
  * @constant {string} DEFAULT_CURRENCY - Default currency code for monetary formatting


### PR DESCRIPTION
## Summary
- remove invalid `height="auto"` from Stackr logo SVG and rely on CSS for sizing
- bump version to `3.04.82` and record patch notes
- document logo height fix for future reference

## Testing
- `npx --yes playwright@latest install chromium` *(fails: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_689ec4d507a0832e976404237e9ec46b