### PR TITLE
feat: load tests only in development

### DIFF
--- a/codex.ai
+++ b/codex.ai
@@ -8,4 +8,5 @@
 - 2025-08-15: Exposed `checkFileSize` and `MAX_LOCAL_FILE_SIZE` to global window and added validation test (GPT)
 
 - 2025-08-15: Removed invalid height attribute from Stackr logo and attempted headless check for warnings (gpt-4o)
+- 2025-08-16: Added dev-only loader for grouped-name-chips test script and created dev server for proper MIME types (gpt-4o)
 

--- a/docs/patch/PATCH-3.04.83.ai
+++ b/docs/patch/PATCH-3.04.83.ai
@@ -1,0 +1,4 @@
+Version: 3.04.83
+Date: 2025-08-16
+Agent: GPT-4o
+Summary: Load grouped-name-chips test only during development and add Node dev server to serve JS with proper MIME type.

--- a/index.html
+++ b/index.html
@@ -2480,8 +2480,15 @@
     <script defer src="./js/events.js"></script>
     
     <!-- Test Scripts (Development) -->
-    <script defer src="./tests/grouped-name-chips.test.js"></script>
-    
+    <script>
+      if (window.location.hostname === 'localhost') {
+        const testScript = document.createElement('script');
+        testScript.defer = true;
+        testScript.src = './tests/grouped-name-chips.test.js';
+        document.head.appendChild(testScript);
+      }
+    </script>
+
     <script defer src="./js/init.js"></script>
   </body>
 </html>

--- a/scripts/dev-server.js
+++ b/scripts/dev-server.js
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const mimeTypes = {
+  '.html': 'text/html',
+  '.css': 'text/css',
+  '.js': 'application/javascript',
+  '.json': 'application/json',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png'
+};
+
+const server = http.createServer((req, res) => {
+  let filePath = '.' + req.url;
+  if (filePath === './') {
+    filePath = './index.html';
+  }
+  const extname = path.extname(filePath);
+  const contentType = mimeTypes[extname] || 'application/octet-stream';
+
+  fs.readFile(path.join(__dirname, '..', filePath), (err, content) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+    } else {
+      res.writeHead(200, { 'Content-Type': contentType });
+      res.end(content, 'utf-8');
+    }
+  });
+});
+
+const port = process.env.PORT || 8080;
+server.listen(port, () => {
+  console.log(`Dev server running on http://localhost:${port}`);
+});

--- a/tests/grouped-name-chips.test.js
+++ b/tests/grouped-name-chips.test.js
@@ -1,0 +1,1 @@
+console.log('grouped-name-chips test loaded');


### PR DESCRIPTION
## Summary
- load grouped-name-chips test script dynamically only when running on localhost
- add simple Node dev server that serves JavaScript with `application/javascript`
- document change and add placeholder browser test file

## Testing
- `node scripts/test-templates.js` *(fails: ENOENT: no such file or directory, open '/workspace/StackTrackr/docs/status.md')*
- `node tests/grouped-name-chips.test.js`
- `node scripts/dev-server.js`

------
https://chatgpt.com/codex/tasks/task_e_689ec7660bf4832ea665e3db5ab01065