### PR TITLE
init: render active filter chips on initial load

### DIFF
--- a/agents/gpt-4o.ai
+++ b/agents/gpt-4o.ai
@@ -4,3 +4,6 @@
 - 2025-08-15: Session start - plan to remove invalid `height="auto"` from SVG logo and verify no browser warnings.
 - 2025-08-15: Completed removal of `height="auto"` from Stackr logo, relying on CSS; attempted browser check (gpt-4o)
 
+- 2025-08-16: Session start - plan to render active filter chips on initial load by calling renderActiveFilters after renderTable.
+- 2025-08-16: Added renderActiveFilters call post-renderTable; filter chips now display on initial load (gpt-4o)
+

--- a/codex.ai
+++ b/codex.ai
@@ -10,3 +10,5 @@
 - 2025-08-15: Removed invalid height attribute from Stackr logo and attempted headless check for warnings (gpt-4o)
 - 2025-08-16: Added dev-only loader for grouped-name-chips test script and created dev server for proper MIME types (gpt-4o)
 
+- 2025-08-16: Inserted renderActiveFilters call after renderTable in init.js to show filter chips on initial load (gpt-4o)
+

--- a/docs/patch/PATCH-3.04.84.ai
+++ b/docs/patch/PATCH-3.04.84.ai
@@ -1,0 +1,4 @@
+Version: 3.04.84
+Date: 2025-08-16
+Agent: GPT-4o
+Summary: Render active filter chips on initial load by calling renderActiveFilters after renderTable in init.js.

--- a/js/init.js
+++ b/js/init.js
@@ -343,6 +343,9 @@ document.addEventListener("DOMContentLoaded", () => {
     // Phase 13: Initial Rendering
     debugLog("Phase 13: Rendering initial display...");
       renderTable();
+      if (typeof renderActiveFilters === 'function') {
+        renderActiveFilters();
+      }
       fetchSpotPrice();
       updateSyncButtonStates();
       if (typeof updateStorageStats === "function") {


### PR DESCRIPTION
## Summary
- ensure filter chips render on startup by invoking `renderActiveFilters` immediately after initial table render
- record change in patch log and agent memory

## Testing
- `node tests/grouped-name-chips.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689ed278fd84832eb71975414a8264f0