### PR TITLE
Allow slash in sanitized item names

### DIFF
--- a/agents/gpt-4-1.ai
+++ b/agents/gpt-4-1.ai
@@ -1,0 +1,5 @@
+# GPT-4-1 Agent Log
+
+## Change Log
+- 2025-08-17: Session start - plan to allow slash in item name sanitization (gpt-4-1)
+- 2025-08-17: Added allowSlash option to sanitizeObjectFields and created test to preserve '/' in names (gpt-4-1)

--- a/codex.ai
+++ b/codex.ai
@@ -12,3 +12,4 @@
 
 - 2025-08-16: Inserted renderActiveFilters call after renderTable in init.js to show filter chips on initial load (gpt-4o)
 
+- 2025-08-17: Enabled slash preservation in item names by extending sanitization helper and adding unit test (gpt-4-1)

--- a/docs/patch/PATCH-3.04.85.ai
+++ b/docs/patch/PATCH-3.04.85.ai
@@ -1,0 +1,4 @@
+Version: 3.04.85
+Date: 2025-08-17
+Agent: GPT-4.1
+Summary: Allow slash in item name sanitization, extended stripNonAlphanumeric helper, and added test for slash preservation.

--- a/js/utils.js
+++ b/js/utils.js
@@ -551,8 +551,19 @@ const detectCurrency = (str = "") => {
  * @param {string} str - Input string
  * @returns {string} Cleaned string containing only letters, numbers, and spaces
  */
-const stripNonAlphanumeric = (str = "", allowHyphen = false) =>
-  str.toString().replace(allowHyphen ? /[^a-zA-Z0-9 -]/g : /[^a-zA-Z0-9 ]/g, "");
+const stripNonAlphanumeric = (str = "", { allowHyphen = false, allowSlash = false } = {}) =>
+  str
+    .toString()
+    .replace(
+      allowHyphen && allowSlash
+        ? /[^a-zA-Z0-9 \\/-]/g
+        : allowHyphen
+        ? /[^a-zA-Z0-9 -]/g
+        : allowSlash
+        ? /[^a-zA-Z0-9 \\/]/g
+        : /[^a-zA-Z0-9 ]/g,
+      ""
+    );
 
 /**
  * Cleans a string by stripping HTML tags and control characters while
@@ -582,10 +593,11 @@ const sanitizeObjectFields = (obj) => {
   for (const key of Object.keys(cleaned)) {
     if (typeof cleaned[key] === "string" && key !== 'notes') {
       const allowHyphen = key === 'date';
+      const allowSlash = key === 'name';
       cleaned[key] =
         key === 'purchaseLocation'
           ? cleanString(cleaned[key])
-          : stripNonAlphanumeric(cleaned[key], allowHyphen);
+          : stripNonAlphanumeric(cleaned[key], { allowHyphen, allowSlash });
     }
   }
   return cleaned;
@@ -1030,8 +1042,6 @@ const closeModalById = (id) => {
   }
   try { if (document && document.body) document.body.style.overflow = ''; } catch (e) {}
 };
-
-window.closeModalById = closeModalById;
 /**
  * Opens a modal by id and sets body overflow to hidden.
  * Also initializes a click-outside-to-close handler once.
@@ -1061,8 +1071,6 @@ const openModalById = (id) => {
     /* ignore */
   }
 };
-
-window.openModalById = openModalById;
 /**
  * Generates comprehensive HTML storage report with theme support
  */
@@ -2491,12 +2499,6 @@ This archive contains a complete snapshot of your StackrTrackr storage data.`;
   return content;
 };
 
-// Make storage report functions globally available
-window.updateStorageStats = updateStorageStats;
-window.downloadStorageReport = downloadStorageReport;
-window.openStorageReportPopup = openStorageReportPopup;
-
-
 /** Storage compression helpers (Phase 1C) */
 const __ST_COMP_PREFIX = 'CMP1:';
 function __compressIfNeeded(str){
@@ -2537,4 +2539,17 @@ if (typeof window !== 'undefined') {
   window.cleanupStorage = cleanupStorage;
   window.checkFileSize = checkFileSize;
   window.MAX_LOCAL_FILE_SIZE = MAX_LOCAL_FILE_SIZE;
+  window.closeModalById = closeModalById;
+  window.openModalById = openModalById;
+  window.updateStorageStats = updateStorageStats;
+  window.downloadStorageReport = downloadStorageReport;
+  window.openStorageReportPopup = openStorageReportPopup;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = {
+    stripNonAlphanumeric,
+    sanitizeObjectFields,
+    sanitizeImportedItem,
+  };
 }

--- a/tests/sanitize-name-slash.test.js
+++ b/tests/sanitize-name-slash.test.js
@@ -1,0 +1,14 @@
+const assert = require('assert');
+const { sanitizeImportedItem } = require('../js/utils.js');
+
+const item = sanitizeImportedItem({
+  name: '1/2 oz Round',
+  type: 'Round',
+  metal: 'Silver',
+  qty: 1,
+  weight: 1,
+  price: 1,
+});
+
+assert.strictEqual(item.name, '1/2 oz Round');
+console.log('sanitizeImportedItem keeps slash in name');


### PR DESCRIPTION
## Summary
- extend stripNonAlphanumeric with `allowSlash` option
- preserve `/` in inventory names during sanitization
- add unit test ensuring imported items retain slash in name

## Testing
- `node tests/sanitize-name-slash.test.js`
- `node tests/grouped-name-chips.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689ed518a04c832e87a9f7486fbfbe95