### PR TITLE
Center Name header text

### DIFF
--- a/agents/gpt.ai
+++ b/agents/gpt.ai
@@ -34,4 +34,5 @@ Your primary role on the StackTrackr project is **Feature Implementation and Gen
 - 2025-08-15: Added browser-safe exports for fuzzy-search utilities (GPT)
 - 2025-08-15: Standardized fuzzy-search threshold defaults and documentation (GPT)
 - 2025-08-15: Exported `checkFileSize` and `MAX_LOCAL_FILE_SIZE` to window and verified availability (GPT)
+- 2025-08-17: Wrapped Name header text with span and removed obsolete centering CSS (GPT)
 

--- a/codex.ai
+++ b/codex.ai
@@ -13,3 +13,4 @@
 - 2025-08-16: Inserted renderActiveFilters call after renderTable in init.js to show filter chips on initial load (gpt-4o)
 
 - 2025-08-17: Enabled slash preservation in item names by extending sanitization helper and adding unit test (gpt-4-1)
+- 2025-08-17: Centered Name header text by wrapping with `.header-text` and removing special CSS (GPT)

--- a/css/styles.css
+++ b/css/styles.css
@@ -1874,13 +1874,8 @@ tr:hover {
   white-space: nowrap;
   min-width: 0;
 }
-/* Ensure the Name header is visually centered while cell contents can be left-aligned */
-#inventoryTable th[data-column="name"] {
-  text-align: center;
-}
-
+/* Name column cells remain left aligned for readability */
 #inventoryTable td[data-column="name"] {
-  /* Cells remain left aligned for readability (set inline in renderTable) */
   text-align: left;
 }
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,11 +1,16 @@
 # StackrTrackr — Changelog
 
-> **Latest release: v3.04.82**
+> **Latest release: v3.04.86**
 
 
 For upcoming work, see [announcements](announcements.md).
 
 ## 📋 Version History
+
+### Version 3.04.86 – Centered Name header (2025-08-17)
+- Wrapped “Name” header text with `.header-text` span for consistent alignment.
+- Removed obsolete `#inventoryTable th[data-column="name"]` centering rule.
+- **Files Updated**: `index.html`, `css/styles.css`, `docs/changelog.md`
 
 ### Version 3.04.82 – Logo height via CSS (2025-08-15)
 - Removed invalid height attribute from Stackr logo SVG, relying on CSS for sizing.

--- a/docs/fixes/name-header-centering-fix.md
+++ b/docs/fixes/name-header-centering-fix.md
@@ -1,0 +1,11 @@
+# Name Header Centering Fix
+
+The “Name” column header was slightly offset because the text sat directly in the `<th>` element while other headers wrapped their labels in `.header-text` spans. This required a special CSS rule to center the header text.
+
+## Solution
+
+- Wrapped the header text in `<span class="header-text">Name</span>`.
+- Removed the `#inventoryTable th[data-column="name"]` centering override; default `.header-text` styling now handles alignment.
+
+This keeps the header consistent with others and removes the need for bespoke CSS.
+

--- a/docs/patch/PATCH-3.04.86.ai
+++ b/docs/patch/PATCH-3.04.86.ai
@@ -1,0 +1,5 @@
+Version: 3.04.86
+Date: 2025-08-17
+Agent: GPT
+Summary: Wrapped Name header text with `.header-text` span and removed special centering override.
+

--- a/index.html
+++ b/index.html
@@ -600,7 +600,7 @@
                   <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/>
                   <circle cx="12" cy="7" r="4"/>
                 </svg>
-                Name
+                <span class="header-text">Name</span>
               </th>
               <th class="shrink" data-column="weight">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">

--- a/tests/header-name-centering.test.js
+++ b/tests/header-name-centering.test.js
@@ -1,0 +1,31 @@
+const puppeteer = require('puppeteer');
+const assert = require('assert');
+
+(async () => {
+  const widths = [375, 768, 1024];
+  const browser = await puppeteer.launch({ args: ['--no-sandbox'] });
+  const page = await browser.newPage();
+
+  for (const width of widths) {
+    await page.setViewport({ width, height: 800 });
+    await page.goto(`file://${process.cwd()}/index.html`);
+
+    const diff = await page.evaluate(() => {
+      const th = document.querySelector('#inventoryTable th[data-column="name"]');
+      const icon = th.querySelector('.header-icon');
+      const text = th.querySelector('.header-text');
+      const iconRect = icon.getBoundingClientRect();
+      const textRect = text.getBoundingClientRect();
+      const iconCenter = iconRect.left + iconRect.width / 2;
+      const textCenter = textRect.left + textRect.width / 2;
+      return Math.abs(iconCenter - textCenter);
+    });
+
+    console.log(`width ${width} center diff ${diff.toFixed(2)}`);
+    assert.ok(diff < 1, `Center diff ${diff}px exceeds 1px at width ${width}`);
+  }
+
+  await browser.close();
+  console.log('Name header centered across widths');
+})();
+


### PR DESCRIPTION
## Summary
- wrap the Name column header in a `.header-text` span for consistent centering
- drop obsolete CSS centering override now handled by header-text class
- document fix and add puppeteer test verifying alignment

## Testing
- `node tests/grouped-name-chips.test.js`
- `node tests/sanitize-name-slash.test.js`
- `node tests/header-name-centering.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689ed70820ec832ebfec42d39b063456