### PR TITLE
Move rows-per-page selector to table footer

### DIFF
--- a/agents/gpt-4o.ai
+++ b/agents/gpt-4o.ai
@@ -7,3 +7,5 @@
 - 2025-08-16: Session start - plan to render active filter chips on initial load by calling renderActiveFilters after renderTable.
 - 2025-08-16: Added renderActiveFilters call post-renderTable; filter chips now display on initial load (gpt-4o)
 
+- 2025-08-17: Session start - plan to wrap #itemCount and itemsPerPage in table-footer-controls and remove old control-group (gpt-4o)
+- 2025-08-17: Wrapped #itemCount with itemsPerPage in table-footer-controls and updated styles for flex layout (gpt-4o)

--- a/codex.ai
+++ b/codex.ai
@@ -14,3 +14,4 @@
 
 - 2025-08-17: Enabled slash preservation in item names by extending sanitization helper and adding unit test (gpt-4-1)
 - 2025-08-17: Centered Name header text by wrapping with `.header-text` and removing special CSS (GPT)
+- 2025-08-17: Repositioned rows-per-page selector below inventory table and paired with item count in new flex container (gpt-4o)

--- a/css/styles.css
+++ b/css/styles.css
@@ -1779,12 +1779,17 @@ table {
   height: auto;
 }
 
-.table-item-count {
-  font-size: 0.875rem;
-  color: var(--text-muted);
-  text-align: right;
-  margin-top: 0.25rem;
-}
+  .table-item-count {
+    font-size: 0.875rem;
+    color: var(--text-muted);
+  }
+
+  .table-footer-controls {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 0.25rem;
+  }
 
 th {
   background: var(--bg-tertiary);

--- a/docs/patch/PATCH-3.04.87.ai
+++ b/docs/patch/PATCH-3.04.87.ai
@@ -1,0 +1,4 @@
+Version: 3.04.87
+Date: 2025-08-17
+Agent: gpt-4o
+Summary: Moved rows-per-page selector below inventory table, wrapping it with item count in a flexbox container and removed old control group.

--- a/index.html
+++ b/index.html
@@ -531,16 +531,6 @@
                   <option value="no">No</option>
                 </select>
               </div>
-              <div class="control-group">
-                <label for="itemsPerPage" class="control-label">Table Rows:</label>
-                <select class="control-select" id="itemsPerPage">
-                  <option value="10" selected>10</option>
-                  <option value="15">15</option>
-                  <option value="25">25</option>
-                  <option value="50">50</option>
-                  <option value="100">100</option>
-                </select>
-              </div>
             </div>
           </div>
         </section>
@@ -690,11 +680,20 @@
             </tr>
           </thead>
           <tbody></tbody>
-        </table>
-        <div id="itemCount" class="table-item-count"></div>
-      </section>
-      <!-- Pagination Controls -->
-      <section class="pagination-section">
+          </table>
+          <div class="table-footer-controls">
+            <div id="itemCount" class="table-item-count"></div>
+            <select id="itemsPerPage" class="control-select" title="Rows per page">
+              <option value="10" selected>10</option>
+              <option value="15">15</option>
+              <option value="25">25</option>
+              <option value="50">50</option>
+              <option value="100">100</option>
+            </select>
+          </div>
+        </section>
+        <!-- Pagination Controls -->
+        <section class="pagination-section">
           <div class="pagination-container">
             <div class="pagination-controls">
               <div class="pagination-buttons">


### PR DESCRIPTION
## Summary
- Remove old toolbar control group for rows-per-page selector.
- Add flexbox `.table-footer-controls` beneath inventory table to align item count left and rows-per-page dropdown right.
- Style new footer controls with flexbox and update agent logs and patch notes.

## Testing
- `node tests/grouped-name-chips.test.js`
- `node tests/sanitize-name-slash.test.js`
- `node tests/header-name-centering.test.js` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_689edace1544832eb09e03b78a11e4cc