### PR TITLE
style: emphasize item counter

### DIFF
--- a/agents/gpt-4o.ai
+++ b/agents/gpt-4o.ai
@@ -9,3 +9,6 @@
 
 - 2025-08-17: Session start - plan to wrap #itemCount and itemsPerPage in table-footer-controls and remove old control-group (gpt-4o)
 - 2025-08-17: Wrapped #itemCount with itemsPerPage in table-footer-controls and updated styles for flex layout (gpt-4o)
+
+- 2025-08-18: Session start - plan to emphasize table item count with bold styling and background (gpt-4o)
+- 2025-08-18: Enhanced table item count with heavier font, larger size, and background; updated docs (gpt-4o)

--- a/agents/gpt-4o.ai
+++ b/agents/gpt-4o.ai
@@ -12,3 +12,5 @@
 
 - 2025-08-18: Session start - plan to emphasize table item count with bold styling and background (gpt-4o)
 - 2025-08-18: Enhanced table item count with heavier font, larger size, and background; updated docs (gpt-4o)
+- 2025-08-18: Session start - plan to modernize rows-per-page dropdown and align controls for symmetry (gpt-4o)
+- 2025-08-18: Styled rows-per-page dropdown as compact button and positioned it on the right, leaving item counter on the left (gpt-4o)

--- a/codex.ai
+++ b/codex.ai
@@ -18,3 +18,4 @@
 
 - 2025-08-18: Begin styling enhancement for table item counter with bold background accent (gpt-4o)
 - 2025-08-18: Added item counter styling with background and bold, updated HTML and documentation (gpt-4o)
+- 2025-08-18: Shrunk rows-per-page dropdown with button styling and aligned it opposite the item counter (gpt-4o)

--- a/codex.ai
+++ b/codex.ai
@@ -15,3 +15,6 @@
 - 2025-08-17: Enabled slash preservation in item names by extending sanitization helper and adding unit test (gpt-4-1)
 - 2025-08-17: Centered Name header text by wrapping with `.header-text` and removing special CSS (GPT)
 - 2025-08-17: Repositioned rows-per-page selector below inventory table and paired with item count in new flex container (gpt-4o)
+
+- 2025-08-18: Begin styling enhancement for table item counter with bold background accent (gpt-4o)
+- 2025-08-18: Added item counter styling with background and bold, updated HTML and documentation (gpt-4o)

--- a/css/styles.css
+++ b/css/styles.css
@@ -1794,6 +1794,7 @@ table {
     justify-content: space-between;
     align-items: center;
     margin-top: 0.25rem;
+    width: 100%;
   }
 
 th {
@@ -3174,14 +3175,22 @@ td input:checked + .slider:before {
   white-space: nowrap;
 }
 
+
 .control-select {
-  padding: 0.375rem 0.75rem;
+  appearance: none;
+  padding: 0.25rem 1.5rem 0.25rem 0.5rem;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  background: var(--bg-primary);
+  background: var(--bg-tertiary);
   color: var(--text-primary);
   font-size: 0.875rem;
-  min-width: 80px;
+  width: 4rem;
+  min-width: 0;
+  text-align: center;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 6' fill='none' stroke='currentColor' stroke-width='1.5'%3E%3Cpath d='M1 1l4 4 4-4'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.35rem center;
+  background-size: 0.65rem;
   cursor: pointer;
   transition: var(--transition);
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -1780,8 +1780,13 @@ table {
 }
 
   .table-item-count {
-    font-size: 0.875rem;
+    font-size: 0.95rem;
+    font-weight: 600;
     color: var(--text-muted);
+    background: var(--bg-tertiary);
+    padding: 0.125rem 0.375rem;
+    border-radius: var(--radius);
+    display: inline-block;
   }
 
   .table-footer-controls {

--- a/docs/patch/PATCH-3.04.88.ai
+++ b/docs/patch/PATCH-3.04.88.ai
@@ -1,0 +1,4 @@
+Version: 3.04.88
+Date: 2025-08-18
+Agent: gpt-4o
+Summary: Added emphasized styling for table item counter with stronger font weight, larger size, and subtle background; updated HTML wrapper and style guide.

--- a/docs/patch/PATCH-3.04.89.ai
+++ b/docs/patch/PATCH-3.04.89.ai
@@ -1,0 +1,4 @@
+Version: 3.04.89
+Date: 2025-08-18
+Agent: gpt-4o
+Summary: Modernized rows-per-page dropdown with compact button styling and aligned it to the table footer's right edge while keeping the item counter on the left.

--- a/docs/ui_style_guide.md
+++ b/docs/ui_style_guide.md
@@ -83,4 +83,5 @@ Use these guidelines to keep new UI elements consistent with the existing design
 ## Inventory Table Counter
 
 - The `#itemCount` element displays the number of visible inventory items.
-- Styled with `.table-item-count` using muted text (`var(--text-muted)`), `0.95rem` font size, `font-weight: 600`, subtle `var(--bg-tertiary)` background with `var(--radius)` corners, right alignment, and a small top margin.
+- Styled with `.table-item-count` using muted text (`var(--text-muted)`), `0.95rem` font size, `font-weight: 600`, subtle `var(--bg-tertiary)` background with `var(--radius)` corners, left alignment, and a small top margin.
+- Rows-per-page control uses `.control-select`, a compact button-style dropdown (`width: 4rem`, custom arrow) aligned to the right side of the table footer.

--- a/docs/ui_style_guide.md
+++ b/docs/ui_style_guide.md
@@ -83,4 +83,4 @@ Use these guidelines to keep new UI elements consistent with the existing design
 ## Inventory Table Counter
 
 - The `#itemCount` element displays the number of visible inventory items.
-- Styled with `.table-item-count` using muted text (`var(--text-muted)`), `0.875rem` font size, right alignment, and a small top margin.
+- Styled with `.table-item-count` using muted text (`var(--text-muted)`), `0.95rem` font size, `font-weight: 600`, subtle `var(--bg-tertiary)` background with `var(--radius)` corners, right alignment, and a small top margin.

--- a/index.html
+++ b/index.html
@@ -682,7 +682,7 @@
           <tbody></tbody>
           </table>
           <div class="table-footer-controls">
-            <div id="itemCount" class="table-item-count"></div>
+            <div class="table-item-count"><strong id="itemCount"></strong></div>
             <select id="itemsPerPage" class="control-select" title="Rows per page">
               <option value="10" selected>10</option>
               <option value="15">15</option>


### PR DESCRIPTION
## Summary
- Improve `.table-item-count` with heavier font weight, larger size, and subtle background.
- Wrap item count value in `<strong>` for semantic emphasis.
- Document updated counter appearance in UI style guide.

## Testing
- `node tests/sanitize-name-slash.test.js`
- `node tests/grouped-name-chips.test.js`
- `node tests/header-name-centering.test.js` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689ee56f34c0832eae1759ffea83b036