### PR TITLE
Move filter controls above chip row and refine spacing

### DIFF
--- a/agents/gpt-4-1.ai
+++ b/agents/gpt-4-1.ai
@@ -3,3 +3,6 @@
 ## Change Log
 - 2025-08-17: Session start - plan to allow slash in item name sanitization (gpt-4-1)
 - 2025-08-17: Added allowSlash option to sanitizeObjectFields and created test to preserve '/' in names (gpt-4-1)
+
+- 2025-08-18: Session start - plan to relocate filter controls and adjust spacing (gpt-4-1)
+- 2025-08-18: Reordered filter controls above chip row, updated spacing, and ensured selectors/tests pass (gpt-4-1)

--- a/codex.ai
+++ b/codex.ai
@@ -19,3 +19,6 @@
 - 2025-08-18: Begin styling enhancement for table item counter with bold background accent (gpt-4o)
 - 2025-08-18: Added item counter styling with background and bold, updated HTML and documentation (gpt-4o)
 - 2025-08-18: Shrunk rows-per-page dropdown with button styling and aligned it opposite the item counter (gpt-4o)
+
+- 2025-08-18: Start session to reposition filter controls above chip row and tweak spacing (gpt-4-1)
+- 2025-08-18: Reordered filter controls above chip row, adjusted spacing, verified selectors and tests (gpt-4-1)

--- a/css/styles.css
+++ b/css/styles.css
@@ -3143,6 +3143,9 @@ td input:checked + .slider:before {
   margin-top: var(--spacing);
   padding-top: var(--spacing);
   border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
 }
 
 .filter-row {

--- a/docs/fixes/filter-controls-order-fix.md
+++ b/docs/fixes/filter-controls-order-fix.md
@@ -1,0 +1,10 @@
+# Filter Controls Order Fix
+
+## Problem
+Filter control selectors were rendered below the active filter chips, making the controls visually detached from the chip row.
+
+## Solution
+Moved the `.filter-controls` block above the `.filter-row` in `index.html` and adjusted `.search-filters` spacing in `css/styles.css` so controls remain separated from the chip row.
+
+## Notes
+No JavaScript changes required; existing selectors rely on element IDs and continue to function.

--- a/docs/patch/PATCH-3.04.90.ai
+++ b/docs/patch/PATCH-3.04.90.ai
@@ -1,0 +1,4 @@
+Version: 3.04.90
+Date: 2025-08-18
+Agent: gpt-4-1
+Summary: Reordered filter controls before chip row and added spacing for clear separation; selectors and pagination verified.

--- a/index.html
+++ b/index.html
@@ -508,10 +508,6 @@
           <!-- Integrated Filters -->
           <div class="search-filters">
             <div id="typeSummary"></div>
-            <div class="filter-row">
-              <div class="active-filters" id="activeFilters"></div>
-              <div class="search-results-info" id="searchResultsInfo"></div>
-            </div>
             <div class="filter-controls">
               <div class="control-group">
                 <label for="chipMinCount" class="control-label">Filter Chips:</label>
@@ -531,6 +527,10 @@
                   <option value="no">No</option>
                 </select>
               </div>
+            </div>
+            <div class="filter-row">
+              <div class="active-filters" id="activeFilters"></div>
+              <div class="search-results-info" id="searchResultsInfo"></div>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- Reordered integrated filter controls ahead of the chip row for a more intuitive layout.
- Added flex-column spacing to `.search-filters` so controls remain visually separated from filter chips.
- Documented the adjustment in fix log and patch notes.

## Testing
- `node tests/grouped-name-chips.test.js`
- `node tests/sanitize-name-slash.test.js`
- `node tests/header-name-centering.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689ee977d590832e839d65e7780feda4