### PR TITLE
Align search action buttons

### DIFF
--- a/agents/gpt-4o.ai
+++ b/agents/gpt-4o.ai
@@ -14,3 +14,6 @@
 - 2025-08-18: Enhanced table item count with heavier font, larger size, and background; updated docs (gpt-4o)
 - 2025-08-18: Session start - plan to modernize rows-per-page dropdown and align controls for symmetry (gpt-4o)
 - 2025-08-18: Styled rows-per-page dropdown as compact button and positioned it on the right, leaving item counter on the left (gpt-4o)
+
+- 2025-08-19: Session start - plan to unify search control buttons and remove obsolete square class; scope table icon styles (gpt-4o)
+- 2025-08-19: Unified search control buttons under .btn.success, removed square class, and scoped inventory table icon styles (gpt-4o)

--- a/codex.ai
+++ b/codex.ai
@@ -24,3 +24,6 @@
 - 2025-08-18: Reordered filter controls above chip row, adjusted spacing, verified selectors and tests (gpt-4-1)
 - 2025-08-19: Start session to improve chip contrast and dynamic text colors (GPT)
 - 2025-08-19: Completed chip contrast helper and text color mapping, ran theme tests (GPT)
+
+- 2025-08-19: Start session to align search control buttons and refine icon sizing (gpt-4o)
+- 2025-08-19: Unified search control buttons under .btn.success and scoped table icon styles to keep sizes consistent (gpt-4o)

--- a/css/styles.css
+++ b/css/styles.css
@@ -4120,7 +4120,7 @@ input:disabled + .slider {
 }
 
 /* Icon button base for action cells */
-.icon-btn {
+#inventoryTable .icon-btn {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -4134,17 +4134,17 @@ input:disabled + .slider {
   transition: background 0.15s ease, transform 0.08s ease;
 }
 
-.icon-btn:focus {
+#inventoryTable .icon-btn:focus {
   outline: 2px solid rgba(59,130,246,0.25);
   outline-offset: 2px;
 }
 
-.icon-btn:hover {
+#inventoryTable .icon-btn:hover {
   background: rgba(0,0,0,0.04);
   transform: translateY(-1px);
 }
 
-.icon-svg { width: 1.05rem; height: 1.05rem; display: block; fill: currentColor; color: inherit; }
+#inventoryTable .icon-svg { width: 1.05rem; height: 1.05rem; display: block; fill: currentColor; color: inherit; }
 .notes-svg { color: inherit; }
 .edit-svg { color: inherit; }
 .delete-svg { color: inherit; }
@@ -4237,27 +4237,27 @@ th {
 }
 
 /* Icon cells in the body: inherit color so they match the row's text color and striping */
-#inventoryTable tbody td.icon-col {
+ #inventoryTable tbody td.icon-col {
   color: inherit;
   padding: 0.25rem 0.35rem;
 }
 
 /* Icon button visual blending */
-.icon-btn {
+#inventoryTable .icon-btn {
   background: transparent; /* keep inline with row */
   color: var(--text-secondary);
   box-shadow: none;
 }
 
-.icon-btn:hover {
+#inventoryTable .icon-btn:hover {
   background: var(--bg-secondary);
   color: var(--text-primary);
 }
 
-.icon-btn:active { transform: translateY(0); }
+#inventoryTable .icon-btn:active { transform: translateY(0); }
 
 /* Slightly smaller icon size in cells to reduce visual weight */
-.icon-svg { width: 0.95rem; height: 0.95rem; }
+#inventoryTable .icon-svg { width: 0.95rem; height: 0.95rem; }
 
 /* Ensure collectable icon visually matches muted style until active */
 .collectable-icon { color: var(--text-secondary); }
@@ -4305,8 +4305,8 @@ th {
   padding-bottom: 0.32rem;
 }
 
-.icon-btn { width: 2rem; height: 2rem; }
-.icon-svg { width: 0.9rem; height: 0.9rem; }
+#inventoryTable .icon-btn { width: 2rem; height: 2rem; }
+#inventoryTable .icon-svg { width: 0.9rem; height: 0.9rem; }
 
 /* Tighter row height */
 #inventoryTable tbody tr { min-height: 2rem; }
@@ -4315,8 +4315,8 @@ th {
 @media (max-width: 480px) {
   #inventoryTable { font-size: 0.78rem; }
   #inventoryTable th, #inventoryTable td { padding: 0.14rem 0.12rem; }
-  .icon-btn { width: 1.8rem; height: 1.8rem; }
-  .icon-svg { width: 0.8rem; height: 0.8rem; }
+  #inventoryTable .icon-btn { width: 1.8rem; height: 1.8rem; }
+  #inventoryTable .icon-svg { width: 0.8rem; height: 0.8rem; }
 }
 
 

--- a/docs/fixes/button-class-consistency-fix.md
+++ b/docs/fixes/button-class-consistency-fix.md
@@ -1,0 +1,12 @@
+# Button Class Consistency Fix
+
+## Problem
+`#clearBtn` used `.secondary` and `#changeLogBtn` used `.square`, leading to inconsistent styling and sizing with the `#newItemBtn`.
+
+## Solution
+- Updated both buttons to use `class="btn success icon-btn"`.
+- Removed obsolete `square` class.
+- Scoped table icon-button styles in `css/styles.css` to `#inventoryTable` so search controls retain their intended size.
+
+## Result
+Search control buttons now share uniform appearance and sizing.

--- a/docs/patch/PATCH-3.04.92.ai
+++ b/docs/patch/PATCH-3.04.92.ai
@@ -1,0 +1,4 @@
+Version: 3.04.92
+Date: 2025-08-19
+Agent: gpt-4o
+Summary: Unified search control buttons under .btn.success, removed obsolete square class, and scoped table icon-button styles to preserve consistent sizing.

--- a/index.html
+++ b/index.html
@@ -492,7 +492,7 @@
               type="text"
             />
             <button
-              class="btn secondary icon-btn"
+              class="btn success icon-btn"
               id="clearBtn"
               title="Clear search"
               aria-label="Clear search"
@@ -500,7 +500,7 @@
               🗑️
             </button>
             <button
-              class="btn square icon-btn" id="changeLogBtn" title="Change log" aria-label="Change log">
+              class="btn success icon-btn" id="changeLogBtn" title="Change log" aria-label="Change log">
               📜
             </button>
           </div>


### PR DESCRIPTION
## Summary
- Apply `.btn.success.icon-btn` to clear and change-log buttons for consistent styling with new item action.
- Scope inventory table icon button styles to `#inventoryTable` so search controls keep intended size.
- Document button class cleanup in fix and patch notes.

## Testing
- `node tests/grouped-name-chips.test.js`
- `node tests/sanitize-name-slash.test.js`
- `node tests/header-name-centering.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689eee223bb4832eb49a91741f954229