### PR TITLE
filters: centralize reset logic for clear button

### DIFF
--- a/agents/gpt-4o.ai
+++ b/agents/gpt-4o.ai
@@ -17,3 +17,5 @@
 
 - 2025-08-19: Session start - plan to unify search control buttons and remove obsolete square class; scope table icon styles (gpt-4o)
 - 2025-08-19: Unified search control buttons under .btn.success, removed square class, and scoped inventory table icon styles (gpt-4o)
+- 2025-08-20: Session start - plan to centralize filter resets and simplify clear button (gpt-4o)
+- 2025-08-20: Centralized type/metal filter resets in clearAllFilters and simplified clear button to call it (gpt-4o)

--- a/codex.ai
+++ b/codex.ai
@@ -27,3 +27,4 @@
 
 - 2025-08-19: Start session to align search control buttons and refine icon sizing (gpt-4o)
 - 2025-08-19: Unified search control buttons under .btn.success and scoped table icon styles to keep sizes consistent (gpt-4o)
+- 2025-08-20: Centralized filter resets in clearAllFilters and simplified clear button to rely on it (gpt-4o)

--- a/docs/fixes/filter-reset-sync-fix.md
+++ b/docs/fixes/filter-reset-sync-fix.md
@@ -1,0 +1,4 @@
+# Filter Reset Sync Fix
+- Centralized `typeFilter` and `metalFilter` resets inside `clearAllFilters`.
+- Simplified `#clearBtn` handler to call `clearAllFilters()` without fallbacks.
+- `clearAllFilters` now resets dropdowns and chips together via `renderActiveFilters`.

--- a/docs/patch/PATCH-3.04.93.ai
+++ b/docs/patch/PATCH-3.04.93.ai
@@ -1,0 +1,4 @@
+Version: 3.04.93
+Date: 2025-08-20
+Agent: gpt-4o
+Summary: Centralized type and metal filter resets within clearAllFilters and streamlined clear button to call the helper directly.

--- a/js/events.js
+++ b/js/events.js
@@ -1508,23 +1508,7 @@ const setupSearch = () => {
         elements.clearBtn,
         "click",
         function () {
-          if (typeof clearAllFilters === "function") {
-            clearAllFilters();
-          } else {
-            if (elements.searchInput) {
-              elements.searchInput.value = "";
-            }
-            searchQuery = "";
-            columnFilters = {};
-            currentPage = 1;
-            renderTable();
-          }
-          if (elements.typeFilter) {
-            elements.typeFilter.value = "";
-          }
-          if (elements.metalFilter) {
-            elements.metalFilter.value = "";
-          }
+          clearAllFilters();
         },
         "Clear search button",
       );

--- a/js/filters.js
+++ b/js/filters.js
@@ -13,10 +13,16 @@ const clearAllFilters = () => {
   activeFilters = {};
   columnFilters = {};
   searchQuery = '';
-  
+
   const searchInput = document.getElementById('searchInput');
   if (searchInput) searchInput.value = '';
-  
+
+  const typeFilter = document.getElementById('typeFilter');
+  if (typeFilter) typeFilter.value = '';
+
+  const metalFilter = document.getElementById('metalFilter');
+  if (metalFilter) metalFilter.value = '';
+
   currentPage = 1;
   renderTable();
   renderActiveFilters();


### PR DESCRIPTION
## Summary
- centralize type and metal filter resets inside `clearAllFilters`
- ensure `clearAllFilters` refreshes chips and dropdowns together via `renderActiveFilters`
- simplify `#clearBtn` handler to call `clearAllFilters()` directly

## Testing
- `node tests/grouped-name-chips.test.js`
- `node tests/sanitize-name-slash.test.js`
- `node tests/header-name-centering.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689eff1f6880832eada034c1adbfcfae