### PR TITLE
refactor: streamline filter reset handling

### DIFF
--- a/agents/gpt.ai
+++ b/agents/gpt.ai
@@ -37,3 +37,4 @@ Your primary role on the StackTrackr project is **Feature Implementation and Gen
 - 2025-08-17: Wrapped Name header text with span and removed obsolete centering CSS (GPT)
 
 - 2025-08-19: Introduced contrast-aware chip text colors with helper and CSS variable (GPT)
+- 2025-08-20: Verified centralized filter resets and simplified clear button handler (GPT)

--- a/codex.ai
+++ b/codex.ai
@@ -28,3 +28,4 @@
 - 2025-08-19: Start session to align search control buttons and refine icon sizing (gpt-4o)
 - 2025-08-19: Unified search control buttons under .btn.success and scoped table icon styles to keep sizes consistent (gpt-4o)
 - 2025-08-20: Centralized filter resets in clearAllFilters and simplified clear button to rely on it (gpt-4o)
+- 2025-08-20: Confirmed filter reset sync and streamlined clear button handler (GPT)

--- a/js/events.js
+++ b/js/events.js
@@ -1507,9 +1507,7 @@ const setupSearch = () => {
       safeAttachListener(
         elements.clearBtn,
         "click",
-        function () {
-          clearAllFilters();
-        },
+        clearAllFilters,
         "Clear search button",
       );
     }

--- a/js/filters.js
+++ b/js/filters.js
@@ -24,8 +24,9 @@ const clearAllFilters = () => {
   if (metalFilter) metalFilter.value = '';
 
   currentPage = 1;
-  renderTable();
+  // Update chip UI before rerendering the table
   renderActiveFilters();
+  renderTable();
 };
 
 /**


### PR DESCRIPTION
## Summary
- Reset type and metal filters in `clearAllFilters` and refresh chips before rerendering the table.
- Simplify `#clearBtn` click handler to call `clearAllFilters` directly.
- Update agent context with filter reset notes.

## Testing
- `node tests/sanitize-name-slash.test.js`
- `node tests/grouped-name-chips.test.js`
- `NODE_PATH=$(npm root -g) node tests/header-name-centering.test.js` *(fails: libatk-bridge-2.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f2ce19554832eb553ae4963882c2d