### PR TITLE
fix: render filter chips after import

### DIFF
--- a/codex.ai
+++ b/codex.ai
@@ -29,3 +29,4 @@
 - 2025-08-19: Unified search control buttons under .btn.success and scoped table icon styles to keep sizes consistent (gpt-4o)
 - 2025-08-20: Centralized filter resets in clearAllFilters and simplified clear button to rely on it (gpt-4o)
 - 2025-08-20: Confirmed filter reset sync and streamlined clear button handler (GPT)
+- 2025-08-20: Trigger renderActiveFilters after CSV/JSON imports to show chips immediately (GPT)

--- a/docs/patch/PATCH-3.04.94.ai
+++ b/docs/patch/PATCH-3.04.94.ai
@@ -1,0 +1,4 @@
+Version: 3.04.94
+Date: 2025-08-20
+Agent: GPT
+Summary: Render active filter chips automatically after imports by calling renderActiveFilters after renderTable.

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -1565,6 +1565,12 @@ const importCsv = (file, override = false) => {
 
         saveInventory();
         renderTable();
+        if (typeof renderActiveFilters === 'function') {
+          renderActiveFilters();
+        }
+        if (typeof updateTypeSummary === 'function') {
+          updateTypeSummary();
+        }
         if (typeof updateStorageStats === 'function') {
           updateStorageStats();
         }
@@ -1783,6 +1789,12 @@ const importNumistaCsv = (file, override = false) => {
 
         saveInventory();
         renderTable();
+        if (typeof renderActiveFilters === 'function') {
+          renderActiveFilters();
+        }
+        if (typeof updateTypeSummary === 'function') {
+          updateTypeSummary();
+        }
         if (typeof updateStorageStats === 'function') {
           updateStorageStats();
         }
@@ -2114,6 +2126,12 @@ const importJson = (file, override = false) => {
 
       saveInventory();
       renderTable();
+      if (typeof renderActiveFilters === 'function') {
+        renderActiveFilters();
+      }
+      if (typeof updateTypeSummary === 'function') {
+        updateTypeSummary();
+      }
       if (typeof updateStorageStats === "function") {
         updateStorageStats();
       }


### PR DESCRIPTION
## Summary
- ensure filter chips display automatically after CSV/JSON/Numista imports
- document change in patch log

## Testing
- `node tests/grouped-name-chips.test.js`
- `node tests/header-name-centering.test.js` *(fails: libatk-bridge-2.0.so.0 missing)*
- `node tests/sanitize-name-slash.test.js`


------
https://chatgpt.com/codex/tasks/task_e_689f3bca090c832eaebaf1973c912955