### PR TITLE
docs: sync README version with latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# StackrTrackr v3.04.71
+# StackrTrackr v3.04.86
 
 
 StackrTrackr is a comprehensive client-side web application for tracking precious metal investments. It's designed to help users manage their silver, gold, platinum, and palladium holdings with detailed financial metrics and enhanced tracking capabilities.
@@ -367,8 +367,8 @@ This project is designed to be maintainable and extensible. When making changes:
 This project is open source and available for personal use.
 
 ---
-**Current Version**: v3.04.61
-**Last Updated**: August 13, 2025
+**Current Version**: v3.04.86
+**Last Updated**: August 17, 2025
 **Status**: Feature complete release candidate
 
 

--- a/codex.ai
+++ b/codex.ai
@@ -30,3 +30,4 @@
 - 2025-08-20: Centralized filter resets in clearAllFilters and simplified clear button to rely on it (gpt-4o)
 - 2025-08-20: Confirmed filter reset sync and streamlined clear button handler (GPT)
 - 2025-08-20: Trigger renderActiveFilters after CSV/JSON imports to show chips immediately (GPT)
+- 2025-08-21: Synced README version heading and release date with latest changelog (gpt-4o)


### PR DESCRIPTION
## Summary
- bump README heading and version info to v3.04.86
- refresh last updated date to August 17, 2025
- log the update in codex.ai

## Testing
- `node tests/grouped-name-chips.test.js && node tests/header-name-centering.test.js && node tests/sanitize-name-slash.test.js` *(fails: libatk-1.0.so.0 missing)*

------
https://chatgpt.com/codex/tasks/task_e_689f50f74d74832ea129fbf13181ee7d