### PR TITLE
fix: correct date header span markup

### DIFF
--- a/agents/gpt-4o.ai
+++ b/agents/gpt-4o.ai
@@ -19,3 +19,6 @@
 - 2025-08-19: Unified search control buttons under .btn.success, removed square class, and scoped inventory table icon styles (gpt-4o)
 - 2025-08-20: Session start - plan to centralize filter resets and simplify clear button (gpt-4o)
 - 2025-08-20: Centralized type/metal filter resets in clearAllFilters and simplified clear button to call it (gpt-4o)
+
+- 2025-08-22: Session start - plan to fix Date header span markup and verify other headers for typos (gpt-4o)
+- 2025-08-22: Replaced stray Date header span markup and confirmed no other header typos (gpt-4o)

--- a/codex.ai
+++ b/codex.ai
@@ -31,3 +31,4 @@
 - 2025-08-20: Confirmed filter reset sync and streamlined clear button handler (GPT)
 - 2025-08-20: Trigger renderActiveFilters after CSV/JSON imports to show chips immediately (GPT)
 - 2025-08-21: Synced README version heading and release date with latest changelog (gpt-4o)
+- 2025-08-22: Corrected Date column header span markup and verified all headers for stray tags (gpt-4o)

--- a/docs/fixes/date-header-span-fix.md
+++ b/docs/fixes/date-header-span-fix.md
@@ -1,0 +1,8 @@
+# Date Header Span Fix
+
+The Date column header contained an empty `span` followed by stray closing tag, resulting in `<span class="header-text"></span>Date</span>`.
+
+## Solution
+- Replaced the malformed markup with `<span class="header-text">Date</span>` to properly wrap the header text.
+- Reviewed all other table headers to ensure no similar closing tag issues exist.
+

--- a/docs/patch/PATCH-3.04.95.ai
+++ b/docs/patch/PATCH-3.04.95.ai
@@ -1,0 +1,4 @@
+Version: 3.04.95
+Date: 2025-08-22
+Agent: gpt-4o
+Summary: Removed stray closing span in Date column header and verified remaining headers.

--- a/index.html
+++ b/index.html
@@ -574,7 +574,7 @@
                   <line x1="8" y1="2" x2="8" y2="6"/>
                   <line x1="3" y1="10" x2="21" y2="10"/>
                 </svg>
-                <span class="header-text"></span>Date</span>
+                <span class="header-text">Date</span>
               </th>
               <th class="shrink" data-column="type">
                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="header-icon">


### PR DESCRIPTION
## Summary
- fix Date column header markup by removing stray closing span
- document fix and patch record

## Testing
- `node tests/fuzzy-search.test.js`
- `node tests/grouped-name-chips.test.js`
- `node tests/sanitize-name-slash.test.js`
- `node tests/header-name-centering.test.js` *(fails: Cannot find module 'puppeteer')*
- `npm install puppeteer --no-save` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a0605947cc832e9577ffcbdc1bb15a